### PR TITLE
Rollback scaling guidance: page-size heap trade-off, undo-cap retention (#13 fallback)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,6 +59,21 @@ Recommendation: 10x your steady-state peak event rate × seconds of acceptable b
 
 If you're seeing first-crossing warnings during normal play, raise the threshold. If you're seeing them after a Mongo restart and they double quickly, the drain is genuinely losing — check Mongo CPU, replica election, network.
 
+## Large rollbacks: heap, GC, and what the TPS metric hides
+
+A multi-million-block rollback is read- and GC-bound — the apply runs off-main, so the main thread stays ~90% parked and MSPT stays flat regardless. Whether it is also *freeze-free* is decided by two dials in `limits` (measured: 2M-block rollback, 6 GB heap, local ClickHouse; full data in [the bench report](report/rollback-bench-results.md)):
+
+| `rollback-page-size` | 2M wall-clock | player experience |
+|---|---|---|
+| 1,000,000 | ~10–14 s | 0.4–1.0 s stop-the-world GC freeze mid-run |
+| 250,000–400,000 | in between | most of the read speed, bounded heap |
+| 100,000 | ~22 s | worst single tick < ~100 ms |
+| 20,000 (default) | slowest | smooth |
+
+- **`rollback-undo-cap`: leave it at the 500k default.** Inverse effects live for the whole operation and promote to old gen; the benchmark's 10M cap pushed ~2 GB into old gen and drew the 0.5–1.0 s pauses above. Streaming undo capture ([#17](https://github.com/medievalrp-net/Spyglass/issues/17)) removes this constraint; until then the cap is the heap's safety net.
+- **Don't trust `/mspt` averages for freeze claims.** Off-main work means a GC pause lands *between* measured ticks: the bench showed "flat 20 TPS" while the GC log recorded an 849 ms stop-the-world pause. Judge a config with the `/mspt` **max** column and the JVM GC log (`grep 'Pause Young' logs/gc*.log`) during a trial rollback — `regression/bot/compare.js` prints a WORST SINGLE TICK row for exactly this reason.
+- `/spyglass undo` of very large rollbacks (> ~250 K effects) currently OOMs on replay — also fixed by [#17](https://github.com/medievalrp-net/Spyglass/issues/17).
+
 ## Disabling events
 
 `config.conf` has per-event toggles under `events.<name>`. Disabling an event:

--- a/docs/report/rollback-bench-results.md
+++ b/docs/report/rollback-bench-results.md
@@ -1,0 +1,114 @@
+# Spyglass vs CoreProtect — rollback throughput & TPS bench
+
+Head-to-head rollback of a **2,000,376-block** cube (126³), with **both** plugins on the **same ClickHouse** (`127.0.0.1:8123`; Spyglass → `spyglass` db, CoreProtect → `coreprotect` db via the `coreprotect-clickhouse` bridge). Run on `../RP_Server` (Paper 1.21.8, Java 21) under the **6 GB benchmark heap** (`start-bench.sh`), driven by [`regression/bot/compare.js`](../../regression/bot/compare.js). Profiling by the **Sundial** plugin (`/sundial`) + the JVM GC log (`logs/gc-bench.log`).
+
+Date of run: 2026-06-03. ClickHouse held ~65 M Spyglass / ~62 M CoreProtect rows from prior runs; all rollback queries are scoped per-bot (`p:`/`u:` + `t:`), so DB size is not a confound for the apply path.
+
+> **Read this first.** The wall-clock and MSPT numbers below make Spyglass look like it holds a flat 20 TPS. **It does not, at the config used.** A 2M rollback triggers G1 **stop-the-world GC pauses of ~0.5–1.0 s** that the MSPT metric cannot see (the rollback's work is off-main, so the pauses land in the inter-tick idle gap rather than extending a measured tick). See [The TPS metric is lying](#the-tps-metric-is-lying) and [Root cause](#root-cause-of-the-gc-freezes). The freezes are config-driven and have a known fix; this document records the *measured* state, warts included.
+
+## TL;DR
+
+| Dimension (2M blocks, ClickHouse) | **Spyglass** | **CoreProtect** | Winner |
+|---|---|---|---|
+| Rollback wall-clock | **13.7 s** (146 k blk/s) | 26.9 s (74 k blk/s) | SG (1.96×) |
+| Restore / re-apply wall-clock | n/a (undo skipped¹) | 14.1 s (142 k blk/s) | — |
+| MSPT 5 s-avg during op (avg) | **5.6 ms** | 66.3 ms | SG |
+| Worst single tick (MSPT 5 s-max) | 90 ms | 1132 ms | SG — but see caveat |
+| Main-thread CPU during rollback (Sundial) | **2.3 %** (90 % parked) | sustained on-main | SG |
+| **Worst GC stop-the-world pause** | **849 ms** | 429 ms | **CoreProtect** |
+| GC pauses > 500 ms during op | **3** (758/849/518 ms) | 2 (424/429 ms) | CoreProtect |
+| Sustained TPS feel | 20 TPS *between* GC freezes | ~15 TPS the **whole** op | SG |
+
+¹ `/spyglass undo` is skipped in the bench — it currently materializes the full inverse-effect list in heap on replay and OOMs above ~250 K effects. This is part of the same heap problem documented below and is covered by the fix.
+
+**Verdict.** Spyglass is ~2× faster than CoreProtect on the same ClickHouse and moves essentially all rollback work off the main thread (main is 90 % parked; tick *bodies* stay ~5 ms). CoreProtect does its apply on the main thread, so it lags *continuously* for the full 27 s (~15 TPS) and additionally throws its own 0.4 s GC freezes. **But Spyglass is not freeze-free:** at the throughput-tuned config it provokes a handful of ~0.5–1.0 s stop-the-world GC pauses per 2M rollback — its *largest* single pause (849 ms) is actually bigger than CoreProtect's (429 ms). Spyglass wins decisively on sustained smoothness and speed; it loses on worst-case single-pause length, and "flat 20 TPS" is an artifact of the metric, not reality. Eliminating the GC freezes is tracked as the rollback-heap fix.
+
+## Verification — the rollback actually changes blocks
+
+Before trusting any timing, confirmed the rollback physically rewrites the world (the completion message also fires on "No results", so a no-op would look instant). Via [`regression/bot/verify-rollback.js`](../../regression/bot/verify-rollback.js) on a 16³ cube, reading server-side ground truth (`execute if block`) at 9 sample points:
+
+| Stage | Server truth |
+|---|---|
+| after `fill stone` | stone ×9 |
+| after `//replace stone air` | air ×9 |
+| after `/spyglass rollback` | **stone ×9** |
+
+Engine reported `4096 reversals across 4 chunks`. Durability confirmed via [`regression/bot/persist-test.js`](../../regression/bot/persist-test.js): rolled-back blocks survive both a `save-all flush` and a *passive* chunk unload→reload (`ChunkDirectWriter.finishChunk` → `setUnsaved(true)` works on this Paper build). Note: the engine applies **unconditionally** (force-overwrite) — `applied` = blocks written, and re-running a rollback re-writes rather than skipping.
+
+## Methodology
+
+`compare.js` (size = 2M): `/fill stone` (RCON, unlogged) → `//replace stone air` (WorldEdit, logged by both plugins) → drain → baseline-TPS wait → time `/spyglass rollback p:<bot> t:30m -g` → `/fill air` reset → time `/co rollback` → time `/co restore`. TPS/MSPT sampled from `/mspt` every 1.5 s (5 s-window avg **and** max). **Sundial profiling is OFF during the timing run** — all-thread sampling forces a safepoint every 5 ms and biases SG's MSPT; it is run separately for attribution. Profiling rollbacks are issued from the console (RCON) against the leftover data, so they re-apply the real 2M set without re-ingesting.
+
+**Config used (the live `RP_Server/plugins/Spyglass/config.conf`):**
+
+| key | value used | shipped default |
+|---|---|---|
+| `rollback-page-size` | **1,000,000** | 20,000 |
+| `rollback-batch-size` | **1,000,000** | 4,000 |
+| `rollback-undo-cap` | **10,000,000** | 500,000 |
+
+These were raised during the perf push to maximize throughput. They are the direct cause of the GC behavior below.
+
+## Results
+
+```
+Size  | Blocks    | SG rollback        | CP rollback        | CP restore
+------|-----------|--------------------|--------------------|-------------------
+2M    | 2,000,376 | 13.7s  146002 bps  | 26.9s   74444 bps  | 14.1s  141579 bps
+
+mspt-5s-AVG during op (max-of-avgs / avg ms):
+2M    | SG 7.8/5.6 ms      | CP rb 178.0/66.3 ms   | CP restore 104.1/45.4 ms
+
+WORST SINGLE TICK (mspt 5s-window max):
+2M    | SG 90.1 ms         | CP rb 1132.4 ms       | CP restore 534.4 ms
+
+TPS (min/avg, derived from mspt — see caveat):
+2M    | SG 20.0/20.0       | CP rb 5.6/14.8        | CP restore 9.6/16.9
+```
+
+**Where Spyglass spends the 13.3 s** (engine's own instrumentation): `query=7227ms (54%)` ≫ `prewarm=1210ms` `collect=612ms` `apply=2020ms (15%)`. The rollback is **read-bound on ClickHouse**, not write-bound. Per-page CH read (1M rows): `submit≈1.0s fetch≈2.2s decode≈0.9s`.
+
+**Sundial main-thread profile** (during SG rollback): `90.3% Unsafe.park` — the main thread is parked the whole time; Spyglass's own main-thread footprint is **2.3%**. Confirms the off-main design works.
+
+### The TPS metric is lying
+
+During the SG rollback the GC log shows stop-the-world pauses of **131 / 758 / 849 / 518 ms** — yet the bench reported a 90 ms worst tick and "flat 20 TPS." MSPT measures **tick-body** time; with the rollback's work off-main the main thread is ~90 % parked, so a GC pause mostly lands in the inter-tick idle budget and never extends a measured tick. `compare.js` derives TPS *from* MSPT, so it inherits the blind spot. The tell: SG's **larger** 849 ms pause produced a **smaller** worst tick (90 ms) than CoreProtect's 429 ms pause (1132 ms tick) — only possible because CoreProtect works on-main (pause hits the tick body) and SG does not. Real player-visible effect of an 849 ms pause is an 849 ms freeze regardless of how MSPT accounts it.
+
+### Root cause of the GC freezes
+
+The big pauses are **"Pause Young (Mixed)"** — G1 evacuating *old-gen* regions, i.e. long-lived data was promoted. G1 region accounting across one 2M rollback (region size 8 MB, 6 GB heap):
+
+| | start | peak | meaning |
+|---|---|---|---|
+| Old regions | 223 (~1.8 GB) | **470 (~3.8 GB)** | **+~2 GB promoted to old gen mid-rollback** |
+| Humongous regions | 25 | 38 | the 1M-element backing arrays (~8 MB each) |
+| GC pause | — | **0.5–1.0 s** | back-to-back Mixed GCs evacuating the swollen old gen |
+
+Two config dials drive it:
+1. **`rollback-undo-cap = 10M`** — `RollbackService` keeps one inverse `RollbackEffect` per applied block, for the **whole** rollback (2M live objects), pushing to `undo_history` only at the end. These survive Young GCs and promote to old gen — most of the +2 GB. (config's own comment: *"the inverse list itself becomes a heap problem."*)
+2. **`rollback-page-size` / `rollback-batch-size = 1M`** — a 1M-element `Object[]`/`RollbackResult[]` is ~8 MB, over G1's 4 MB **humongous** threshold, so each lands directly in old gen (the 25–38 humongous regions). Prefetch keeps two 1M-row pages live at once.
+
+On a 6 GB heap this drives old gen 1.8 → 3.8 GB, and G1 can't honor `MaxGCPauseMillis=200` evacuating a 470-region old gen. It is **retention during the op, not a leak** — old regions fall back afterward. Small rollbacks never hit it (4 096 blocks: 256 ms, zero GC drama).
+
+The fix (tracked separately) keeps undo fully functional for arbitrarily large rollbacks by **streaming inverse effects to `undo_history` per page** (the table is already chunked, keyed on `operation_id, chunk_index`) and **paging the undo replay**, plus bounding apply sub-batches under the 4 MB humongous threshold — so `undo-cap` can stay high (undo is the safety net for an accidental huge rollback) at near-zero heap cost.
+
+## Reproduction
+
+```
+# Server up on the bench heap (≥6 GB; the 3 GB prod heap drops the bot mid-ingest):
+../RP_Server/start-bench.sh
+
+# Timing head-to-head (Sundial OFF):
+node regression/bot/compare.js                 # 2M cube; SG vs CP rollback + CP restore
+
+# Verify blocks change + durability:
+node regression/bot/verify-rollback.js
+node regression/bot/persist-test.js            # add 'nosave' arg for passive-unload test
+
+# Profile a rollback (Sundial main + all) against existing data, no re-ingest:
+bash regression/bot/profile-rollback.sh <botTag>     # reports under RP_Server/plugins/Sundial/reports/
+
+# GC pauses for a window:  grep 'Pause Young' RP_Server/logs/gc-bench.log
+```
+
+RCON: `127.0.0.1:25576` (pw `test123`); one-shot helper `regression/bot/rcon-send.js "<cmd>"`.

--- a/regression/bot/compare.js
+++ b/regression/bot/compare.js
@@ -98,6 +98,7 @@ const SIZES = [
     // { name: '100K',  side: 47  },
     // { name: '1M',    side: 100 },
     { name: '2M',    side: 126 },
+    // { name: '500K',  side: 80  },
 ];
 
 const X_BASE = 14000, Y_BASE = 80, Z_BASE = 14000;
@@ -119,12 +120,21 @@ function tpsStats(samples) {
 // null if it didn't parse. mspt < 50 ms = healthy 20 TPS;
 // mspt > 50 ms = real TPS drop.
 async function msptAvg5s() {
+    const s = await msptSample();
+    return s == null ? null : s.avg;
+}
+
+// Parse the 5s window's avg AND max single tick. The avg smooths
+// short spikes (a lone 200ms tick over ~100 ticks barely moves it),
+// so the max is what actually reveals a single-tick stall. Returns
+// { avg, max } in ms, or null.
+async function msptSample() {
     try {
         const r = await rcon('mspt');
         // "Server tick times (avg/min/max) from last 5s, 10s, 1m:
-        //  ◴ 1.7/0.6/7.4, 1.8/0.6/7.4, 1.6/0.5/21.0"
+        //  ◴ 1.7/0.6/7.4, 1.8/0.6/7.4, 1.6/0.5/21.0"  -> first triple = 5s
         const m = r.match(/([\d.]+)\/([\d.]+)\/([\d.]+),/);
-        if (m) return parseFloat(m[1]);
+        if (m) return { avg: parseFloat(m[1]), max: parseFloat(m[3]) };
     } catch { }
     return null;
 }
@@ -179,26 +189,36 @@ async function timedOp(bot, command, completionRegex, timeout = 1800000) {
     const t0 = Date.now();
     const done = waitForChat(bot, completionRegex, timeout);
 
+    // Sundial all-threads profiling forces a JVM safepoint every 5ms and
+    // only runs during the SG rollback, so it inflates SG's tick times vs
+    // CP. Keep it OFF for fair MSPT/worst-tick measurement; flip to the
+    // regex only when specifically capturing an off-main profile.
+    const profile = false;
+
     const tpsDuring = [];
     const msptDuring = [];
+    let worstTick = 0;        // max single-tick mspt seen (5s-window max)
     let sampling = true;
     const sampler = (async () => {
         while (sampling) {
-            const m = await msptAvg5s();  // 5s avg — responsive within rollback window
-            if (m != null) {
-                msptDuring.push(m);
-                tpsDuring.push(tpsFromMspt(m));
+            const s = await msptSample();  // {avg, max} over the last 5s
+            if (s != null) {
+                msptDuring.push(s.avg);
+                tpsDuring.push(tpsFromMspt(s.avg));
+                if (s.max > worstTick) worstTick = s.max;
             }
             await sleep(1500);
         }
     })();
 
+    if (profile) { try { await rcon('sundial start all 5'); } catch (e) {} }
     bot.chat(command);
     const summary = await done;
     const ms = Date.now() - t0;
     sampling = false;
     await sampler;
-    return { ms, summary, tpsDuring, msptDuring };
+    if (profile) { try { await rcon('sundial stop'); } catch (e) {} }
+    return { ms, summary, tpsDuring, msptDuring, worstTick };
 }
 
 const results = [];
@@ -287,7 +307,7 @@ async function runOneSize(s, idx) {
         /(reversals|No results)/i);
     log(`  → ${sgRb.ms} ms (${(expected / (sgRb.ms / 1000)).toFixed(0)} bps)`);
     log(`     summary: ${(sgRb.summary || '(timeout)').replace(/\s+/g, ' ').slice(0, 200)}`);
-    r.sgRollback = { ms: sgRb.ms, summary: sgRb.summary, tps: tpsStats(sgRb.tpsDuring), mspt: tpsStats(sgRb.msptDuring) };
+    r.sgRollback = { ms: sgRb.ms, summary: sgRb.summary, tps: tpsStats(sgRb.tpsDuring), mspt: tpsStats(sgRb.msptDuring), worstTick: sgRb.worstTick };
     await sleep(4000);
 
     // ── Spyglass undo SKIPPED ────────────────────────────────────
@@ -323,7 +343,7 @@ async function runOneSize(s, idx) {
         /(Rollback completed|No data found)/i);
     log(`  → ${cpRb.ms} ms (${(expected / (cpRb.ms / 1000)).toFixed(0)} bps)`);
     log(`     summary: ${(cpRb.summary || '(timeout)').replace(/\s+/g, ' ').slice(0, 200)}`);
-    r.cpRollback = { ms: cpRb.ms, summary: cpRb.summary, tps: tpsStats(cpRb.tpsDuring), mspt: tpsStats(cpRb.msptDuring) };
+    r.cpRollback = { ms: cpRb.ms, summary: cpRb.summary, tps: tpsStats(cpRb.tpsDuring), mspt: tpsStats(cpRb.msptDuring), worstTick: cpRb.worstTick };
     await sleep(4000);
 
     // ── CoreProtect restore (re-apply the breaks → back to air) ──
@@ -332,7 +352,7 @@ async function runOneSize(s, idx) {
         /(Restore completed|No data found)/i);
     log(`  → ${cpRestore.ms} ms (${(expected / (cpRestore.ms / 1000)).toFixed(0)} bps)`);
     log(`     summary: ${(cpRestore.summary || '(timeout)').replace(/\s+/g, ' ').slice(0, 200)}`);
-    r.cpRestore = { ms: cpRestore.ms, summary: cpRestore.summary, tps: tpsStats(cpRestore.tpsDuring), mspt: tpsStats(cpRestore.msptDuring) };
+    r.cpRestore = { ms: cpRestore.ms, summary: cpRestore.summary, tps: tpsStats(cpRestore.tpsDuring), mspt: tpsStats(cpRestore.msptDuring), worstTick: cpRestore.worstTick };
     await sleep(2000);
 
     bot.quit();
@@ -369,13 +389,24 @@ function printReport() {
         log(`${fmtSize} | ${fmtBlk} | ${fmt(r.sgRollback)} | ${fmt(r.sgUndo)} | ${fmt(r.cpRollback)} | ${fmt(r.cpRestore)}`);
     }
     log('');
-    log('mspt during op (max / avg ms — 50 ms = 20 TPS floor):');
+    log('mspt-5s-AVG during op (max-of-avgs / avg ms — SMOOTHS single-tick spikes):');
     log('Size  | SG rollback         | SG undo             | CP rollback         | CP restore');
     log('------|---------------------|---------------------|---------------------|----------------');
     for (const r of results) {
         const fmt = (op) => {
             if (!op || !op.mspt || op.mspt.n === 0) return 'n/a                ';
             return `${op.mspt.max.toFixed(1).padStart(5)}/${op.mspt.avg.toFixed(1).padEnd(5)} ms (n=${op.mspt.n.toString().padEnd(2)})`;
+        };
+        log(`${r.size.padEnd(5)} | ${fmt(r.sgRollback)} | ${fmt(r.sgUndo)} | ${fmt(r.cpRollback)} | ${fmt(r.cpRestore)}`);
+    }
+    log('');
+    log('WORST SINGLE TICK during op (mspt 5s-window max — > 50 ms = a real TPS dip that tick):');
+    log('Size  | SG rollback     | SG undo         | CP rollback     | CP restore');
+    log('------|-----------------|-----------------|-----------------|----------------');
+    for (const r of results) {
+        const fmt = (op) => {
+            if (!op || op.worstTick == null) return 'n/a            ';
+            return `${op.worstTick.toFixed(1).padStart(7)} ms    `;
         };
         log(`${r.size.padEnd(5)} | ${fmt(r.sgRollback)} | ${fmt(r.sgUndo)} | ${fmt(r.cpRollback)} | ${fmt(r.cpRestore)}`);
     }

--- a/regression/bot/persist-test.js
+++ b/regression/bot/persist-test.js
@@ -1,0 +1,127 @@
+// Durability check: does a /spyglass rollback SURVIVE a chunk
+// save→unload→reload, or is it only an in-memory write that's lost
+// when the chunk leaves memory?
+//
+//   1. fill stone, //replace air (logged), rollback -> stone (in mem)
+//   2. read (expect stone)            : in-memory rollback worked
+//   3. save-all flush                 : persist dirty chunks to disk
+//   4. bot quits + forceload remove   : let the chunk UNLOAD
+//   5. forceload add (reload on disk) : bring it back from the region file
+//   6. read (stone? persisted : air?) : the verdict
+
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = (...a) => console.log('[' + new Date().toISOString().slice(11, 19) + ']', ...a);
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8'); const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length); return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 60000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej); s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout')); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c); const all = Buffer.concat(bufs);
+            if (all.length < 4) return; const len = all.readInt32LE(0);
+            if (all.length < len + 4) return; const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+function waitForChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+async function readBlock(x, y, z) {
+    if (/passed/i.test(await rcon(`execute if block ${x} ${y} ${z} minecraft:stone`))) return 'stone';
+    if (/passed/i.test(await rcon(`execute if block ${x} ${y} ${z} minecraft:air`))) return 'air';
+    return 'other/unloaded';
+}
+
+const BOT = 'pst' + Date.now().toString(36).slice(-4);
+const SIDE = 8;                              // 512 blocks, small & fast
+const X0 = 12000, Y0 = 80, Z0 = 12000;
+const X1 = X0 + SIDE - 1, Y1 = Y0 + SIDE - 1, Z1 = Z0 + SIDE - 1;
+const PX = X0 + 4, PY = Y0 + 4, PZ = Z0 + 4; // probe point (centre)
+
+(async () => {
+    log(`Durability test, bot ${BOT}, ${SIDE}³ cube @ ${X0},${Y0},${Z0}, probe (${PX},${PY},${PZ})`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`); await sleep(800);
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`); await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + 4.5} ${Y1 + 6} ${Z0 + 4.5}`); await sleep(2500);
+
+    log('fill stone + //replace stone air…');
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} stone`); await sleep(1000);
+    bot.chat('//sel cuboid'); await sleep(250);
+    bot.chat(`//pos1 ${X0},${Y0},${Z0}`); await sleep(250);
+    bot.chat(`//pos2 ${X1},${Y1},${Z1}`); await sleep(250);
+    const rep = waitForChat(bot, /blocks have been replaced/i, 30000);
+    bot.chat('//replace stone air'); await rep;
+    await sleep(3000);
+    log(`  after //replace, probe = ${await readBlock(PX, PY, PZ)} (expect air)`);
+
+    const NOSAVE = process.argv[2] === 'nosave';
+    if (NOSAVE) {
+        // Persist the air baseline and CLEAR the dirty flag set by
+        // //replace, so the only thing that can re-dirty the chunk is the
+        // rollback itself. This isolates whether the rollback marks the
+        // chunk unsaved (without it, a passive unload won't save).
+        log('nosave mode: save-all flush to lock in the AIR baseline (clears //replace dirty)…');
+        await rcon('save-all flush'); await sleep(4000);
+        log(`  baseline locked, probe = ${await readBlock(PX, PY, PZ)} (expect air)`);
+    }
+
+    log('rollback…');
+    const done = waitForChat(bot, /(reversals|No results)/i, 30000);
+    bot.chat(`/spyglass rollback p:${BOT} t:5m -g`);
+    const sum = await done;
+    log(`  summary: ${(sum || '(timeout)').replace(/\s+/g, ' ').trim()}`);
+    await sleep(1500);
+    const inMem = await readBlock(PX, PY, PZ);
+    log(`  after rollback (in memory), probe = ${inMem} (expect stone)`);
+
+    if (NOSAVE) {
+        log('NOT saving after rollback — passive unload must save it via the dirty flag…');
+    } else {
+        log('save-all flush (persist) …');
+        log('  ' + (await rcon('save-all flush')).replace(/\s+/g, ' ').trim());
+        await sleep(4000);
+    }
+
+    log('bot quit + forceload remove → unload the chunk…');
+    bot.quit(); await sleep(2500);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(6000);   // give the chunk time to actually unload
+
+    log('forceload add → reload the chunk from disk…');
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(4000);
+    const onDisk = await readBlock(PX, PY, PZ);
+    log(`  after save→unload→reload, probe = ${onDisk}`);
+
+    log('\n──────── DURABILITY VERDICT ────────');
+    log(`  in-memory after rollback : ${inMem}`);
+    log(`  after reload from disk   : ${onDisk}`);
+    const durable = inMem === 'stone' && onDisk === 'stone';
+    log(`  RESULT: ${durable ? 'DURABLE — rollback persisted to disk.'
+        : (inMem === 'stone' ? 'NOT DURABLE — rollback was lost on chunk unload (in-memory only).'
+            : 'INCONCLUSIVE — rollback did not apply in memory; see log.')}`);
+
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(durable ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/regression/bot/profile-rollback.sh
+++ b/regression/bot/profile-rollback.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Profile a Spyglass 2M rollback with Sundial, against EXISTING data (no
+# re-ingest). Runs a `main`-thread profile (what eats tick time → lag
+# spikes) then an `all`-threads profile (where the off-main work goes).
+# Usage: profile-rollback.sh <botTag>
+#
+# Run this in the BACKGROUND (sleeps are fine there). Sundial is ONLY on
+# during these profiling rollbacks — never during the compare.js timing
+# run, where it would bias SG's MSPT via forced safepoints.
+TAG="$1"
+RP=/Volumes/External-NVME/Documents/GitHub/MedievalRP/RP_Server
+LOG="$RP/logs/latest.log"
+cd /Volumes/External-NVME/Documents/GitHub/MedievalRP/Spyglass/regression/bot || exit 2
+
+profile_one () {
+  MODE="$1"
+  before=$(grep -c "Spyglass rollback .* timings" "$LOG")
+  echo ">>> sundial start $MODE  +  /spyglass rollback p:$TAG t:60m -g"
+  node rcon-send.js "sundial start $MODE 5" >/dev/null 2>&1
+  sleep 1
+  node rcon-send.js "spyglass rollback p:$TAG t:60m -g" >/dev/null 2>&1
+  # Wait for a NEW rollback-completion line in the server log.
+  for i in $(seq 1 120); do
+    now=$(grep -c "Spyglass rollback .* timings" "$LOG")
+    if [ "$now" -gt "$before" ]; then break; fi
+    sleep 1
+  done
+  sleep 1
+  node rcon-send.js "sundial stop" >/dev/null 2>&1
+  sleep 2
+  echo "   timings: $(grep 'Spyglass rollback .* timings' "$LOG" | tail -1 | sed 's/.*\] //')"
+  echo "   report : $(ls -t "$RP/plugins/Sundial/reports/"*.txt 2>/dev/null | head -1)"
+}
+
+echo "=== PROFILE: main thread (lag-spike attribution) ==="
+profile_one main
+sleep 3
+echo "=== PROFILE: all threads (work distribution) ==="
+profile_one all
+echo "=== done ==="

--- a/regression/bot/rcon-send.js
+++ b/regression/bot/rcon-send.js
@@ -1,0 +1,30 @@
+// Minimal RCON one-shot: node rcon-send.js "<command>"
+import net from 'net';
+const RCON_PORT = 25576, PASS = 'test123', HOST = '127.0.0.1';
+const cmd = process.argv[2] || 'list';
+
+function packet(id, type, body) {
+    const buf = Buffer.alloc(14 + body.length);
+    buf.writeInt32LE(10 + body.length, 0);
+    buf.writeInt32LE(id, 4);
+    buf.writeInt32LE(type, 8);
+    buf.write(body, 12, 'ascii');
+    return buf;
+}
+
+const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 30000 });
+let auth = false;
+s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+s.on('data', (d) => {
+    if (!auth) {
+        auth = true;
+        s.write(packet(0x2001, 2, cmd));
+    } else {
+        const body = d.slice(12, d.length - 2).toString('ascii');
+        if (body.trim()) process.stdout.write(body + '\n');
+        s.end();
+    }
+});
+s.on('timeout', () => { s.destroy(); process.exit(1); });
+s.on('error', (e) => { console.error('rcon error:', e.message); process.exit(1); });
+s.on('close', () => process.exit(0));

--- a/regression/bot/verify-rollback.js
+++ b/regression/bot/verify-rollback.js
@@ -1,0 +1,178 @@
+// Proof-of-work verification: does /spyglass rollback ACTUALLY change
+// blocks in the world, or does it just report a fast "done"?
+//
+// A rollback whose completion regex matches "No results" would look
+// blazing fast while changing nothing — so timing alone can't prove the
+// engine works. This script reads the REAL block state at sample points
+// across three stages and shows it changing:
+//
+//   1. fill stone (RCON, unlogged)        → samples should read STONE
+//   2. //replace stone air (WE, logged)   → samples should read AIR
+//   3. /spyglass rollback (restore)        → samples should read STONE again
+//
+// Two independent readers per sample:
+//   - bot.blockAt()  : the literal block name the bot sees (client view)
+//   - execute if block: server-side ground truth over RCON
+// Plus the rollback summary's APPLIED count (RollbackService only counts
+// a reversal as "applied" when it genuinely changed a world block —
+// already-correct blocks are "skipped"). applied > 0 == real writes.
+
+import mineflayer from 'mineflayer';
+import { Vec3 } from 'vec3';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566;
+const RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+// ── RCON (color-code-stripping, lifted from compare.js) ────────────
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 60000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout')); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+function waitForChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const handler = m => { if (re.test(m)) { bot.removeListener('messagestr', handler); resolve(m); } };
+        bot.on('messagestr', handler);
+        setTimeout(() => { bot.removeListener('messagestr', handler); resolve(null); }, timeout);
+    });
+}
+
+// Server-side ground truth: ask the server whether the block equals a
+// given type. `execute if block` prints "Test passed" / "Test failed".
+async function serverBlockIs(x, y, z, type) {
+    const r = await rcon(`execute if block ${x} ${y} ${z} minecraft:${type}`);
+    return /passed/i.test(r);
+}
+async function serverRead(x, y, z) {
+    if (await serverBlockIs(x, y, z, 'stone')) return 'stone';
+    if (await serverBlockIs(x, y, z, 'air')) return 'air';
+    return 'other';
+}
+
+const BOT = 'vrf' + Date.now().toString(36).slice(-4);
+// 16³ = 4096 blocks, clear of compare.js (14000) and quick-rb (11000).
+const SIDE = 16;
+const X0 = 13000, Y0 = 80, Z0 = 13000;
+const X1 = X0 + SIDE - 1, Y1 = Y0 + SIDE - 1, Z1 = Z0 + SIDE - 1;
+
+// Sample the 8 corners + the centre.
+const SAMPLES = [
+    [X0, Y0, Z0], [X1, Y0, Z0], [X0, Y1, Z0], [X1, Y1, Z0],
+    [X0, Y0, Z1], [X1, Y0, Z1], [X0, Y1, Z1], [X1, Y1, Z1],
+    [X0 + 8, Y0 + 8, Z0 + 8],
+];
+
+async function readAll(bot) {
+    const out = [];
+    for (const [x, y, z] of SAMPLES) {
+        const server = await serverRead(x, y, z);
+        const b = bot.blockAt(new Vec3(x, y, z));
+        out.push({ x, y, z, server, client: b ? b.name : 'null' });
+    }
+    return out;
+}
+function fmtStage(rows) {
+    return rows.map(r => `(${r.x},${r.y},${r.z}) srv=${r.server} cli=${r.client}`);
+}
+
+(async () => {
+    log(`Verifying rollback writes with bot ${BOT} on a ${SIDE}³=${SIDE ** 3}-block cube @ ${X0},${Y0},${Z0}`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(800);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + 8.5} ${Y1 + 6} ${Z0 + 8.5}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1000);
+
+    // ── Stage 1: fill stone (unlogged) ────────────────────────────
+    log('Stage 1: /fill stone (RCON, unlogged)…');
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} stone`);
+    await sleep(1500);
+    const afterFill = await readAll(bot);
+
+    // ── Stage 2: //replace stone air (logged by Spyglass) ─────────
+    log('Stage 2: //replace stone air (WorldEdit, logged)…');
+    bot.chat('//sel cuboid'); await sleep(300);
+    bot.chat(`//pos1 ${X0},${Y0},${Z0}`); await sleep(300);
+    bot.chat(`//pos2 ${X1},${Y1},${Z1}`); await sleep(300);
+    const replaceDone = waitForChat(bot, /blocks have been replaced/i, 60000);
+    bot.chat('//replace stone air');
+    const replMsg = await replaceDone;
+    log(`  WE: ${(replMsg || '(no replace confirmation)').trim()}`);
+    await sleep(3000);  // let the recorder drain the break events
+    const afterReplace = await readAll(bot);
+
+    // ── Stage 3: /spyglass rollback (restore air → stone) ─────────
+    log('Stage 3: /spyglass rollback p:' + BOT + ' t:5m -g …');
+    let summary = null;
+    const rbHandler = m => { if (/(reversals|No results)/i.test(m)) summary = m; };
+    bot.on('messagestr', rbHandler);
+    const t0 = Date.now();
+    bot.chat(`/spyglass rollback p:${BOT} t:5m -g`);
+    while (summary == null && Date.now() - t0 < 60000) await sleep(200);
+    bot.removeListener('messagestr', rbHandler);
+    await sleep(2000);
+    const afterRollback = await readAll(bot);
+
+    // ── Report ────────────────────────────────────────────────────
+    log('\n──────── BLOCK STATE BY STAGE (srv = server truth, cli = bot view) ────────');
+    for (let i = 0; i < SAMPLES.length; i++) {
+        const f = afterFill[i], r = afterReplace[i], b = afterRollback[i];
+        log(`(${f.x},${f.y},${f.z})  fill:srv=${f.server}/cli=${f.client}  ->  replace:srv=${r.server}/cli=${r.client}  ->  rollback:srv=${b.server}/cli=${b.client}`);
+    }
+    log('');
+    log(`Rollback summary line: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none / timeout)'}`);
+    log(`Rollback wall time: ${Date.now() - t0} ms`);
+
+    // ── Verdict ───────────────────────────────────────────────────
+    const allStoneAfterFill = afterFill.every(s => s.server === 'stone');
+    const allAirAfterReplace = afterReplace.every(s => s.server === 'air');
+    const allStoneAfterRollback = afterRollback.every(s => s.server === 'stone');
+    const appliedMatch = summary && summary.match(/(\d[\d,]*)\s+reversal/i);
+    const applied = appliedMatch ? parseInt(appliedMatch[1].replace(/,/g, ''), 10) : 0;
+
+    log('\n──────── VERDICT ────────');
+    log(`  all samples STONE after fill:        ${allStoneAfterFill ? 'YES' : 'NO'}`);
+    log(`  all samples AIR after //replace:     ${allAirAfterReplace ? 'YES' : 'NO'}`);
+    log(`  all samples STONE after rollback:    ${allStoneAfterRollback ? 'YES' : 'NO'}  <-- rollback wrote blocks`);
+    log(`  rollback reported reversals:         ${applied.toLocaleString()}`);
+    const pass = allStoneAfterFill && allAirAfterReplace && allStoneAfterRollback && applied > 0;
+    log(`\n  RESULT: ${pass ? 'PASS — rollback physically restored the blocks.' : 'FAIL — see stages above.'}`);
+
+    bot.quit();
+    await sleep(1500);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(pass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -80,13 +80,12 @@ limits {
   rollback-result = 10000
   chat-dump = 50
   # How many block-replace effects the rollback engine processes per
-  # tick before yielding back to the main thread. Phase 3 is pure
-  # bookkeeping for simple blocks when the EditSession (FAWE/WE) has
-  # already done the writes off-tick — so 4000/tick lands well under
-  # the 50ms tick budget in the common case. Lower this if you have
-  # many tile-entity rollbacks (chests, signs, banners) where Phase 3
-  # also writes block state via Bukkit, or if your TPS dips during a
-  # rollback.
+  # tick before yielding back to the main thread. Simple block writes
+  # fan out to the off-main worker pool, so this budgets the main-thread
+  # share of a page (tile entities, containers, leftovers, per-batch
+  # bookkeeping) — 4000/tick lands well under the 50ms tick budget in
+  # the common case. Lower this if you have many tile-entity rollbacks
+  # (chests, signs, banners), or if your TPS dips during a rollback.
   rollback-batch-size = 4000
   # Max time a rollback waits for the recorder queue to drain to the
   # store before running its query. Closes the read-your-writes hole
@@ -97,22 +96,33 @@ limits {
   # the most recent events may be missed.
   rollback-flush-timeout = 30s
   # Streaming page size — how many records the rollback engine fetches
-  # from the store at a time. Each page's precondition check (Phase 1)
-  # runs on the main thread at ~1 µs per cell, so a 50k page eats
-  # ~50ms = a full tick budget and the server visibly stutters.
-  # 20000 = ~20ms of main-thread Phase 1 work per page (under tick
-  # budget) and a 1M rollback runs as 50 pages. Lower if you still
-  # see TPS dips; higher only if you've moved Phase 1 off-thread.
+  # from the store at a time. The apply runs off-main, so this dial no
+  # longer buys tick time; it trades read throughput against LIVE HEAP.
+  # With the prefetch pipeline ~two pages of decoded records are in
+  # memory at once, and at million-row pages the backing arrays are
+  # humongous allocations (multi-MB single objects) that go straight
+  # to G1's old generation. Measured on a 2M-block rollback (6 GB heap,
+  # local ClickHouse): 1M pages ≈ 10-14s wall-clock but a 0.4-1.0s
+  # stop-the-world GC pause mid-run — a real freeze the TPS metrics do
+  # not show; 100K pages ≈ 22s with the worst single tick under ~100ms.
+  # The default is the smooth-and-safe end; raise toward 250000-400000
+  # if you roll back multi-million-block events often and want most of
+  # the read speed without the GC freeze. Verify with /mspt's MAX
+  # column and the GC log, never the 5s average — see
+  # docs/operations.md "Large rollbacks".
   rollback-page-size = 20000
   # Undo-stack cap. The rollback retains an inverse effect for every
-  # block it actually places so /spyglass undo can reverse it. For
-  # huge rollbacks the inverse list itself becomes a heap problem
-  # (~200B × 1M = ~200 MB). Past this many applied effects we drop
-  # subsequent inverses and tell the operator their /undo isn't
-  # available. The rollback itself still completes — only the undo
-  # is sacrificed. Default 500k covers all but the very largest WE
-  # bursts. Set to 0 to disable undo capture entirely; bump higher
-  # if you have ample heap and care about /undo on multi-million ops.
+  # block it actually places so /spyglass undo can reverse it. Unlike
+  # page memory these inverses live for the WHOLE operation — the cost
+  # scales with rollback size, survives young GCs, and promotes to old
+  # gen. Measured: raising this to 10M for a 2M-block rollback pushed
+  # ~2 GB into old gen and drew 0.5-1.0s stop-the-world GC pauses on a
+  # 6 GB heap. Past the cap subsequent inverses are dropped and the
+  # operator is told their /undo isn't available; the rollback itself
+  # still completes. The 500k default is the scaling-safe ceiling for
+  # typical heaps — resist raising it until undo capture streams to
+  # the store instead of the heap (#17). Set to 0 to disable undo
+  # capture entirely.
   rollback-undo-cap = 500000
 }
 


### PR DESCRIPTION
Issue #13's Phase 0 gate **failed** (details in the [issue comment](https://github.com/medievalrp-net/Spyglass/issues/13#issuecomment-new)): on client-v2 0.9.8, `queryRecords` already streams through a single reused `BinaryReaderBackedRecord` — binary RowBinary decode has nothing to bypass, measured within noise on time and identical on allocation. Per the issue's own spec, gate failure routes to the documented config fallback.

## What ships

- **`config.conf`** — `rollback-page-size` rewritten as the speed↔live-heap dial it now is (apply is off-main since #10/#11; the old Phase-1-on-main rationale was stale), with measured 2M-rollback endpoints (1M pages ≈ 10–14 s + 0.4–1.0 s GC freeze; 100K ≈ 22 s + <100 ms worst tick) and a 250–400K recommendation for big-rollback servers. `rollback-undo-cap` documents the whole-operation retention trap (10M cap → ~2 GB old-gen promotion → 0.5–1.0 s pauses, measured) and points at #17. `rollback-batch-size` loses its removed-FAWE reference. **No default values change.**
- **`docs/operations.md`** — new *Large rollbacks* runbook section: the dial table, the undo-cap rule, and the measurement caveat (off-main GC pauses are invisible to MSPT averages — judge by `/mspt` max + the GC log).
- **Benchmark tooling** (`regression/bot/`: worst-tick capture in compare.js, verify-rollback.js, persist-test.js, profile-rollback.sh, rcon-send.js) and the **full bench report** (`docs/report/rollback-bench-results.md`) committed for durability, per the issue's handoff note.

## Verification

Full `./gradlew check` green (all modules, Docker up, ITs running). Docs-and-tooling change; no production code paths touched.

The real fix for the GC freeze — streaming undo capture + paged replay — is tracked as #17.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)