### PR TITLE
feat: gate player-IP visibility behind spyglass.search.ip (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All default to `op`. Grant via your permissions plugin to scope access.
 |---|---|
 | `spyglass.use` | `/spyglass help`, `/spyglass events`, `/spyglass page` |
 | `spyglass.search` | `/spyglass search` |
+| `spyglass.search.ip` | See join IPs in results and use the `ip:` key, on Paper and the proxy alike. Without it IPs render as `(ip hidden)` and `ip:` errors. |
 | `spyglass.rollback` | `/spyglass rollback`, `/spyglass restore`, `/spyglass undo`, `/spyglass rbqueue` |
 | `spyglass.tool` | `/spyglass tool` (inspection wand) |
 | `spyglass.tele` | `/spyglass tele` (jump to a search result) |

--- a/commands.md
+++ b/commands.md
@@ -10,6 +10,7 @@ All default to `op`.
 |---|---|
 | `spyglass.use` | help, events, page |
 | `spyglass.search` | search |
+| `spyglass.search.ip` | reveals join IPs in results and unlocks the `ip:` key (without it IPs render as `(ip hidden)`) |
 | `spyglass.rollback` | rollback, restore, undo, rbqueue |
 | `spyglass.tool` | inspection wand |
 | `spyglass.tele` | teleport (used by clickable result rows) |

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParser.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParser.java
@@ -46,7 +46,12 @@ public final class ProxyQueryStringParser {
         this.ipToPlayerIds = ipToPlayerIds;
     }
 
-    public QueryRequest parse(String raw) throws ParseException {
+    /**
+     * @param allowIp whether the invoking source holds
+     *     {@code spyglass.search.ip}; the {@code ip:} param (IP→player
+     *     correlation, PII) is rejected without it (#48)
+     */
+    public QueryRequest parse(String raw, boolean allowIp) throws ParseException {
         List<QueryPredicate> predicates = new ArrayList<>();
         EnumSet<Flag> flags = EnumSet.noneOf(Flag.class);
         Sort sort = Sort.NEWEST_FIRST;
@@ -106,7 +111,12 @@ public final class ProxyQueryStringParser {
                                             ".*" + java.util.regex.Pattern.quote(value) + ".*",
                                             java.util.regex.Pattern.CASE_INSENSITIVE)));
                     case "target", "trg" -> predicates.add(new QueryPredicate.Eq("target", value));
-                    case "ip" -> predicates.add(resolveIpPredicate(value));
+                    case "ip" -> {
+                        if (!allowIp) {
+                            throw new ParseException("Missing permission spyglass.search.ip.");
+                        }
+                        predicates.add(resolveIpPredicate(value));
+                    }
                     case "w", "world" -> predicates.add(new QueryPredicate.Eq("location.worldName", value));
                     default -> throw new ParseException("Unknown parameter: " + alias);
                 }

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyResultRenderer.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyResultRenderer.java
@@ -104,19 +104,23 @@ public final class ProxyResultRenderer {
             Map.entry("rolled-place", "placed"),
             Map.entry("rolled-break", "broke"));
 
-    public Component renderAggregation(QueryResult.RecordAggregation aggregation) {
+    /** Mirrors Paper's ResultRenderer.IP_HIDDEN — shown where a join IP
+     *  would render when the viewer lacks {@code spyglass.search.ip}. */
+    public static final String IP_HIDDEN = "(ip hidden)";
+
+    public Component renderAggregation(QueryResult.RecordAggregation aggregation, boolean showIp) {
         return line(aggregation.sample(), aggregation.count(), true, false,
-                EnumSet.noneOf(Flag.class));
+                EnumSet.noneOf(Flag.class), showIp);
     }
 
