### PR TITLE
fix: resurrect entities by type when the death NBT is absent (#29)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EntityDeathRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EntityDeathRecord.java
@@ -9,9 +9,11 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Death record. Rollback re-spawns the entity from its captured NBT; note that
- * NBT schema is version-brittle across Minecraft releases, so rollback across
- * a server upgrade may fail silently.
+ * Death record. Rollback re-spawns the entity from its captured NBT when a
+ * snapshot exists, falling back to a fresh spawn of {@link #entityType()}
+ * otherwise (#29 — Paper refuses to serialize dying entities, so most death
+ * records carry no NBT). NBT, when present, is version-brittle across
+ * Minecraft releases; a failed deserialize also falls back to by-type.
  */
 public record EntityDeathRecord(
         UUID id,

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1072,24 +1072,52 @@ public final class RollbackEngine {
     }
 
     private RollbackResult applyEntitySpawn(RollbackEffect.EntitySpawn effect) {
-        if (effect.serializedEntity() == null || effect.serializedEntity().isBlank()) {
-            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(
-                    "Entity NBT not captured (record is pre-Block-11)."));
-        }
         Optional<World> world = BlockLocations.resolveWorld(effect.location());
         if (world.isEmpty()) {
             return new RollbackResult.Skipped(effect, new RollbackReason.InvalidLocation(effect.location()));
         }
         Location location = new Location(world.get(),
                 effect.location().x() + 0.5, effect.location().y(), effect.location().z() + 0.5);
-        try {
-            byte[] bytes = Base64.getDecoder().decode(effect.serializedEntity());
-            Entity entity = Bukkit.getUnsafe().deserializeEntity(bytes, world.get(), true, false);
-            if (entity == null) {
-                return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(
-                        "Entity deserialization returned null."));
+        // Full-NBT resurrection when a snapshot exists. In practice it
+        // rarely does: Paper's serializeEntity rejects dying entities,
+        // so death records ship with null NBT (#29) — hence the
+        // by-type fallback below rather than a skip.
+        if (effect.serializedEntity() != null && !effect.serializedEntity().isBlank()) {
+            try {
+                byte[] bytes = Base64.getDecoder().decode(effect.serializedEntity());
+                Entity entity = Bukkit.getUnsafe().deserializeEntity(bytes, world.get(), true, false);
+                if (entity != null) {
+                    entity.teleport(location);
+                    RollbackEffect inverse = new RollbackEffect.EntityRemove(
+                            effect.location(), effect.entityType(), entity.getUniqueId().toString());
+                    return new RollbackResult.Applied(effect, inverse);
+                }
+            } catch (Throwable thrown) {
+                // Version-brittle NBT (documented on EntityDeathRecord);
+                // fall through to the by-type spawn.
             }
-            entity.teleport(location);
+        }
+        return spawnByType(effect, world.get(), location);
+    }
+
+    // Resurrection without a snapshot: a fresh entity of the recorded
+    // type. Loses name/tame/equipment fidelity but beats refusing the
+    // rollback outright — and matches what operators get elsewhere.
+    private RollbackResult spawnByType(RollbackEffect.EntitySpawn effect, World world, Location location) {
+        if (effect.entityType() == null || effect.entityType().isBlank()) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(
+                    "No entity NBT and no entity type recorded."));
+        }
+        try {
+            org.bukkit.NamespacedKey key = org.bukkit.NamespacedKey.minecraft(
+                    effect.entityType().toLowerCase(java.util.Locale.ROOT));
+            org.bukkit.entity.EntityType type =
+                    org.bukkit.Registry.ENTITY_TYPE.get(key);
+            if (type == null || !type.isSpawnable()) {
+                return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(
+                        "Entity type '" + effect.entityType() + "' is not spawnable."));
+            }
+            Entity entity = world.spawnEntity(location, type);
             RollbackEffect inverse = new RollbackEffect.EntityRemove(
                     effect.location(), effect.entityType(), entity.getUniqueId().toString());
             return new RollbackResult.Applied(effect, inverse);


### PR DESCRIPTION
Every death record carries null entity_nbt in practice — Paper's
serializeEntity rejects dying entities, so the listener's capture has
silently nulled since the field shipped (verified against the live
store: all death rows nbt-missing). applyEntitySpawn previously
skipped on missing NBT, making a:death rollbacks no-ops while
CoreProtect resurrects mobs.

The NBT path stays first (and a failed deserialize now also falls
through instead of skipping); without a snapshot the engine spawns a
fresh entity of the recorded type via the registry. Loses
name/tame/equipment fidelity, beats refusing the rollback, and closes
the suite's D1 CP-ahead cell. Record javadoc states the real contract.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
