### PR TITLE
fix: !-prefix excludes on a:, b:, and p: params (#30)

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -34,13 +34,13 @@ Root: `/spyglass`. Short alias: `/sg`.
 
 ## Query keys
 
-`key:value`. Combine freely; results match all keys.
+`key:value`. Combine freely; results match all keys. On `p:`, `a:`, `b:`, and `c:`, prefix a value with `!` to exclude it instead — `b:stone,!chest` matches stone but never chests; `a:!place` matches everything except placements.
 
 | Key | Aliases | Notes |
 |---|---|---|
-| `p` | `player` | Player(s). Comma-separated for OR |
-| `a` | `action`, `event` | Event type. See `/sg events` |
-| `b` | `block` | Target block material |
+| `p` | `player` | Player(s). Comma-separated for OR; `!name` excludes |
+| `a` | `action`, `event` | Event type. See `/sg events`; `!name` excludes |
+| `b` | `block` | Target block material; `!material` excludes |
 | `i` | `item` | Item material |
 | `iname` | `itemname` | Item display name (substring) |
 | `ilore` | `itemlore`, `d` | Item lore (substring) |

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BlockParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BlockParam.java
@@ -20,15 +20,39 @@ public final class BlockParam implements QueryParamHandler {
         if (value == null || value.isBlank()) {
             throw new ParamParseException("Block parameter requires a material.");
         }
-        String[] parts = value.split(",");
-        List<String> names = new ArrayList<>();
-        for (String raw : parts) {
-            Material material = Material.matchMaterial(raw.trim(), false);
-            if (material == null || !material.isBlock()) {
-                throw new ParamParseException("Unknown block: " + raw);
+        // `!`-prefixed materials are excludes (#30). The prefix MUST be
+        // stripped before Material.matchMaterial — Bukkit drops non-word
+        // characters, so an unstripped "!chest" would silently parse as
+        // CHEST and invert the operator's intent.
+        List<String> includes = new ArrayList<>();
+        List<String> excludes = new ArrayList<>();
+        for (String raw : value.split(",")) {
+            String token = raw.trim();
+            if (token.isEmpty() || token.equals("!")) {
+                continue;
             }
-            names.add(material.name());
+            boolean negated = token.startsWith("!");
+            String name = negated ? token.substring(1) : token;
+            Material material = Material.matchMaterial(name, false);
+            if (material == null || !material.isBlock()) {
+                throw new ParamParseException("Unknown block: " + name);
+            }
+            (negated ? excludes : includes).add(material.name());
         }
+        if (includes.isEmpty() && excludes.isEmpty()) {
+            throw new ParamParseException("Block parameter requires at least one material.");
+        }
+        List<QueryPredicate> clauses = new ArrayList<>(2);
+        if (!includes.isEmpty()) {
+            clauses.add(membership(includes));
+        }
+        if (!excludes.isEmpty()) {
+            clauses.add(new QueryPredicate.Not(membership(excludes)));
+        }
+        return clauses.size() == 1 ? clauses.getFirst() : new QueryPredicate.And(clauses);
+    }
+
+    private static QueryPredicate membership(List<String> names) {
         if (names.size() == 1) {
             return new QueryPredicate.Eq("target", names.getFirst());
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
@@ -25,21 +25,35 @@ public final class EventParam implements QueryParamHandler {
         if (value == null || value.isBlank()) {
             throw new ParamParseException("Event parameter requires a value.");
         }
-        String[] parts = value.split(",");
-        List<String> names = new java.util.ArrayList<>();
-        for (String raw : parts) {
-            String name = raw.trim().toLowerCase(java.util.Locale.ROOT);
-            if (name.isEmpty()) {
+        // `!`-prefixed names are excludes, same syntax as c: (#30).
+        List<String> includes = new java.util.ArrayList<>();
+        List<String> excludes = new java.util.ArrayList<>();
+        for (String raw : value.split(",")) {
+            String token = raw.trim().toLowerCase(java.util.Locale.ROOT);
+            if (token.isEmpty() || token.equals("!")) {
                 continue;
             }
+            boolean negated = token.startsWith("!");
+            String name = negated ? token.substring(1) : token;
             if (!enabledEvents.contains(name)) {
                 throw new ParamParseException("Unknown or disabled event: " + name);
             }
-            names.add(name);
+            (negated ? excludes : includes).add(name);
         }
-        if (names.isEmpty()) {
+        if (includes.isEmpty() && excludes.isEmpty()) {
             throw new ParamParseException("Event parameter requires at least one name.");
         }
+        List<QueryPredicate> clauses = new java.util.ArrayList<>(2);
+        if (!includes.isEmpty()) {
+            clauses.add(membership(includes));
+        }
+        if (!excludes.isEmpty()) {
+            clauses.add(new QueryPredicate.Not(membership(excludes)));
+        }
+        return clauses.size() == 1 ? clauses.getFirst() : new QueryPredicate.And(clauses);
+    }
+
+    private static QueryPredicate membership(List<String> names) {
         if (names.size() == 1) {
             return new QueryPredicate.Eq("event", names.getFirst());
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
@@ -34,33 +34,52 @@ public final class PlayerParam implements QueryParamHandler {
         if (value == null || value.isBlank()) {
             throw new ParamParseException("Player parameter requires a name.");
         }
-        String[] tokens = value.split(",");
+        // `!`-prefixed names are excludes (#30), same syntax as c:.
         List<UUID> ids = new ArrayList<>();
         List<String> rawNames = new ArrayList<>();
-        for (String raw : tokens) {
+        List<UUID> excludeIds = new ArrayList<>();
+        List<String> excludeRawNames = new ArrayList<>();
+        for (String raw : value.split(",")) {
             String trimmed = raw.trim();
-            if (trimmed.isEmpty()) {
+            if (trimmed.isEmpty() || trimmed.equals("!")) {
                 continue;
             }
-            UUID uuidLiteral = tryParseUuid(trimmed);
+            boolean negated = trimmed.startsWith("!");
+            String name = negated ? trimmed.substring(1) : trimmed;
+            List<UUID> idSink = negated ? excludeIds : ids;
+            List<String> nameSink = negated ? excludeRawNames : rawNames;
+            UUID uuidLiteral = tryParseUuid(name);
             if (uuidLiteral != null) {
-                ids.add(uuidLiteral);
+                idSink.add(uuidLiteral);
                 continue;
             }
-            UUID resolved = nameResolver.apply(trimmed);
+            UUID resolved = nameResolver.apply(name);
             if (resolved != null) {
-                ids.add(resolved);
+                idSink.add(resolved);
                 continue;
             }
             // Fallback: Bukkit never saw this player, but the name may still
             // exist verbatim in source.playerName for events captured while
             // the player was connected. Matches v1 behavior, which does a
             // raw string match.
-            rawNames.add(trimmed);
+            nameSink.add(name);
         }
-        if (ids.isEmpty() && rawNames.isEmpty()) {
+        QueryPredicate include = matchPredicate(ids, rawNames);
+        QueryPredicate exclude = matchPredicate(excludeIds, excludeRawNames);
+        if (include == null && exclude == null) {
             throw new ParamParseException("Player parameter requires at least one name.");
         }
+        List<QueryPredicate> clauses = new ArrayList<>(2);
+        if (include != null) {
+            clauses.add(include);
+        }
+        if (exclude != null) {
+            clauses.add(new QueryPredicate.Not(exclude));
+        }
+        return clauses.size() == 1 ? clauses.getFirst() : new QueryPredicate.And(clauses);
+    }
+
+    private static QueryPredicate matchPredicate(List<UUID> ids, List<String> rawNames) {
         QueryPredicate byId = idPredicate(ids);
         QueryPredicate byName = namePredicate(rawNames);
         if (byId != null && byName != null) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
@@ -103,6 +103,42 @@ class EventParamTest {
         assertThat(new EventParam(ENABLED).aliases()).containsExactly("a", "action", "event");
     }
 
+    @Test
+    void negatedEventProducesNot() throws Exception {
+        QueryPredicate predicate = new EventParam(ENABLED).parse("a", "!place", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.Not.class);
+        QueryPredicate inner = ((QueryPredicate.Not) predicate).predicate();
+        assertThat(((QueryPredicate.Eq) inner).value()).isEqualTo("place");
+    }
+
+    @Test
+    void mixedIncludeAndExcludeProducesAndWithNot() throws Exception {
+        QueryPredicate predicate = new EventParam(ENABLED).parse("a", "break,!place,!say", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.And.class);
+        var clauses = ((QueryPredicate.And) predicate).predicates();
+        assertThat(clauses).hasSize(2);
+        assertThat(((QueryPredicate.Eq) clauses.get(0)).value()).isEqualTo("break");
+        QueryPredicate excluded = ((QueryPredicate.Not) clauses.get(1)).predicate();
+        assertThat(((QueryPredicate.In) excluded).values().toArray()).containsExactly("place", "say");
+    }
+
+    @Test
+    void negatedUnknownEventStillRejected() {
+        // The exclusion of an unknown event is as much a typo as an
+        // inclusion of one — fail loudly either way.
+        assertThatThrownBy(() -> new EventParam(ENABLED).parse("a", "!warp", ctx()))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("warp");
+    }
+
+    @Test
+    void bareExclamationAloneRejected() {
+        assertThatThrownBy(() -> new EventParam(ENABLED).parse("a", "!", ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
     private static ParamContext ctx() {
         return new ParamContext(null, null, 100);
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamTest.java
@@ -113,6 +113,38 @@ class PlayerParamTest {
         assertThat(((QueryPredicate.Eq) predicate).field()).isEqualTo("source.playerName");
     }
 
+    @Test
+    void negatedKnownNameProducesNotOnPlayerId() throws Exception {
+        QueryPredicate predicate = withKnownPlayers(Map.of("Alice", ALICE)).parse("p", "!Alice", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.Not.class);
+        QueryPredicate inner = ((QueryPredicate.Not) predicate).predicate();
+        assertThat(((QueryPredicate.Eq) inner).field()).isEqualTo("source.playerId");
+        assertThat(((QueryPredicate.Eq) inner).value()).isEqualTo(ALICE);
+    }
+
+    @Test
+    void includeAndExcludeCombineWithAnd() throws Exception {
+        UUID bob = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        QueryPredicate predicate = withKnownPlayers(Map.of("Alice", ALICE, "Bob", bob))
+                .parse("p", "Alice,!Bob", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.And.class);
+        var clauses = ((QueryPredicate.And) predicate).predicates();
+        assertThat(((QueryPredicate.Eq) clauses.get(0)).value()).isEqualTo(ALICE);
+        QueryPredicate excluded = ((QueryPredicate.Not) clauses.get(1)).predicate();
+        assertThat(((QueryPredicate.Eq) excluded).value()).isEqualTo(bob);
+    }
+
+    @Test
+    void negatedUnresolvedNameFallsBackToRawNameExclusion() throws Exception {
+        QueryPredicate predicate = withKnownPlayers(Map.of()).parse("p", "!Ghost", ctx());
+
+        QueryPredicate inner = ((QueryPredicate.Not) predicate).predicate();
+        assertThat(((QueryPredicate.Eq) inner).field()).isEqualTo("source.playerName");
+        assertThat(((QueryPredicate.Eq) inner).value()).isEqualTo("Ghost");
+    }
+
     private static ParamContext ctx() {
         return new ParamContext(null, null, 100);
     }


### PR DESCRIPTION
b:!chest previously parsed as b:chest — Bukkit's matchMaterial strips
non-word characters, so the exclusion silently inverted into a
targeted include and rolled back exactly the material the operator
tried to protect (suite case G13). a:!place at least failed loudly
(H7). All three params now split !-prefixed tokens into an exclude
list and emit Not predicates, the same pattern CauseParam already
used; unknown names under negation still error. commands.md documents
the syntax.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
