### PR TITLE
fix: expected-state check on the parallel palette-write fast path (#27)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -685,9 +685,37 @@ public final class RollbackEngine {
             }
             BlockLocation loc = effect.location();
             BlockSnapshot replacement = effect.replacement();
-            if (work.ctx != null) {
-                work.ctx.writeBlock(loc.x(), loc.y(), loc.z(), bd);
+            if (work.ctx == null) {
+                // Degraded path (prepareChunk failed): route EVERY cell to
+                // the main-thread half, which writes via the single-block
+                // fallback. Simple cells previously reported Applied here
+                // without any write ever happening.
+                nonSimpleMask.set(j);
+                continue;
             }
+            // Expected-state check (#27): same semantics as the slow
+            // path's matches() — interned NMS states make identity equal
+            // to material+blockData equality. Skipping here is what keeps
+            // a p:<actor> rollback from clobbering another player's newer
+            // edit, and makes re-runs report skips instead of re-applying.
+            BlockSnapshot expected = effect.expectedCurrent();
+            if (expected != null) {
+                org.bukkit.block.data.BlockData expectedBd;
+                try {
+                    expectedBd = blockDataFor(expected.blockData());
+                } catch (RuntimeException thrown) {
+                    expectedBd = null;
+                }
+                if (expectedBd != null
+                        && work.ctx.currentStateMatches(loc.x(), loc.y(), loc.z(), expectedBd) == 0) {
+                    resultArray[targetIndex] = new RollbackResult.Skipped(effect,
+                            new RollbackReason.BlockChanged(loc, expected,
+                                    snapshotOfCurrent(work.ctx, loc)));
+                    writes[j] = null;
+                    continue;
+                }
+            }
+            work.ctx.writeBlock(loc.x(), loc.y(), loc.z(), bd);
             if (replacement.simple()) {
                 // No tile entity to apply; the palette write is the whole
                 // apply. Build Applied here on the worker.
@@ -701,6 +729,19 @@ public final class RollbackEngine {
         }
         work.writes = writes;
         work.nonSimpleMask = nonSimpleMask;
+    }
+
+    // Mismatch reporting only — allocates a Bukkit BlockData wrapper, so
+    // it stays off the per-block hot path.
+    private static BlockSnapshot snapshotOfCurrent(
+            ChunkDirectWriter.ChunkContext ctx, BlockLocation loc) {
+        org.bukkit.block.data.BlockData current = ctx.readBlockData(loc.x(), loc.y(), loc.z());
+        if (current == null) {
+            return null;
+        }
+        return new BlockSnapshot(current.getMaterial(), current.getAsString(),
+                java.util.List.of(), java.util.List.of(), java.util.List.of(),
+                java.util.List.of(), null);
     }
 
     // Main-thread half: apply tile-entity state for the non-simple blocks
@@ -724,8 +765,18 @@ public final class RollbackEngine {
                     BlockLocation loc = effect.location();
                     try {
                         if (work.ctx == null) {
-                            // prepareChunk failed for this chunk; fall back
-                            // to a single-block write here on main.
+                            // prepareChunk failed for this chunk; run the
+                            // expected-state check (#27) via Bukkit, then
+                            // fall back to a single-block write here on main.
+                            Block current = world.getBlockAt(loc.x(), loc.y(), loc.z());
+                            BlockSnapshot expected = effect.expectedCurrent();
+                            if (expected != null
+                                    && !expected.blockData().equals(current.getBlockData().getAsString())) {
+                                resultArray[targetIndex] = new RollbackResult.Skipped(effect,
+                                        new RollbackReason.BlockChanged(loc, expected,
+                                                BlockSnapshots.capture(current.getState())));
+                                continue;
+                            }
                             ChunkDirectWriter.writeBlock(
                                     world, loc.x(), loc.y(), loc.z(), writes[j]);
                         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ChunkDirectWriter.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ChunkDirectWriter.java
@@ -54,6 +54,8 @@ public final class ChunkDirectWriter {
     private static Method levelChunkSetUnsaved;
     private static Method sectionSetBlockState;
     private static Method craftBlockDataGetState;
+    private static Method sectionGetBlockState;
+    private static Method craftBlockDataFromData;
     // Light engine bits — optional. If lookup fails the writer still
     // works; the chunk packet just carries stale light data and the
     // client briefly sees wrong lighting until the engine catches up.
@@ -137,6 +139,66 @@ public final class ChunkDirectWriter {
         private Object resolveNmsState(BlockData bd) {
             try {
                 return craftBlockDataGetState.invoke(bd);
+            } catch (Throwable t) {
+                return null;
+            }
+        }
+
+        /**
+         * Expected-state check for the parallel apply (#27). NMS block
+         * states are interned, so identity against the section's current
+         * entry is exactly material+blockData equality — the same
+         * semantics as the slow path's snapshot compare — with no
+         * per-block allocation.
+         *
+         * @return 1 = current state equals {@code expected}, 0 = it
+         *         differs, -1 = unreadable (caller writes anyway, the
+         *         pre-#27 behavior).
+         */
+        public int currentStateMatches(int x, int y, int z, BlockData expected) {
+            if (sectionGetBlockState == null) {
+                return -1;
+            }
+            try {
+                int sectionIndex = (y >> 4) - minSection;
+                if (sectionIndex != lastSectionIndex) {
+                    lastSection = levelChunkGetSection.invoke(levelChunk, sectionIndex);
+                    lastSectionIndex = sectionIndex;
+                }
+                if (lastSection == null) {
+                    return -1;
+                }
+                Object expectedNms = NMS_STATE_CACHE.computeIfAbsent(expected, this::resolveNmsState);
+                if (expectedNms == null) {
+                    return -1;
+                }
+                Object current = sectionGetBlockState.invoke(lastSection, x & 15, y & 15, z & 15);
+                return current == expectedNms ? 1 : 0;
+            } catch (Throwable t) {
+                return -1;
+            }
+        }
+
+        /**
+         * The current block's data, for mismatch reporting only — this
+         * allocates a Bukkit wrapper, so it must stay off the per-block
+         * hot path. Null when unreadable.
+         */
+        public BlockData readBlockData(int x, int y, int z) {
+            if (sectionGetBlockState == null || craftBlockDataFromData == null) {
+                return null;
+            }
+            try {
+                int sectionIndex = (y >> 4) - minSection;
+                if (sectionIndex != lastSectionIndex) {
+                    lastSection = levelChunkGetSection.invoke(levelChunk, sectionIndex);
+                    lastSectionIndex = sectionIndex;
+                }
+                if (lastSection == null) {
+                    return null;
+                }
+                Object current = sectionGetBlockState.invoke(lastSection, x & 15, y & 15, z & 15);
+                return current == null ? null : (BlockData) craftBlockDataFromData.invoke(null, current);
             } catch (Throwable t) {
                 return null;
             }
@@ -331,9 +393,23 @@ public final class ChunkDirectWriter {
             // safe path). We're on the main thread so either works.
             sectionSetBlockState = findMethod(sectionClass, "setBlockState",
                     int.class, int.class, int.class, blockStateClass);
+            // getBlockState(int,int,int) — palette read used by the
+            // expected-state check (#27). Best-effort: when missing the
+            // check degrades to write-without-compare, never to a crash.
+            try {
+                sectionGetBlockState = findMethod(sectionClass, "getBlockState",
+                        int.class, int.class, int.class);
+            } catch (NoSuchMethodException ignored) {
+                sectionGetBlockState = null;
+            }
 
             Class<?> craftBlockData = Class.forName("org.bukkit.craftbukkit.block.data.CraftBlockData");
             craftBlockDataGetState = craftBlockData.getMethod("getState");
+            try {
+                craftBlockDataFromData = craftBlockData.getMethod("fromData", blockStateClass);
+            } catch (NoSuchMethodException ignored) {
+                craftBlockDataFromData = null;
+            }
 
             // Light engine — best-effort. checkBlock(BlockPos) re-evaluates
             // light at that position. Without this, the chunk-resender


### PR DESCRIPTION
The #10 parallel apply wrote every palette entry unconditionally — the
slow path's matches() guard never carried over — so rolling back one
player overwrote another player's newer edits (suite case A5) and
identical re-runs re-applied 100% instead of skipping (G3).

The worker now identity-compares the section's current NMS state
against the effect's expectedCurrent before writing: block states are
interned, so pointer equality IS material+blockData equality — one
reflective getBlockState per block, zero allocation, with the Bukkit
wrapper conversion only on the rare mismatch path for the BlockChanged
reason payload. Reflection-degraded chunks (prepareChunk null) run the
same check via Bukkit on main — and that path previously marked simple
cells Applied without ever writing them; they now route through the
main-thread fallback write.

Resume/undo convergence is preserved: a re-applied effect sees
current==replacement, mismatches expectedCurrent, and skips — same end
state, honestly reported as skipped.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
