### PR TITLE
feat: redact secret-bearing command arguments at the recording site (#47)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -53,6 +53,7 @@ import net.medievalrp.spyglass.plugin.listener.block.FallingBlockLandListener;
 import net.medievalrp.spyglass.plugin.listener.block.MultiBlockBreakListener;
 import net.medievalrp.spyglass.plugin.listener.chat.ChatListener;
 import net.medievalrp.spyglass.plugin.listener.chat.CommandListener;
+import net.medievalrp.spyglass.plugin.listener.chat.CommandRedaction;
 import net.medievalrp.spyglass.plugin.listener.container.ContainerDragListener;
 import net.medievalrp.spyglass.plugin.listener.container.ContainerInteractListener;
 import net.medievalrp.spyglass.plugin.listener.container.ContainerTransactionListener;
@@ -243,7 +244,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new BlockUseListener(recorder, support),
                 new ContainerDropListener(recorder, support),
                 new ChatListener(recorder, support),
-                new CommandListener(recorder, support),
+                new CommandListener(recorder, support,
+                        new CommandRedaction(config.commandRedact())),
                 new JoinListener(recorder, support),
                 new QuitListener(recorder, support),
                 new LeavesDecayListener(recorder, support),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -17,8 +17,20 @@ public record SpyglassConfig(
         Defaults defaults,
         Limits limits,
         Map<String, EventSettings> events,
+        java.util.List<String> commandRedact,
         Tool tool,
         Server server) {
+
+    /**
+     * Default heads for {@code events.command.redact} (#47): the common
+     * auth-plugin command set whose arguments are credentials. Applied
+     * when the key is absent from an existing on-disk config so old
+     * installs pick up redaction on upgrade; an explicit
+     * {@code redact = []} opts out.
+     */
+    public static final java.util.List<String> DEFAULT_COMMAND_REDACT = java.util.List.of(
+            "login", "register", "l", "reg", "changepassword", "changepw",
+            "unregister", "premium", "2fa", "totp", "auth");
 
     public static SpyglassConfig load(JavaPlugin plugin) throws IOException {
         Path path = plugin.getDataFolder().toPath().resolve("config.conf");
@@ -47,6 +59,8 @@ public record SpyglassConfig(
                 new EventSettings(
                         value.node("enabled").getBoolean(true),
                         value.node("past-tense").getString(String.valueOf(key)))));
+
+        java.util.List<String> commandRedact = parseCommandRedact(root);
 
         String backendName = root.node("database", "backend").getString("mongo").trim().toLowerCase(java.util.Locale.ROOT);
         Backend backend = switch (backendName) {
@@ -97,8 +111,26 @@ public record SpyglassConfig(
                         // faster wall-clock at the cost of TPS.
                         root.node("limits", "rollback-tick-budget-ms").getLong(15L)),
                 Map.copyOf(events),
+                commandRedact,
                 new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
                 new Server(root.node("server", "name").getString("default")));
+    }
+
+    /**
+     * Absent key (configs predating #47) → the default auth set; an
+     * explicit empty list is the operator's record-everything opt-out,
+     * so it must NOT fall back to the default. Null elements (HOCON
+     * oddities) are dropped rather than failing plugin enable.
+     */
+    static java.util.List<String> parseCommandRedact(ConfigurationNode root)
+            throws org.spongepowered.configurate.serialize.SerializationException {
+        ConfigurationNode redactNode = root.node("events", "command", "redact");
+        if (redactNode.virtual()) {
+            return DEFAULT_COMMAND_REDACT;
+        }
+        return redactNode.getList(String.class, java.util.List.of()).stream()
+                .filter(java.util.Objects::nonNull)
+                .toList();
     }
 
     public boolean enabled(String eventName) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/chat/CommandListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/chat/CommandListener.java
@@ -27,10 +27,13 @@ public final class CommandListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final CommandRedaction redaction;
 
-    public CommandListener(Recorder recorder, RecordingSupport support) {
+    public CommandListener(Recorder recorder, RecordingSupport support,
+                           CommandRedaction redaction) {
         this.recorder = recorder;
         this.support = support;
+        this.redaction = redaction;
     }
 
     @Override
@@ -44,7 +47,7 @@ public final class CommandListener implements RecordingListener {
         BlockLocation location = BlockLocations.fromLocation(event.getPlayer().getLocation());
         RecordContext ctx = support.playerContext(event.getPlayer(), location);
         String head = extractHead(line);
-        recorder.record(CommandRecord.of(ctx, head, line));
+        recorder.record(CommandRecord.of(ctx, head, redaction.apply(head, line)));
     }
 
     /**
@@ -72,7 +75,7 @@ public final class CommandListener implements RecordingListener {
         }
 
         RecordContext ctx = support.context(origin, source, location);
-        recorder.record(CommandRecord.of(ctx, head, line));
+        recorder.record(CommandRecord.of(ctx, head, redaction.apply(head, line)));
     }
 
     /**

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/chat/CommandRedaction.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/chat/CommandRedaction.java
@@ -1,0 +1,79 @@
+package net.medievalrp.spyglass.plugin.listener.chat;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Masks the arguments of secret-bearing commands before they are
+ * recorded (#47). {@code /login hunter2} becomes {@code /login ***}
+ * so auth-plugin credentials never reach the WAL, either backend, or
+ * a search hover. Matching is on the command head only — the head
+ * itself still records verbatim, so {@code a:command} searches and
+ * grouping keep working.
+ *
+ * <p>Heads are compared case-insensitively, with the leading slash
+ * and any {@code plugin:} namespace prefix ignored, so
+ * {@code /LOGIN}, {@code login} (console form) and
+ * {@code /authme:login} all match a configured {@code login}.
+ *
+ * <p>Redaction happens at the recording site, not at render time:
+ * once a secret is stored it is already in the database, the WAL
+ * file, and every backup — masking on display would be theater.
+ */
+@ApiStatus.Internal
+public final class CommandRedaction {
+
+    static final String MASK = "***";
+
+    private final Set<String> heads;
+
+    public CommandRedaction(Collection<String> configuredHeads) {
+        Set<String> normalized = new HashSet<>(configuredHeads.size());
+        for (String head : configuredHeads) {
+            if (head == null) {
+                continue;
+            }
+            String clean = simpleName(stripSlash(head.trim()))
+                    .toLowerCase(Locale.ROOT);
+            if (!clean.isEmpty()) {
+                normalized.add(clean);
+            }
+        }
+        this.heads = Set.copyOf(normalized);
+    }
+
+    /**
+     * Returns the line to record: the original line when the head is
+     * not on the redact list (or the line carries no arguments), or
+     * the head portion followed by a single {@code ***} otherwise.
+     * The head's original spelling — case, slash, namespace — is
+     * preserved in the output; only the arguments are replaced.
+     */
+    public String apply(String head, String line) {
+        if (heads.isEmpty() || head == null || line == null) {
+            return line;
+        }
+        if (!heads.contains(simpleName(head).toLowerCase(Locale.ROOT))) {
+            return line;
+        }
+        int space = line.indexOf(' ');
+        if (space < 0 || line.substring(space + 1).isBlank()) {
+            // No arguments — nothing secret to mask.
+            return line;
+        }
+        return line.substring(0, space) + " " + MASK;
+    }
+
+    private static String stripSlash(String head) {
+        return head.startsWith("/") ? head.substring(1) : head;
+    }
+
+    /** {@code authme:login} → {@code login}; plain heads pass through. */
+    private static String simpleName(String head) {
+        int colon = head.lastIndexOf(':');
+        return colon < 0 ? head : head.substring(colon + 1);
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -150,7 +150,19 @@ events {
   use = { enabled = true, past-tense = "used" }
   useSign = { enabled = true, past-tense = "activated" }
   say = { enabled = true, past-tense = "said" }
-  command = { enabled = true, past-tense = "ran" }
+  # redact: command heads whose ARGUMENTS are masked before recording —
+  # "/login hunter2" is stored as "/login ***" so auth-plugin passwords
+  # never reach the database, the WAL, or a search hover. Heads match
+  # case-insensitively, with the leading slash and any "plugin:"
+  # namespace ignored ("/authme:login" matches "login"); applies to the
+  # player, console, RCON, and command-block paths alike. The head
+  # itself still records, so a:command searches keep working. Set
+  # redact = [] to record every argument verbatim. If the key is
+  # absent (configs from before this option), the default list below
+  # applies.
+  command = { enabled = true, past-tense = "ran",
+    redact = ["login", "register", "l", "reg", "changepassword", "changepw",
+              "unregister", "premium", "2fa", "totp", "auth"] }
   join = { enabled = true, past-tense = "joined" }
   quit = { enabled = true, past-tense = "quit" }
   decay = { enabled = true, past-tense = "decayed" }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -1,0 +1,46 @@
+package net.medievalrp.spyglass.plugin.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+class SpyglassConfigTest {
+
+    @Test
+    void absentRedactKeyFallsBackToDefaultAuthSet() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+
+        assertThat(SpyglassConfig.parseCommandRedact(root))
+                .isEqualTo(SpyglassConfig.DEFAULT_COMMAND_REDACT);
+    }
+
+    @Test
+    void explicitEmptyRedactListIsTheOptOut() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("events", "command", "redact").setList(String.class, List.of());
+
+        assertThat(SpyglassConfig.parseCommandRedact(root)).isEmpty();
+    }
+
+    @Test
+    void explicitRedactListIsUsedVerbatim() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("events", "command", "redact").setList(String.class, List.of("pin", "vault"));
+
+        assertThat(SpyglassConfig.parseCommandRedact(root))
+                .containsExactly("pin", "vault");
+    }
+
+    @Test
+    void nullListElementsAreDroppedInsteadOfFailingLoad() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("events", "command", "redact").set(Arrays.asList("login", null));
+
+        assertThat(SpyglassConfig.parseCommandRedact(root))
+                .containsExactly("login");
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/chat/CommandListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/chat/CommandListenerTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
@@ -32,7 +33,8 @@ class CommandListenerTest {
     void setUp() {
         recorder = new CapturingRecorder();
         RecordingSupport support = new RecordingSupport(new Duration(3600), "test");
-        listener = new CommandListener(recorder, support);
+        listener = new CommandListener(recorder, support,
+                new CommandRedaction(SpyglassConfig.DEFAULT_COMMAND_REDACT));
     }
 
     @Test
@@ -71,6 +73,40 @@ class CommandListenerTest {
         CommandRecord record = (CommandRecord) recorder.records.get(0);
         assertThat(record.target()).isEqualTo("emote");
         assertThat(record.commandLine()).isEqualTo("emote wave");
+    }
+
+    @Test
+    void redactsAuthCommandArgsOnPlayerPath() {
+        Player alice = mockPlayer();
+        PlayerCommandPreprocessEvent event = mock(PlayerCommandPreprocessEvent.class);
+        when(event.getPlayer()).thenReturn(alice);
+        when(event.getMessage()).thenReturn("/login hunter2");
+
+        listener.onCommand(event);
+
+        CommandRecord record = (CommandRecord) recorder.records.get(0);
+        assertThat(record.target()).isEqualTo("login");
+        assertThat(record.commandLine()).isEqualTo("/login ***");
+    }
+
+    @Test
+    void redactsAuthCommandArgsOnConsolePath() {
+        org.bukkit.event.server.ServerCommandEvent event =
+                mock(org.bukkit.event.server.ServerCommandEvent.class);
+        when(event.getSender()).thenReturn(mock(org.bukkit.command.CommandSender.class));
+        when(event.getCommand()).thenReturn("login hunter2");
+
+        // sentinelLocation() asks Bukkit for the world list; no server
+        // runs in unit tests, so pin the static to the empty fallback.
+        try (org.mockito.MockedStatic<org.bukkit.Bukkit> bukkit =
+                     org.mockito.Mockito.mockStatic(org.bukkit.Bukkit.class)) {
+            bukkit.when(org.bukkit.Bukkit::getWorlds).thenReturn(List.of());
+            listener.onServerCommand(event);
+        }
+
+        CommandRecord record = (CommandRecord) recorder.records.get(0);
+        assertThat(record.target()).isEqualTo("login");
+        assertThat(record.commandLine()).isEqualTo("login ***");
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/chat/CommandRedactionTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/chat/CommandRedactionTest.java
@@ -1,0 +1,75 @@
+package net.medievalrp.spyglass.plugin.listener.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import org.junit.jupiter.api.Test;
+
+class CommandRedactionTest {
+
+    private final CommandRedaction defaults =
+            new CommandRedaction(SpyglassConfig.DEFAULT_COMMAND_REDACT);
+
+    @Test
+    void masksArgsOfListedCommand() {
+        assertThat(defaults.apply("login", "/login hunter2"))
+                .isEqualTo("/login ***");
+    }
+
+    @Test
+    void matchIsCaseInsensitiveAndPreservesOriginalSpelling() {
+        assertThat(defaults.apply("LOGIN", "/LOGIN hunter2"))
+                .isEqualTo("/LOGIN ***");
+    }
+
+    @Test
+    void slashlessConsoleFormMasks() {
+        assertThat(defaults.apply("login", "login hunter2"))
+                .isEqualTo("login ***");
+    }
+
+    @Test
+    void namespacedHeadMatchesSimpleName() {
+        assertThat(defaults.apply("authme:login", "/authme:login hunter2"))
+                .isEqualTo("/authme:login ***");
+    }
+
+    @Test
+    void multipleArgsCollapseToOneMask() {
+        assertThat(defaults.apply("register", "/register pw pw"))
+                .isEqualTo("/register ***");
+    }
+
+    @Test
+    void differentHeadSharingPrefixIsNotMasked() {
+        assertThat(defaults.apply("loginfo", "/loginfo verbose"))
+                .isEqualTo("/loginfo verbose");
+    }
+
+    @Test
+    void unlistedCommandRecordsVerbatim() {
+        assertThat(defaults.apply("give", "/give Alice diamond 64"))
+                .isEqualTo("/give Alice diamond 64");
+    }
+
+    @Test
+    void argLessListedCommandRecordsVerbatim() {
+        assertThat(defaults.apply("login", "/login")).isEqualTo("/login");
+        assertThat(defaults.apply("login", "/login ")).isEqualTo("/login ");
+    }
+
+    @Test
+    void emptyListIsTheOptOut() {
+        CommandRedaction off = new CommandRedaction(List.of());
+        assertThat(off.apply("login", "/login hunter2"))
+                .isEqualTo("/login hunter2");
+    }
+
+    @Test
+    void configEntriesNormalizeSlashCaseAndWhitespace() {
+        CommandRedaction redaction = new CommandRedaction(List.of(" /Login "));
+        assertThat(redaction.apply("login", "/login hunter2"))
+                .isEqualTo("/login ***");
+    }
+}


### PR DESCRIPTION
Head-matched redaction list (events.command.redact, default = common
auth-plugin commands) masks arguments to '***' in CommandListener
before the line reaches the WAL or either backend. Heads still record
verbatim so a:command searches and grouping keep working. Absent key
on upgraded configs applies the default set; explicit redact = [] is
the record-everything opt-out.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
