### PR TITLE
fix: iname:/ilore:/ench: work on ClickHouse via in-memory post-filter (#32)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -619,22 +619,54 @@ public final class ClickHouseRecordStore implements RecordStore {
         return "toDateTime64('" + s + "." + String.format("%03d", ms) + "', 3, 'UTC')";
     }
 
-    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
-        StringBuilder sql = new StringBuilder("SELECT ")
-                .append(includeHeavy ? fullSelect : summarySelect)
-                .append(" FROM ").append(qualifiedTable);
+    // Post-filter fallback (#32): rows scanned per query when part of
+    // the predicate tree (item.name / lore / enchants — opaque BSON on
+    // CH) must be evaluated in memory. The pushable predicates (player,
+    // time, radius, event) bound the scan in practice; this bounds it
+    // in pathology.
+    private static final int POST_FILTER_SCAN_CAP = 20_000;
 
+    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
         List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
         if (request.flags().contains(Flag.NO_CHAT)) {
             predicates.add(new QueryPredicate.Exists(RecordFields.MESSAGE, false));
         }
-        String where = predicateToSql.translate(predicates);
+
+        // Full pushdown first; on an unsupported path, split the
+        // top-level AND list into pushable SQL + an in-memory residual
+        // evaluated against the decoded records (#32). Residual fields
+        // live inside the heavy blobs, so the scan hydrates them even
+        // for summary queries.
+        String where;
+        List<QueryPredicate> residual = List.of();
+        try {
+            where = predicateToSql.translate(predicates);
+        } catch (PredicateToSql.UnsupportedPredicateException unsupported) {
+            List<QueryPredicate> pushable = new ArrayList<>();
+            List<QueryPredicate> inMemory = new ArrayList<>();
+            for (QueryPredicate predicate : predicates) {
+                try {
+                    predicateToSql.translate(List.of(predicate));
+                    pushable.add(predicate);
+                } catch (PredicateToSql.UnsupportedPredicateException ex) {
+                    inMemory.add(predicate);
+                }
+            }
+            residual = inMemory;
+            where = predicateToSql.translate(pushable);
+        }
+        boolean postFilter = !residual.isEmpty();
+        boolean hydrate = includeHeavy || postFilter;
+
+        StringBuilder sql = new StringBuilder("SELECT ")
+                .append(hydrate ? fullSelect : summarySelect)
+                .append(" FROM ").append(qualifiedTable);
         if (!where.isEmpty()) {
             sql.append(" WHERE ").append(where);
         }
         sql.append(" ORDER BY occurred ")
                 .append(request.sort() == Sort.OLDEST_FIRST ? "ASC" : "DESC");
