### PR TITLE
Fix ClickHouse first-install bootstrap + IT async-insert visibility

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
@@ -2,6 +2,7 @@ package net.medievalrp.spyglass.plugin.storage;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.command.CommandResponse;
+import com.clickhouse.client.api.command.CommandSettings;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -57,7 +58,16 @@ final class ClickHouseSchema {
     }
 
     static void ensure(Client client, String database, String eventsTable) {
-        execute(client, "CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(database));
+        // The client's session database is the configured one, which on a
+        // first install does not exist yet — and the server rejects any
+        // request whose session database is missing, including the very
+        // CREATE DATABASE that would create it. Run that one statement
+        // with the session pointed at `system` (always present); the
+        // session database only scopes unqualified table names, which
+        // the statement has none of.
+        CommandSettings bootstrap = new CommandSettings();
+        bootstrap.setDatabase("system");
+        execute(client, "CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(database), bootstrap);
         execute(client, buildEventRecordsTable(database, eventsTable));
         // Idempotent ADD COLUMN for tables created by older Spyglass
         // versions: CH ignores ADD COLUMN IF NOT EXISTS when the column
@@ -110,7 +120,13 @@ final class ClickHouseSchema {
     }
 
     private static void execute(Client client, String sql) {
-        try (CommandResponse ignored = client.execute(sql).get(60, TimeUnit.SECONDS)) {
+        execute(client, sql, null);
+    }
+
+    private static void execute(Client client, String sql, CommandSettings settings) {
+        try (CommandResponse ignored = (settings == null
+                ? client.execute(sql)
+                : client.execute(sql, settings)).get(60, TimeUnit.SECONDS)) {
             // ack received
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -77,6 +77,22 @@ class ClickHouseRecordStoreIT {
                 .get(30, java.util.concurrent.TimeUnit.SECONDS).close();
     }
 
+    // save() is fire-and-forget (async_insert=1, wait_for_async_insert=0):
+    // the INSERT acks before the server materializes the part, so an
+    // immediate SELECT races the server-side flush and reads empty.
+    // Tests need read-your-writes; force the flush between save and query.
+    private void flushAsyncInserts() {
+        try {
+            store.client().execute("SYSTEM FLUSH ASYNC INSERT QUEUE")
+                    .get(30, java.util.concurrent.TimeUnit.SECONDS).close();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("async-insert flush interrupted", ie);
+        } catch (Exception ex) {
+            throw new IllegalStateException("async-insert flush failed", ex);
+        }
+    }
+
     @Test
     void savesAndQueriesAllRecordTypes() {
         Instant now = Instant.now().minusSeconds(60);
@@ -105,6 +121,7 @@ class ClickHouseRecordStoreIT {
                         UUID.randomUUID(), "player", "ENTITY_ATTACK", null));
 
         store.save(records);
+        flushAsyncInserts();
 
         QueryRequest allEvents = new QueryRequest(
                 List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
@@ -140,6 +157,7 @@ class ClickHouseRecordStoreIT {
                 UUID.randomUUID(), "break", now, now.plusSeconds(3600),
                 origin, source, loc, "test", "CHEST", stoneWithItem, air);
         store.save(List.of(saved));
+        flushAsyncInserts();
 
         QueryRequest byEvent = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),
@@ -171,6 +189,7 @@ class ClickHouseRecordStoreIT {
                     origin, source, loc, "test", "STONE", stone, air));
         }
         store.save(many);
+        flushAsyncInserts();
         QueryRequest limited = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),
                 Sort.NEWEST_FIRST, 5, EnumSet.noneOf(Flag.class), false);
@@ -198,6 +217,7 @@ class ClickHouseRecordStoreIT {
                     new BlockLocation(WORLD, "world", 100 + i, 64, 200 + i),
                     "test", "STONE", stone, air)));
         }
+        flushAsyncInserts();
 
         QueryRequest spatial = new QueryRequest(
                 List.of(
@@ -223,6 +243,7 @@ class ClickHouseRecordStoreIT {
         store.save(List.of(new BlockBreakRecord(
                 UUID.randomUUID(), "break", now, now.plusSeconds(3600),
                 origin, source, loc, "test", "CHEST", bigSnapshot, null)));
+        flushAsyncInserts();
 
         QueryRequest q = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),
@@ -260,6 +281,7 @@ class ClickHouseRecordStoreIT {
 
         store.save(List.of(record));
         store.save(List.of(record));
+        flushAsyncInserts();
 
         // Force a merge so dedup is observable; in production this
         // happens lazily on background merges.


### PR DESCRIPTION
Two latent defects surfaced by actually running `ClickHouseRecordStoreIT` with Docker available (it silently skips without it — every prior `check` on a Docker-less session never exercised it).

## 1. First-install bootstrap failure (the bug in #15)

On a fresh ClickHouse server, `ClickHouseRecordStore` construction died at schema bootstrap:

```
Schema bootstrap failed: CREATE DATABASE IF NOT EXISTS `spyglass_it`
Caused by: Code: 81. DB::Exception: Database spyglass_it does not exist. (UNKNOWN_DATABASE)
```

Since c295836 the client's **session** database is the configured one — and ClickHouse validates the session database before executing any statement, so the very CREATE DATABASE that would create it can never run inside it. Fix: pin that single statement's session to `system` via `CommandSettings.setDatabase` (session db only scopes unqualified names; the statement has none). All other DDL already runs after the database exists and is fully qualified.

Existing deployments never hit this (their database already exists) — only first installs.

## 2. IT read-your-writes race (latent since 35e0e06)

With the bootstrap fixed, all 6 tests ran — and all 6 read empty results. `save()` is fire-and-forget (`async_insert=1, wait_for_async_insert=0`) since 35e0e06: the INSERT acks before the server materializes the part, so the IT's immediate SELECT raced the flush. The IT now forces `SYSTEM FLUSH ASYNC INSERT QUEUE` between save and query. Production insert behavior is untouched.

## Verification

- `ClickHouseRecordStoreIT`: initializationError → **6/6 green** on a fresh testcontainer
- Full `./gradlew check` (Docker up, all ITs running): **BUILD SUCCESSFUL**, jacoco floors held

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)