### PR TITLE
fix: prune synthesis op expansion so op-dense global searches return (#33)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
@@ -64,8 +64,23 @@ public final class RolledSynthesis {
         if (!eventFilterMightIncludeRolled(request.predicates())) {
             return List.of();
         }
+        // Synthesized records always carry Source.environment("ROLLBACK");
+        // a positive source.player* predicate can never match one — same
+        // as the persisted receipts it emulates — so skip the op scan
+        // entirely. This is what kept p:-filtered global searches from
+        // grinding through one store query per op in the window (#33).
+        if (!sourcePredicatesFeasible(request.predicates())) {
+            return List.of();
+        }
         List<EventRecord> out = new ArrayList<>();
         for (EventRecord candidate : findOps(request)) {
+            // Expansion is one store query per op; once the caller's
+            // limit is satisfiable the rest only add rows the merge
+            // would truncate anyway. Newest ops expand first, matching
+            // the default sort's bias.
+            if (out.size() >= request.limit()) {
+                break;
+            }
             if (!(candidate instanceof RollbackOpRecord op) || op.reference() == null) {
                 continue;
             }
@@ -75,9 +90,93 @@ public final class RolledSynthesis {
             } catch (RuntimeException ex) {
                 continue; // unreadable blob — skip the op, never the search
             }
+            if (!boxesIntersectRequest(ref, request.predicates())) {
+                continue; // op landed entirely outside the searched area
+            }
             expandOp(request, op, ref, out);
         }
         return out;
+    }
+
+    /**
+     * False when the request's top-level predicates can never match a
+     * synthesized record (which has playerId/playerName == null). Only
+     * positive forms prune; Not(...) over a source predicate matches an
+     * environment source and stays feasible.
+     */
+    private static boolean sourcePredicatesFeasible(List<QueryPredicate> predicates) {
+        for (QueryPredicate predicate : predicates) {
+            if (isPositiveSourcePlayerPredicate(predicate)) {
+                return false;
+            }
+            if (predicate instanceof QueryPredicate.Or or
+                    && !or.predicates().isEmpty()
+                    && or.predicates().stream().allMatch(RolledSynthesis::isPositiveSourcePlayerPredicate)) {
+                // p:<unresolved-name> parses to Or(byId, byName) — every
+                // branch targets the player source, so none can match.
+                return false;
+            }
+            if (predicate instanceof QueryPredicate.And and
+                    && !sourcePredicatesFeasible(and.predicates())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isPositiveSourcePlayerPredicate(QueryPredicate predicate) {
+        String field = switch (predicate) {
+            case QueryPredicate.Eq eq -> eq.field();
+            case QueryPredicate.In in -> in.field();
+            default -> null;
+        };
+        return field != null
+                && (field.equals("source.playerId") || field.equals("source.playerName"));
+    }
+
+    /**
+     * False when the request constrains location to a box that misses
+     * every bounding box the operation recorded (v2 references). v1
+     * references carry no boxes and always expand.
+     */
+    private static boolean boxesIntersectRequest(UndoReferenceBson.Reference ref,
+                                                 List<QueryPredicate> predicates) {
+        if (ref.boxes() == null || ref.boxes().isEmpty()) {
+            return true;
+        }
+        long[] xRange = coordRange(predicates, "location.x");
+        long[] zRange = coordRange(predicates, "location.z");
+        if (xRange == null && zRange == null) {
+            return true; // unbounded request — every op is in scope
+        }
+        for (UndoReferenceBson.WorldBox box : ref.boxes()) {
+            boolean xOk = xRange == null
+                    || (box.maxX() >= xRange[0] && box.minX() <= xRange[1]);
+            boolean zOk = zRange == null
+                    || (box.maxZ() >= zRange[0] && box.minZ() <= zRange[1]);
+            if (xOk && zOk) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static long @Nullable [] coordRange(List<QueryPredicate> predicates, String field) {
+        for (QueryPredicate predicate : predicates) {
+            if (predicate instanceof QueryPredicate.Range range
+                    && field.equals(range.field())
+                    && range.lowerInclusive() instanceof Number lo
+                    && range.upperInclusive() instanceof Number hi) {
+                return new long[]{lo.longValue(), hi.longValue()};
+            }
+            if (predicate instanceof QueryPredicate.And and) {
+                long[] nested = coordRange(and.predicates(), field);
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
+        return null;
     }
 
     private List<EventRecord> findOps(QueryRequest request) {

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -36,6 +36,7 @@ class RolledSynthesisTest {
      */
     private static final class MemoryStore implements RecordStore {
         final List<EventRecord> rows = new ArrayList<>();
+        int queryCount;
 
         @Override
         public void save(List<EventRecord> records) {
@@ -44,6 +45,7 @@ class RolledSynthesisTest {
 
         @Override
         public QueryResult query(QueryRequest request) {
+            queryCount++;
             List<EventRecord> matched = rows.stream()
                     .filter(r -> PredicateEvaluator.matchesAll(request.predicates(), r))
                     .limit(request.limit())
@@ -183,4 +185,87 @@ class RolledSynthesisTest {
         UUID second = synthesis.synthesize(search).get(0).id();
         assertThat(first).isEqualTo(second);
     }
+    @Test
+    void positivePlayerFilterSkipsSynthesisWithoutAnyStoreQuery() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(griefBreak(1),
+                op(coveredQuery(), "ROLLBACK", OP_TIME)));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        QueryRequest request = new QueryRequest(List.of(
+                new QueryPredicate.Eq("source.playerId", GRIEFER)),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+        List<EventRecord> out = synthesis.synthesize(request);
+
+        assertThat(out).isEmpty();
+        assertThat(store.queryCount)
+                .as("a p:-filtered request must not pay the op scan (#33)")
+                .isZero();
+    }
+
+    @Test
+    void negatedPlayerFilterStaysFeasible() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(griefBreak(1),
+                op(coveredQuery(), "ROLLBACK", OP_TIME)));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        QueryRequest request = new QueryRequest(List.of(
+                new QueryPredicate.Not(new QueryPredicate.Eq("source.playerId", GRIEFER))),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+        List<EventRecord> out = synthesis.synthesize(request);
+
+        assertThat(out)
+                .as("Not(p:) matches the environment source; synthesis must run")
+                .isNotEmpty();
+    }
+
+    @Test
+    void opOutsideTheSearchedBoxIsNotExpanded() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(griefBreak(1),
+                op(coveredQuery(), "ROLLBACK", OP_TIME)));   // box spans x 0..10
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        QueryRequest farAway = new QueryRequest(List.of(
+                new QueryPredicate.Range("location.x", 5000, 5016),
+                new QueryPredicate.Range("location.z", -16, 16)),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+        List<EventRecord> out = synthesis.synthesize(farAway);
+
+        assertThat(out).isEmpty();
+        assertThat(store.queryCount)
+                .as("only the op scan runs; the op expansion is pruned by its box")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void expansionStopsOnceTheLimitIsFilled() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(griefBreak(1),
+                op(coveredQuery(), "ROLLBACK", OP_TIME),
+                op(coveredQuery(), "ROLLBACK", OP_TIME)));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        QueryRequest limited = new QueryRequest(List.of(),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 1,
+                EnumSet.of(Flag.NO_GROUP), false);
+        List<EventRecord> out = synthesis.synthesize(limited);
+
+        assertThat(out).hasSize(1);
+        assertThat(store.queryCount)
+                .as("op scan + exactly one expansion for limit=1")
+                .isEqualTo(2);
+    }
+
+    private static QueryRequest coveredQuery() {
+        return new QueryRequest(List.of(
+                new QueryPredicate.Eq("source.playerId", GRIEFER)),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 10000,
+                EnumSet.of(Flag.NO_GROUP), false);
+    }
+
 }


### PR DESCRIPTION
An unfiltered global search ran one store query per rollback-op in the
window (up to 256, sequential) — after a busy operator hour that
ground past every reasonable wait and the search appeared to return
nothing (suite case H11).

Three bounds, all exactness-preserving:
- Positive source.player* predicates can never match a synthesized
  record (environment source, same as the persisted receipts they
  emulate) — skip the op scan entirely. This alone fixes the H11
  shape (p:<player> ... -g).
- v2 references carry the operation's bounding boxes: ops whose boxes
  miss the request's coordinate ranges are pruned without a query.
- Expansion stops once the caller's limit is satisfiable (newest ops
  first, matching the default sort's bias) — the merge would truncate
  anything further anyway.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