-        sql.append(" LIMIT ").append(request.limit());
+        sql.append(" LIMIT ").append(postFilter ? POST_FILTER_SCAN_CAP : request.limit());
 
         List<GenericRecord> rows;
         try {
@@ -642,11 +674,18 @@ public final class ClickHouseRecordStore implements RecordStore {
         } catch (RuntimeException ex) {
             throw new RuntimeException("ClickHouse query failed: " + ex.getMessage(), ex);
         }
-        List<EventRecord> records = new ArrayList<>(rows.size());
+        List<EventRecord> records = new ArrayList<>(postFilter ? 64 : rows.size());
         for (GenericRecord row : rows) {
-            EventRecord record = decodeRow(row, includeHeavy);
-            if (record != null) {
-                records.add(record);
+            EventRecord record = decodeRow(row, hydrate);
+            if (record == null) {
+                continue;
+            }
+            if (postFilter && !PredicateEvaluator.matchesAll(residual, record)) {
+                continue;
+            }
+            records.add(record);
+            if (postFilter && records.size() >= request.limit()) {
+                break;
             }
         }
         List<QueryResult.RecordAggregation> aggregations =

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -2,7 +2,16 @@ package net.medievalrp.spyglass.plugin.storage;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.ItemDropRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
+import net.medievalrp.spyglass.api.event.StoredItem;
 import net.medievalrp.spyglass.api.query.QueryPredicate;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -65,6 +74,16 @@ final class PredicateEvaluator {
         if (actual == null || expected == null) {
             return actual == null && expected == null;
         }
+        // Multi-valued fields (lore lines, enchant strings, container
+        // items) match when ANY element matches — same semantics as the
+        // Mongo array-field queries the iname:/ilore:/ench: params were
+        // designed against.
+        if (actual instanceof List<?> list) {
+            return list.stream().anyMatch(element -> equalsValue(element, expected));
+        }
+        if (expected instanceof Pattern pattern) {
+            return pattern.matcher(String.valueOf(actual)).find();
+        }
         if (actual instanceof Number a && expected instanceof Number b) {
             return a.doubleValue() == b.doubleValue();
         }
@@ -102,8 +121,106 @@ final class PredicateEvaluator {
             case "location.x" -> record.location() == null ? null : record.location().x();
             case "location.y" -> record.location() == null ? null : record.location().y();
             case "location.z" -> record.location() == null ? null : record.location().z();
+            default -> itemPathValue(record, field);
+        };
+    }
+
+    // ── nested item / snapshot paths (#32) ───────────────────────
+    // These live in opaque blobs on ClickHouse; the store's post-filter
+    // fallback (and the synthesis parity filter) resolve them here from
+    // the decoded records instead.
+
+    private static @Nullable Object itemPathValue(EventRecord record, String field) {
+        int dot = field.indexOf('.');
+        if (dot < 0) {
+            return null;
+        }
+        String root = field.substring(0, dot);
+        String rest = field.substring(dot + 1);
+        return switch (root) {
+            case "item" -> storedItemField(itemOf(record), rest);
+            case "beforeItem" -> storedItemField(beforeItemOf(record), rest);
+            case "afterItem" -> storedItemField(afterItemOf(record), rest);
+            case "originalBlock" -> snapshotField(originalBlockOf(record), rest);
+            case "newBlock" -> snapshotField(newBlockOf(record), rest);
             default -> null;
         };
+    }
+
+    private static @Nullable StoredItem itemOf(EventRecord record) {
+        return switch (record) {
+            case ItemDropRecord r -> r.item();
+            case ItemPickupRecord r -> r.item();
+            default -> null;
+        };
+    }
+
+    private static @Nullable StoredItem beforeItemOf(EventRecord record) {
+        return switch (record) {
+            case ContainerDepositRecord r -> r.beforeItem();
+            case ContainerWithdrawRecord r -> r.beforeItem();
+            default -> null;
+        };
+    }
+
+    private static @Nullable StoredItem afterItemOf(EventRecord record) {
+        return switch (record) {
+            case ContainerDepositRecord r -> r.afterItem();
+            case ContainerWithdrawRecord r -> r.afterItem();
+            default -> null;
+        };
+    }
+
+    private static @Nullable BlockSnapshot originalBlockOf(EventRecord record) {
+        return switch (record) {
+            case BlockBreakRecord r -> r.originalBlock();
+            case BlockPlaceRecord r -> r.originalBlock();
+            default -> null;
+        };
+    }
+
+    private static @Nullable BlockSnapshot newBlockOf(EventRecord record) {
+        return switch (record) {
+            case BlockBreakRecord r -> r.newBlock();
+            case BlockPlaceRecord r -> r.newBlock();
+            default -> null;
+        };
+    }
+
+    private static @Nullable Object storedItemField(@Nullable StoredItem item, String rest) {
+        if (item == null) {
+            return null;
+        }
+        return switch (rest) {
+            case "name" -> item.name();
+            case "material" -> item.material();
+            case "data" -> item.data();
+            case "slot" -> item.slot();
+            case "lore" -> item.lore();
+            case "enchants" -> item.enchants();
+            // hasMetadata() probes array non-emptiness via ".0".
+            case "lore.0" -> item.lore().isEmpty() ? null : item.lore().get(0);
+            case "enchants.0" -> item.enchants().isEmpty() ? null : item.enchants().get(0);
+            default -> null;
+        };
+    }
+
+    private static @Nullable Object snapshotField(@Nullable BlockSnapshot snapshot, String rest) {
+        if (snapshot == null) {
+            return null;
+        }
+        if (!rest.startsWith("containerItems")) {
+            return null;
+        }
+        List<StoredItem> items = snapshot.containerItems();
+        if (rest.equals("containerItems")) {
+            return items;
+        }
+        String sub = rest.substring("containerItems.".length());
+        return items.stream()
+                .map(item -> storedItemField(item, sub))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
 }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -368,4 +368,59 @@ class ClickHouseRecordStoreIT {
                 .containsExactlyElementsOf(pagedIds);
         assertThat(streamRounds).isEqualTo(pageRounds);
     }
+    @Test
+    void itemFieldFiltersPostFilterInMemory() {
+        // #32: iname:/ilore:/ench: paths live inside opaque BSON on CH.
+        // The store pushes what it can and applies the item predicates
+        // in memory — this drives the exact Or-of-paths shape the params
+        // emit, Pattern values included.
+        Instant now = Instant.now().minusSeconds(60);
+        StoredItem excaliblur = new StoredItem(0, "DIAMOND_SWORD", "AAAA",
+                "Excaliblur",
+                List.of("Forged in primordial fire"),
+                List.of("sharpness=5"));
+        StoredItem mundane = new StoredItem(0, "IRON_SWORD", "BBBB",
+                null, List.of(), List.of());
+        store.save(List.of(
+                new net.medievalrp.spyglass.api.event.ItemDropRecord(
+                        UUID.randomUUID(), "drop", now, now.plusSeconds(3600),
+                        Origin.player(), Source.player(ALICE, "Alice"),
+                        new BlockLocation(WORLD, "world", 1, 64, 1), "test",
+                        "DIAMOND_SWORD", 1, excaliblur),
+                new net.medievalrp.spyglass.api.event.ItemDropRecord(
+                        UUID.randomUUID(), "drop", now, now.plusSeconds(3600),
+                        Origin.player(), Source.player(ALICE, "Alice"),
+                        new BlockLocation(WORLD, "world", 2, 64, 2), "test",
+                        "IRON_SWORD", 1, mundane)));
+        flushAsyncInserts();
+
+        java.util.function.Function<QueryPredicate, QueryRequest> req = p ->
+                new QueryRequest(List.of(
+                        new QueryPredicate.Eq("source.playerId", ALICE), p),
+                        Sort.NEWEST_FIRST, 100, EnumSet.noneOf(Flag.class), false);
+        java.util.function.BiFunction<String, String, QueryPredicate> anyItem = (sub, term) -> {
+            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                    java.util.regex.Pattern.quote(term), java.util.regex.Pattern.CASE_INSENSITIVE);
+            List<QueryPredicate> clauses = new java.util.ArrayList<>();
+            for (String path : List.of("item", "beforeItem", "afterItem",
+                    "originalBlock.containerItems", "newBlock.containerItems")) {
+                clauses.add(new QueryPredicate.Eq(path + "." + sub, pattern));
+            }
+            return new QueryPredicate.Or(List.copyOf(clauses));
+        };
+
+        assertThat(store.query(req.apply(anyItem.apply("name", "excali"))).records())
+                .hasSize(1)
+                .allMatch(r -> "DIAMOND_SWORD".equals(r.target()));
+        assertThat(store.query(req.apply(anyItem.apply("lore", "primordial"))).records())
+                .hasSize(1);
+        assertThat(store.query(req.apply(anyItem.apply("enchants", "sharpness"))).records())
+                .hasSize(1);
+        assertThat(store.query(req.apply(anyItem.apply("name", "nonexistent"))).records())
+                .isEmpty();
+        // Summary entry point must hydrate + filter identically.
+        assertThat(store.querySummary(req.apply(anyItem.apply("name", "excali"))).records())
+                .hasSize(1);
+    }
+
 }


### PR DESCRIPTION
The CH backend threw UnsupportedPredicateException for any predicate
touching nested item paths (item.name, *.lore, *.enchants,
containerItems.*) — the flagship forensic filters were Mongo-only
(suite cases H3-H5).

runQuery now splits the top-level predicate list on translation
failure: pushable predicates (player, time, radius, event) bound the
scan server-side; the residual evaluates in memory against decoded
rows via PredicateEvaluator, which gains nested item/snapshot path
resolution, any-element list semantics, and Pattern matching — the
shapes the i*/ench params emit. Summary queries force heavy hydration
when a residual exists (the filtered fields live in the blobs). Scan
bounded at 20K rows past the pushable predicates.

IT drives the exact Or-of-five-paths + Pattern shape end-to-end on a
real ClickHouse for name, lore, and enchant terms, both query entry
points.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