-    public Component renderSingle(EventRecord record, EnumSet<Flag> flags) {
+    public Component renderSingle(EventRecord record, EnumSet<Flag> flags, boolean showIp) {
         EnumSet<Flag> safe = flags == null ? EnumSet.noneOf(Flag.class) : flags;
         boolean extended = safe.contains(Flag.EXTENDED);
-        return line(record, 1, false, extended, safe);
+        return line(record, 1, false, extended, safe, showIp);
     }
 
     private Component line(EventRecord record, long count, boolean grouped, boolean extended,
-                           EnumSet<Flag> flags) {
+                           EnumSet<Flag> flags, boolean showIp) {
         var builder = Component.text()
                 .append(Component.text("= ", NamedTextColor.GRAY));
         if (grouped) {
@@ -133,7 +137,7 @@ public final class ProxyResultRenderer {
         if (qty > 0) {
             builder.append(Component.text(" " + qty, NamedTextColor.GREEN));
         }
-        String targetText = targetOf(record);
+        String targetText = targetOf(record, showIp);
         if (!targetText.isEmpty()) {
             builder.append(Component.text(" " + targetText, NamedTextColor.AQUA));
         }
@@ -141,7 +145,7 @@ public final class ProxyResultRenderer {
             builder.append(Component.text(" x" + count, NamedTextColor.GREEN));
         }
         builder.append(Component.text(" " + timeAgo(record.occurred()), NamedTextColor.WHITE))
-                .hoverEvent(HoverEvent.showText(hover(record, count)));
+                .hoverEvent(HoverEvent.showText(hover(record, count, showIp)));
         if (grouped) {
             // Drill-down: same trick as Paper's renderer. Click runs a
             // narrowed search restricted to this player + event + server,
@@ -166,14 +170,14 @@ public final class ProxyResultRenderer {
         return builder.build();
     }
 
-    private Component hover(EventRecord record, long count) {
+    private Component hover(EventRecord record, long count, boolean showIp) {
         List<Component> lines = new ArrayList<>();
         lines.add(kv("Source", record.sourceName()));
         lines.add(kv("Event", record.event()));
         if (count > 1) {
             lines.add(kv("Count", String.valueOf(count)));
         }
-        lines.add(kv("Target", targetOf(record)));
+        lines.add(kv("Target", targetOf(record, showIp)));
         lines.add(kv("When", fullTimestamp(record.occurred())));
         lines.add(kv("Origin", originText(record.origin())));
         lines.add(kv("Location", locationText(record.location())));
@@ -190,7 +194,7 @@ public final class ProxyResultRenderer {
             lines.add(kv("Line", command.commandLine()));
         }
         if (record instanceof JoinRecord join && join.address() != null && !join.address().isBlank()) {
-            lines.add(kv("IP", join.address()));
+            lines.add(kv("IP", showIp ? join.address() : IP_HIDDEN));
         }
         if (record instanceof EntityHitRecord hit) {
             lines.add(kv("Damage", String.format(Locale.ROOT, "%.1f", hit.damage())));
@@ -248,7 +252,7 @@ public final class ProxyResultRenderer {
         return item + " IN " + containerType;
     }
 
-    private static String targetOf(EventRecord record) {
+    private static String targetOf(EventRecord record, boolean showIp) {
         return switch (record) {
             case BlockBreakRecord r -> r.target();
             case BlockPlaceRecord r -> r.target();
@@ -259,7 +263,9 @@ public final class ProxyResultRenderer {
             case RollbackOpRecord r -> r.mode() == null ? "" : r.mode().toUpperCase(java.util.Locale.ROOT);
             case ChatRecord r -> r.target();
             case CommandRecord r -> "/" + r.target();
-            case JoinRecord r -> r.address() == null ? "" : r.address();
+            case JoinRecord r -> r.address() == null || r.address().isEmpty()
+                    ? ""
+                    : (showIp ? r.address() : IP_HIDDEN);
             case QuitRecord r -> "";
             case ItemDropRecord r -> r.target();
             case ItemPickupRecord r -> r.target();

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/SpyglassCommand.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/SpyglassCommand.java
@@ -116,9 +116,12 @@ public final class SpyglassCommand implements SimpleCommand {
             sendHelp(source);
             return;
         }
+        // One permission read per invocation: gates the ip: param at
+        // parse time and decides whether join IPs render or mask (#48).
+        boolean showIp = source.hasPermission("spyglass.search.ip");
         QueryRequest request;
         try {
-            request = parser.parse(raw);
+            request = parser.parse(raw, showIp);
         } catch (ProxyQueryStringParser.ParseException ex) {
             source.sendMessage(Component.text(ex.getMessage(), NamedTextColor.RED));
             return;
@@ -134,13 +137,14 @@ public final class SpyglassCommand implements SimpleCommand {
                                 "Query failed: " + error.getMessage(), NamedTextColor.RED));
                         return;
                     }
-                    deliver(source, key, result, request.flags());
+                    deliver(source, key, result, request.flags(), showIp);
                 });
     }
 
-    private void deliver(CommandSource source, UUID key, QueryResult result, EnumSet<Flag> flags) {
+    private void deliver(CommandSource source, UUID key, QueryResult result, EnumSet<Flag> flags,
+                         boolean showIp) {
         boolean grouping = !flags.contains(Flag.NO_GROUP);
-        List<Component> rendered = renderRows(result, flags, grouping);
+        List<Component> rendered = renderRows(result, flags, grouping, showIp);
         if (rendered.isEmpty()) {
             source.sendMessage(Component.text("No matching records.", NamedTextColor.GRAY));
             buffers.remove(key);
@@ -151,15 +155,16 @@ public final class SpyglassCommand implements SimpleCommand {
         sendPage(source, buffer, 1);
     }
 
-    private List<Component> renderRows(QueryResult result, EnumSet<Flag> flags, boolean grouping) {
+    private List<Component> renderRows(QueryResult result, EnumSet<Flag> flags, boolean grouping,
+                                       boolean showIp) {
         List<Component> rows = new ArrayList<>();
         if (grouping && !flags.contains(Flag.NO_GROUP) && !result.aggregations().isEmpty()) {
             for (QueryResult.RecordAggregation agg : result.aggregations()) {
-                rows.add(renderer.renderAggregation(agg));
+                rows.add(renderer.renderAggregation(agg, showIp));
             }
         } else {
             for (EventRecord record : result.records()) {
-                rows.add(renderer.renderSingle(record, flags));
+                rows.add(renderer.renderSingle(record, flags, showIp));
             }
         }
         return rows;

--- a/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParserTest.java
+++ b/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParserTest.java
@@ -1,0 +1,56 @@
+package net.medievalrp.spyglass.proxy.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import org.junit.jupiter.api.Test;
+
+class ProxyQueryStringParserTest {
+
+    private static final UUID PLAYER = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private static ProxyQueryStringParser parser(java.util.function.Function<String, List<UUID>> resolver) {
+        return new ProxyQueryStringParser(1000, 3600, resolver);
+    }
+
+    @Test
+    void ipParamRejectedWithoutIpPermission() {
+        AtomicBoolean resolverCalled = new AtomicBoolean(false);
+        ProxyQueryStringParser parser = parser(ip -> {
+            resolverCalled.set(true);
+            return List.of(PLAYER);
+        });
+
+        assertThatThrownBy(() -> parser.parse("ip:10.0.0.1", false))
+                .isInstanceOf(ProxyQueryStringParser.ParseException.class)
+                .hasMessageContaining("spyglass.search.ip");
+        // The gate must run before the store-backed resolver: a denied
+        // source should not trigger the IP→player lookup at all.
+        assertThat(resolverCalled).isFalse();
+    }
+
+    @Test
+    void ipParamResolvesWithIpPermission() throws Exception {
+        ProxyQueryStringParser parser = parser(ip -> List.of(PLAYER));
+
+        QueryRequest request = parser.parse("ip:10.0.0.1", true);
+
+        assertThat(request.predicates())
+                .anyMatch(p -> p instanceof QueryPredicate.Or
+                        || (p instanceof QueryPredicate.Eq eq && "address".equals(eq.field())));
+    }
+
+    @Test
+    void nonIpQueryUnaffectedByMissingIpPermission() throws Exception {
+        ProxyQueryStringParser parser = parser(ip -> List.of());
+
+        QueryRequest request = parser.parse("p:Alice t:1h", false);
+
+        assertThat(request.predicates()).isNotEmpty();
+    }
+}

--- a/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyResultRendererTest.java
+++ b/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyResultRendererTest.java
@@ -1,0 +1,65 @@
+package net.medievalrp.spyglass.proxy.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+class ProxyResultRendererTest {
+
+    private static final UUID PLAYER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    private final ProxyResultRenderer renderer = new ProxyResultRenderer();
+
+    private static JoinRecord joinRecord() {
+        Instant now = Instant.now();
+        return new JoinRecord(
+                UUID.randomUUID(), "join",
+                now, now.plusSeconds(60),
+                Origin.player(),
+                Source.player(PLAYER_ID, "Alice"),
+                new BlockLocation(WORLD_ID, "world", 10, 64, 20),
+                "survival",
+                "Alice",
+                "203.0.113.7");
+    }
+
+    private static String hoverPlain(Component rendered) {
+        net.kyori.adventure.text.event.HoverEvent<?> hover = rendered.hoverEvent();
+        assertThat(hover).isNotNull();
+        return PlainTextComponentSerializer.plainText()
+                .serialize((Component) hover.value());
+    }
+
+    @Test
+    void joinIpRendersForViewerWithIpPermission() {
+        Component rendered = renderer.renderSingle(joinRecord(), EnumSet.noneOf(Flag.class), true);
+
+        assertThat(PlainTextComponentSerializer.plainText().serialize(rendered))
+                .contains("203.0.113.7");
+        assertThat(hoverPlain(rendered)).contains("IP: 203.0.113.7");
+    }
+
+    @Test
+    void joinIpMasksInLineAndHoverWithoutIpPermission() {
+        Component rendered = renderer.renderSingle(joinRecord(), EnumSet.noneOf(Flag.class), false);
+
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+        assertThat(plain)
+                .contains(ProxyResultRenderer.IP_HIDDEN)
+                .doesNotContain("203.0.113.7");
+        assertThat(hoverPlain(rendered))
+                .contains("IP: " + ProxyResultRenderer.IP_HIDDEN)
+                .doesNotContain("203.0.113.7");
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/IpParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/IpParam.java
@@ -45,6 +45,14 @@ public final class IpParam implements QueryParamHandler {
 
     @Override
     public QueryPredicate parse(String alias, String value, ParamContext context) throws ParamParseException {
+        // IP→player correlation is PII (#48); spyglass.search alone
+        // does not unlock it. Mirrors the renderer-side masking.
+        // Fail closed on a null sender — there is no one to attribute
+        // the permission to.
+        if (context.sender() == null
+                || !context.sender().hasPermission("spyglass.search.ip")) {
+            throw new ParamParseException("Missing permission spyglass.search.ip.");
+        }
         if (value == null || value.isBlank()) {
             throw new ParamParseException("ip requires an address.");
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -47,25 +47,31 @@ public final class ResultRenderer {
         this.config = config;
     }
 
-    public Component renderAggregation(QueryResult.RecordAggregation aggregation) {
+    /** Stand-in shown where a join IP would render when the viewer
+     *  lacks {@code spyglass.search.ip} (#48). */
+    public static final String IP_HIDDEN = "(ip hidden)";
+
+    public Component renderAggregation(QueryResult.RecordAggregation aggregation, boolean showIp) {
         EventRecord sample = aggregation.sample();
         long count = aggregation.count();
         // Aggregations span multiple locations; `-ex` location-append is
         // skipped because any one sample.location() would be misleading.
         return line(sample, count, true, false, java.util.EnumSet.noneOf(
-                net.medievalrp.spyglass.api.query.Flag.class));
+                net.medievalrp.spyglass.api.query.Flag.class), showIp);
     }
 
-    public Component renderSingle(EventRecord record, java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags) {
+    public Component renderSingle(EventRecord record, java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
+                                  boolean showIp) {
         java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> safe = flags == null
                 ? java.util.EnumSet.noneOf(net.medievalrp.spyglass.api.query.Flag.class)
                 : flags;
         boolean extended = safe.contains(net.medievalrp.spyglass.api.query.Flag.EXTENDED);
-        return line(record, 1, false, extended, safe);
+        return line(record, 1, false, extended, safe, showIp);
     }
 
     private Component line(EventRecord record, long count, boolean grouped, boolean extended,
-                           java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags) {
+                           java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
+                           boolean showIp) {
         // v1 grouped: "= (24/4/26) SOURCE verb [qty ]TARGET xCOUNT TIME"
         // v1 ungrouped: "= SOURCE verb [qty ]TARGET TIME"
         var builder = Component.text()
@@ -88,7 +94,7 @@ public final class ResultRenderer {
         // useful to put there (e.g. QuitRecord), otherwise rendered as
         // " TARGET" with a single leading space so the line stays
         // tidy regardless of whether quantity/target are present.
-        String targetText = targetOf(record);
+        String targetText = targetOf(record, showIp);
         if (!targetText.isEmpty()) {
             Component defaultTarget = Component.text(" " + targetText, NamedTextColor.AQUA);
             java.util.Optional<DisplayRenderer> custom = api == null
@@ -109,7 +115,7 @@ public final class ResultRenderer {
             builder.append(Component.text(" x" + count, NamedTextColor.GREEN));
         }
         builder.append(Component.text(" " + timeAgo(record.occurred()), NamedTextColor.WHITE))
-                .hoverEvent(HoverEvent.showText(hover(record, count)));
+                .hoverEvent(HoverEvent.showText(hover(record, count, showIp)));
         if (grouped) {
             // Grouped result: click drills down into the per-player,
             // per-event stream. Matches v1's buildDetailCommand shape.
@@ -184,14 +190,14 @@ public final class ResultRenderer {
                         Component.text("Page " + targetPage, NamedTextColor.RED)));
     }
 
-    private Component hover(EventRecord record, long count) {
+    private Component hover(EventRecord record, long count, boolean showIp) {
         List<Component> lines = new ArrayList<>();
         lines.add(kv("Source", record.sourceName()));
         lines.add(kv("Event", record.event()));
         if (count > 1) {
             lines.add(kv("Count", String.valueOf(count)));
         }
-        lines.add(kv("Target", targetOf(record)));
+        lines.add(kv("Target", targetOf(record, showIp)));
         lines.add(kv("When", fullTimestamp(record.occurred())));
         lines.add(kv("Origin", originText(record.origin())));
         lines.add(kv("Location", locationText(record.location())));
@@ -205,7 +211,7 @@ public final class ResultRenderer {
             lines.add(kv("Line", command.commandLine()));
         }
         if (record instanceof JoinRecord join && !join.address().isBlank()) {
-            lines.add(kv("IP", join.address()));
+            lines.add(kv("IP", showIp ? join.address() : IP_HIDDEN));
         }
         if (record instanceof EntityHitRecord hit) {
             lines.add(kv("Damage", String.format(Locale.ROOT, "%.1f", hit.damage())));
@@ -283,7 +289,7 @@ public final class ResultRenderer {
         return item + " IN " + containerType;
     }
 
-    private static String targetOf(EventRecord record) {
+    private static String targetOf(EventRecord record, boolean showIp) {
         return switch (record) {
             case BlockBreakRecord breakRec -> breakRec.target();
             case BlockPlaceRecord placeRec -> placeRec.target();
@@ -301,7 +307,9 @@ public final class ResultRenderer {
             // so the line reads "<player> joined <ip>". Quit has no
             // companion field so the target span gets suppressed
             // entirely (the line() builder skips empty targets).
-            case JoinRecord join -> join.address() == null ? "" : join.address();
+            case JoinRecord join -> join.address() == null || join.address().isEmpty()
+                    ? ""
+                    : (showIp ? join.address() : IP_HIDDEN);
             case QuitRecord quit -> "";
             case ItemDropRecord drop -> drop.target();
             case ItemPickupRecord pickup -> pickup.target();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SearchService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SearchService.java
@@ -98,14 +98,18 @@ public final class SearchService {
         // Keeping the underlying records/aggregations list closed-over is
         // cheap — the typed record graph is already allocated by the
         // Mongo decode.
+        // Evaluated once at search time and captured: the page cache is
+        // per-sender, so the viewer on every later page flip is the same
+        // sender this bit was computed for (#48).
+        boolean showIp = sender.hasPermission("spyglass.search.ip");
         IntFunction<Component> lines;
         if (grouping) {
             List<QueryResult.RecordAggregation> aggregations = result.aggregations();
-            lines = index -> renderer.renderAggregation(aggregations.get(index));
+            lines = index -> renderer.renderAggregation(aggregations.get(index), showIp);
         } else {
             List<EventRecord> records = result.records();
             var flags = request.flags();
-            lines = index -> renderer.renderSingle(records.get(index), flags);
+            lines = index -> renderer.renderSingle(records.get(index), flags, showIp);
         }
         pageCache.store(sender, count, lines);
         pageCache.show(sender, 1);

--- a/spyglass/src/main/resources/plugin.yml
+++ b/spyglass/src/main/resources/plugin.yml
@@ -13,6 +13,11 @@ permissions:
     default: op
   spyglass.search:
     default: op
+  # Reveals player IPs in search results (join lines/hover) and
+  # unlocks the ip: param. Separate from spyglass.search so block-log
+  # access doesn't imply PII access (#48).
+  spyglass.search.ip:
+    default: op
   spyglass.rollback:
     default: op
   spyglass.tool:

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/IpParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/IpParamTest.java
@@ -68,7 +68,33 @@ class IpParamTest {
                 .isInstanceOf(ParamParseException.class);
     }
 
+    @Test
+    void rejectedWithoutIpPermission() {
+        IpParam param = new IpParam(ip -> List.of(PLAYER_A));
+        org.bukkit.command.CommandSender sender =
+                org.mockito.Mockito.mock(org.bukkit.command.CommandSender.class);
+        org.mockito.Mockito.when(sender.hasPermission("spyglass.search.ip")).thenReturn(false);
+
+        assertThatThrownBy(() -> param.parse("ip", "10.0.0.1",
+                new ParamContext(sender, null, 100)))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("spyglass.search.ip");
+    }
+
+    @Test
+    void rejectedForNullSender() {
+        IpParam param = new IpParam(ip -> List.of());
+        assertThatThrownBy(() -> param.parse("ip", "10.0.0.1",
+                new ParamContext(null, null, 100)))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("spyglass.search.ip");
+    }
+
+    /** Sender holding spyglass.search.ip — the param's happy path. */
     private static ParamContext ctx() {
-        return new ParamContext(null, null, 100);
+        org.bukkit.command.CommandSender sender =
+                org.mockito.Mockito.mock(org.bukkit.command.CommandSender.class);
+        org.mockito.Mockito.when(sender.hasPermission("spyglass.search.ip")).thenReturn(true);
+        return new ParamContext(sender, null, 100);
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -50,7 +50,7 @@ class ResultRendererTest {
         when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
 
-        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class));
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
 
         assertThat(plain).contains("SCULK_SENSOR");
@@ -74,7 +74,7 @@ class ResultRendererTest {
         when(api.displayRenderer("sculk")).thenReturn(Optional.of(custom));
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
 
-        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class));
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
 
         assertThat(plain).contains("CUSTOM_TARGET").doesNotContain("SCULK_SENSOR");
@@ -86,7 +86,7 @@ class ResultRendererTest {
         when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
 
-        Component rendered = renderer.renderSingle(useRecord(), EnumSet.of(Flag.EXTENDED));
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.of(Flag.EXTENDED), true);
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
 
         assertThat(plain).contains("x: 10").contains("y: 64").contains("z: 20").contains("world: world");
@@ -98,7 +98,7 @@ class ResultRendererTest {
         when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
 
-        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class));
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
 
         assertThat(findRunCommand(rendered))
                 .as("click event on a single result should be /spyglass tele")
@@ -120,6 +120,57 @@ class ResultRendererTest {
         return null;
     }
 
+    private static net.medievalrp.spyglass.api.event.JoinRecord joinRecord() {
+        Instant now = Instant.now();
+        return new net.medievalrp.spyglass.api.event.JoinRecord(
+                UUID.randomUUID(), "join",
+                now, now.plusSeconds(60),
+                Origin.player(),
+                Source.player(PLAYER_ID, "Alice"),
+                new BlockLocation(WORLD_ID, "world", 10, 64, 20),
+                "test",
+                "Alice",
+                "203.0.113.7");
+    }
+
+    private static String hoverPlain(Component rendered) {
+        net.kyori.adventure.text.event.HoverEvent<?> hover = rendered.hoverEvent();
+        assertThat(hover).isNotNull();
+        return PlainTextComponentSerializer.plainText()
+                .serialize((Component) hover.value());
+    }
+
+    @Test
+    void joinIpRendersForViewerWithIpPermission() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("join")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("join", "joined"));
+
+        Component rendered = renderer.renderSingle(joinRecord(), EnumSet.noneOf(Flag.class), true);
+
+        assertThat(PlainTextComponentSerializer.plainText().serialize(rendered))
+                .contains("203.0.113.7");
+        assertThat(hoverPlain(rendered))
+                .contains("IP: 203.0.113.7");
+    }
+
+    @Test
+    void joinIpMasksInLineAndHoverWithoutIpPermission() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("join")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("join", "joined"));
+
+        Component rendered = renderer.renderSingle(joinRecord(), EnumSet.noneOf(Flag.class), false);
+
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+        assertThat(plain)
+                .contains(ResultRenderer.IP_HIDDEN)
+                .doesNotContain("203.0.113.7");
+        assertThat(hoverPlain(rendered))
+                .contains("IP: " + ResultRenderer.IP_HIDDEN)
+                .doesNotContain("203.0.113.7");
+    }
+
     @Test
     void rendererExceptionFallsBackToDefault() {
         SpyglassApi api = mock(SpyglassApi.class);
@@ -133,7 +184,7 @@ class ResultRendererTest {
         when(api.displayRenderer("sculk")).thenReturn(Optional.of(broken));
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
 
-        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class));
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
 
         // Falls back to the default SCULK_SENSOR target instead of throwing.

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SearchServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SearchServiceTest.java
@@ -2,6 +2,7 @@ package net.medievalrp.spyglass.plugin.command.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -64,8 +65,10 @@ class SearchServiceTest {
                 ServiceSupport.synchronous(), Logger.getLogger("test"));
 
         TestFixture() {
-            when(renderer.renderSingle(any(EventRecord.class), any())).thenReturn(Component.text("rendered"));
-            when(renderer.renderAggregation(any())).thenReturn(Component.text("rendered-agg"));
+            when(renderer.renderSingle(any(EventRecord.class), any(), anyBoolean()))
+                    .thenReturn(Component.text("rendered"));
+            when(renderer.renderAggregation(any(), anyBoolean()))
+                    .thenReturn(Component.text("rendered-agg"));
         }
     }
 


### PR DESCRIPTION
Join IPs in search lines and hovers render as '(ip hidden)' and the
ip: param errors unless the viewer holds the new node — on Paper and
the Velocity proxy alike. The proxy gate runs before the store-backed
IP-to-player resolver so a denied source triggers no lookup. Node
defaults to op; documented in README and commands.md. First tests in
the spyglass-velocity module.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
