### PR TITLE
feat: attribute player-lit TNT explosions to the igniter (#34)

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -69,6 +69,10 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `-ex` | `-extended` | Show extra detail columns |
 | `-nod:<keys>` | `-nodefault:` | Suppress defaults (e.g. `-nod:r,t`) |
 
+## Explosion grief
+
+Player-lit TNT records the igniter as the source — `p:<griefer>` searches and rollbacks cover the crater directly. Chained, dispensed, or redstone-primed TNT and mob explosions (creeper, wither) are entity-attributed: sweep those with `c:tnt`, `c:creeper`, etc.
+
 ## Time formats
 
 `30s`, `15m`, `4h`, `2d`, `1w`, `1mo`. Combine: `t:1d12h`.

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/environment/EntityExplodeListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/environment/EntityExplodeListener.java
@@ -49,7 +49,7 @@ public final class EntityExplodeListener implements RecordingListener {
         String entityType = entity.getType().getKey().getKey();
         Instant occurred = support.now();
         Origin origin = support.environmentOrigin("entity-explode:" + entityType);
-        Source source = support.entitySource(entity.getUniqueId(), entityType);
+        Source source = explosionSource(entity, entityType);
 
         for (Block block : event.blockList()) {
             emitBreak(block, occurred, origin, source);
@@ -69,6 +69,21 @@ public final class EntityExplodeListener implements RecordingListener {
         for (Block partner : MultiBlockPartners.partnersBeyond(event.blockList())) {
             emitBreak(partner, occurred, origin, source);
         }
+    }
+
+    // Player-lit TNT is the PLAYER's grief (#34): Paper tracks the
+    // priming entity, so the source carries the igniter — one
+    // p:<griefer> rollback covers the crater, which u:<player> can't do
+    // on CoreProtect. The origin keeps the mechanism
+    // ("entity-explode:tnt") either way. Chained / dispenser / redstone
+    // TNT has no player source and stays entity-attributed, so c:tnt
+    // sweeps still cover the unattributed remainder.
+    Source explosionSource(Entity entity, String entityType) {
+        if (entity instanceof org.bukkit.entity.TNTPrimed primed
+                && primed.getSource() instanceof org.bukkit.entity.Player igniter) {
+            return support.playerSource(igniter);
+        }
+        return support.entitySource(entity.getUniqueId(), entityType);
     }
 
     private void emitBreak(Block block, Instant occurred, Origin origin, Source source) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/environment/EntityExplodeListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/environment/EntityExplodeListenerTest.java
@@ -1,0 +1,66 @@
+package net.medievalrp.spyglass.plugin.listener.environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Attribution policy for explosion grief (#34): player-lit TNT carries
+ * the igniter as the source — so {@code p:<griefer>} searches and
+ * rollbacks cover the crater — while chained/dispenser TNT and mob
+ * explosions stay entity-attributed for {@code c:} sweeps.
+ */
+class EntityExplodeListenerTest {
+
+    private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    private final EntityExplodeListener listener = new EntityExplodeListener(
+            mock(net.medievalrp.spyglass.plugin.pipeline.Recorder.class), support);
+
+    @Test
+    void playerLitTntAttributesTheIgniter() {
+        UUID igniterId = UUID.randomUUID();
+        Player igniter = mock(Player.class);
+        when(igniter.getUniqueId()).thenReturn(igniterId);
+        when(igniter.getName()).thenReturn("Griefer");
+        TNTPrimed tnt = mock(TNTPrimed.class);
+        when(tnt.getSource()).thenReturn(igniter);
+
+        Source source = listener.explosionSource(tnt, "tnt");
+
+        assertThat(source.playerId()).isEqualTo(igniterId);
+        assertThat(source.playerName()).isEqualTo("Griefer");
+    }
+
+    @Test
+    void unattributedTntStaysEntitySourced() {
+        TNTPrimed tnt = mock(TNTPrimed.class);
+        when(tnt.getSource()).thenReturn(null);
+        UUID entityId = UUID.randomUUID();
+        when(tnt.getUniqueId()).thenReturn(entityId);
+
+        Source source = listener.explosionSource(tnt, "tnt");
+
+        assertThat(source.playerId()).isNull();
+        assertThat(source.entityType()).isEqualTo("tnt");
+    }
+
+    @Test
+    void mobExplosionsStayEntitySourced() {
+        Creeper creeper = mock(Creeper.class);
+        when(creeper.getUniqueId()).thenReturn(UUID.randomUUID());
+
+        Source source = listener.explosionSource(creeper, "creeper");
+
+        assertThat(source.playerId()).isNull();
+        assertThat(source.entityType()).isEqualTo("creeper");
+    }
+}


### PR DESCRIPTION
Explosion breaks were always entity-attributed, so neither p:<griefer>
on Spyglass nor u:<player> on CoreProtect covered a TNT crater (suite
case F2) — operators had to know the c:tnt / u:#tnt incantation.

Paper tracks the priming entity: when a TNTPrimed's source is a
player, the break/drop records now carry that player as the source
(the origin keeps the entity-explode:tnt mechanism). One p:<griefer>
rollback covers the crater — something CP's u: cannot do. Chained,
dispensed, and redstone-primed TNT plus mob explosions keep entity
attribution, so c:tnt / c:creeper sweeps still cover the unattributed
remainder. commands.md documents the split.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
