### PR TITLE
fix: resume replays the stored resolved request instead of re-parsing (#49)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackResumeStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackResumeStore.java
@@ -41,13 +41,18 @@ public final class RollbackResumeStore {
     }
 
     // Best-effort: a write failure here logs but does not abort the
-    // rollback.
+    // rollback. {@code requestBase64} is the RESOLVED query plan
+    // (UndoReferenceBson-encoded, #49) — resume replays it verbatim
+    // instead of re-parsing {@code query}, whose r:/t: defaults would
+    // re-anchor to the resumer's position and clock. Null for jobs
+    // that must not be resumed from the marker (undo replays).
     public void markStart(UUID jobId, String operatorName, @Nullable UUID operatorId,
-                          String query, RollbackJob.Mode mode) {
+                          String query, RollbackJob.Mode mode,
+                          @Nullable String requestBase64) {
         Path file = baseDir.resolve(filename(jobId));
         try {
             Files.writeString(file, serialize(
-                    jobId, operatorName, operatorId, query, mode,
+                    jobId, operatorName, operatorId, query, mode, requestBase64,
                     Instant.now(), null, 0, 0), StandardCharsets.UTF_8);
         } catch (IOException ex) {
             logger.log(Level.WARNING, "Spyglass: failed to write resume marker for "
@@ -58,12 +63,13 @@ public final class RollbackResumeStore {
     // Updates the marker with cursor and counters after each page
     // completes so a crash resumes from here rather than the start.
     public void markProgress(UUID jobId, String operatorName, @Nullable UUID operatorId,
-                             String query, RollbackJob.Mode mode, Instant startedAt,
+                             String query, RollbackJob.Mode mode,
+                             @Nullable String requestBase64, Instant startedAt,
                              @Nullable Cursor cursor, int appliedSoFar, int skippedSoFar) {
         Path file = baseDir.resolve(filename(jobId));
         try {
             Files.writeString(file, serialize(
-                    jobId, operatorName, operatorId, query, mode,
+                    jobId, operatorName, operatorId, query, mode, requestBase64,
                     startedAt, cursor, appliedSoFar, skippedSoFar),
                     StandardCharsets.UTF_8);
         } catch (IOException ex) {
@@ -74,7 +80,8 @@ public final class RollbackResumeStore {
 
     private static String serialize(UUID jobId, String operatorName,
                                     @Nullable UUID operatorId, String query,
-                                    RollbackJob.Mode mode, Instant startedAt,
+                                    RollbackJob.Mode mode,
+                                    @Nullable String requestBase64, Instant startedAt,
                                     @Nullable Cursor cursor, int appliedSoFar,
                                     int skippedSoFar) {
         StringBuilder sb = new StringBuilder();
@@ -83,6 +90,7 @@ public final class RollbackResumeStore {
         if (operatorId != null) sb.append("operatorId=").append(operatorId).append('\n');
         sb.append("mode=").append(mode.name()).append('\n');
         sb.append("query=").append(escape(query)).append('\n');
+        if (requestBase64 != null) sb.append("request=").append(escape(requestBase64)).append('\n');
         sb.append("startedAt=").append(startedAt.toString()).append('\n');
         if (cursor != null) {
             sb.append("cursor.occurred=").append(cursor.occurred().toString()).append('\n');
@@ -128,7 +136,7 @@ public final class RollbackResumeStore {
         try {
             String text = Files.readString(file, StandardCharsets.UTF_8);
             UUID id = null, operatorId = null;
-            String operatorName = null, query = null;
+            String operatorName = null, query = null, requestBase64 = null;
             RollbackJob.Mode mode = RollbackJob.Mode.ROLLBACK;
             Instant startedAt = null;
             Instant cursorOccurred = null;
@@ -144,6 +152,7 @@ public final class RollbackResumeStore {
                     case "operatorId" -> operatorId = UUID.fromString(v);
                     case "operatorName" -> operatorName = v;
                     case "query" -> query = v;
+                    case "request" -> requestBase64 = v;
                     case "mode" -> mode = RollbackJob.Mode.valueOf(v);
                     case "startedAt" -> startedAt = Instant.parse(v);
                     case "cursor.occurred" -> cursorOccurred = Instant.parse(v);
@@ -161,7 +170,7 @@ public final class RollbackResumeStore {
             Cursor cursor = (cursorOccurred != null && cursorId != null)
                     ? new Cursor(cursorOccurred, cursorId) : null;
             return new Saved(id, operatorId, operatorName, query, mode, startedAt,
-                    cursor, applied, skipped, file);
+                    cursor, applied, skipped, requestBase64, file);
         } catch (Exception ex) {
             logger.log(Level.WARNING, "Spyglass: failed to read resume marker "
                     + file.getFileName(), ex);
@@ -200,6 +209,9 @@ public final class RollbackResumeStore {
         return sb.toString();
     }
 
+    /** {@code requestBase64} — the resolved query plan written at
+     *  submit time; null on markers from older Spyglass versions and
+     *  on undo-replay jobs, both of which refuse to resume (#49). */
     public record Saved(UUID id,
                         @Nullable UUID operatorId,
                         String operatorName,
@@ -209,6 +221,7 @@ public final class RollbackResumeStore {
                         @Nullable Cursor cursor,
                         int appliedSoFar,
                         int skippedSoFar,
+                        @Nullable String requestBase64,
                         Path file) {
         public String shortId() {
             return id.toString().substring(0, 8);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -34,6 +34,7 @@ import net.medievalrp.spyglass.plugin.command.param.QueryStringParser;
 import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
+import net.medievalrp.spyglass.plugin.storage.UndoReferenceBson;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
@@ -95,25 +96,41 @@ public final class RollbackService {
 
     // Re-submit an interrupted rollback as a fresh job. Idempotent:
     // already-applied cells skip with "block changed" on the re-run.
+    //
+    // Replays the marker's RESOLVED request verbatim (#49) — never
+    // re-parse saved.query() here: r:/t: defaults would re-anchor to
+    // THIS sender's position and the current clock, so a resume from
+    // a different place (or hours later) would target a different
+    // region and time window than the interrupted operation, and the
+    // saved cursor would then page through the wrong match set.
     public boolean resumeFromSaved(RollbackResumeStore.Saved saved, CommandSender sender) {
-        QueryRequest request;
-        try {
-            RollbackMode mode = saved.mode() == RollbackJob.Mode.RESTORE
-                    ? RollbackMode.RESTORE : RollbackMode.ROLLBACK;
-            request = forceNoGroup(parser.parse(sender, saved.query(),
-                    rollbackResultLimit()), mode);
-        } catch (ParamParseException ex) {
-            sender.sendMessage(Feedback.error(
-                    "Resume failed: " + ex.getMessage() + " (query: " + saved.query() + ")"));
+        if (saved.requestBase64() == null) {
+            // Pre-#49 marker, or an undo replay (whose label is not a
+            // query and whose recovery path is /spyglass undo).
+            sender.sendMessage(Feedback.error("Resume entry " + saved.shortId()
+                    + " has no stored query plan (written by an older Spyglass,"
+                    + " or left by an undo replay). Re-run the original command"
+                    + " instead; discard the entry with /sg rbqueue cancel "
+                    + saved.shortId() + "."));
             return false;
         }
+        QueryRequest stored;
+        try {
+            stored = UndoReferenceBson.decodeBase64(saved.requestBase64()).request();
+        } catch (RuntimeException ex) {
+            sender.sendMessage(Feedback.error("Resume entry " + saved.shortId()
+                    + " is unreadable: " + ex.getMessage() + ". Discard it with"
+                    + " /sg rbqueue cancel " + saved.shortId() + "."));
+            return false;
+        }
+        RollbackMode mode = saved.mode() == RollbackJob.Mode.RESTORE
+                ? RollbackMode.RESTORE : RollbackMode.ROLLBACK;
+        QueryRequest request = forceNoGroup(stored, mode);
         // Fresh job id so the current sender (which may differ from
         // the original operator) gets progress messages.
         UUID operatorId = sender instanceof Player p ? p.getUniqueId() : null;
         RollbackJob job = new RollbackJob(UUID.randomUUID(), operatorId, sender.getName(),
                 saved.query(), saved.mode(), Instant.now(), sender);
-        RollbackMode rmode = saved.mode() == RollbackJob.Mode.RESTORE
-                ? RollbackMode.RESTORE : RollbackMode.ROLLBACK;
         // Resume from the saved cursor so we don't re-query the
         // already-applied prefix on big rollbacks.
         net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor startCursor = null;
@@ -121,7 +138,7 @@ public final class RollbackService {
             startCursor = new net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor(
                     saved.cursor().occurred(), saved.cursor().id());
         }
-        pendingContexts.put(job.id, new JobContext(request, rmode, startCursor,
+        pendingContexts.put(job.id, new JobContext(request, mode, startCursor,
                 saved.appliedSoFar(), saved.skippedSoFar()));
 
         int position = jobQueue.submit(job);
@@ -169,7 +186,10 @@ public final class RollbackService {
         RollbackJob job = new RollbackJob(UUID.randomUUID(), operator.getUniqueId(),
                 operator.getName(), queueLabel, jobMode, Instant.now(), operator);
         pendingContexts.put(job.id, new JobContext(replay, mode, null, 0, 0, onDone, true));
-        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode);
+        // No stored request: a crashed replay's recovery path is
+        // /spyglass undo (the reference stays poppable), not rbqueue
+        // resume — the marker exists for visibility only.
+        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode, null);
         int position = jobQueue.submit(job);
         if (position > 0) {
             operator.sendMessage(Feedback.bonus("Undo queued at position " + position
@@ -198,7 +218,8 @@ public final class RollbackService {
 
         // Persist before queueing so pending jobs also survive a
         // restart and show up as resumable.
-        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode);
+        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode,
+                encodeResumeRequest(request, job.mode));
 
         int position = jobQueue.submit(job);
         if (position > 0) {
@@ -215,7 +236,8 @@ public final class RollbackService {
             return;
         }
         job.sender.sendMessage(Feedback.querying());
-        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode);
+        resumeStore.markStart(job.id, job.operatorName, job.operatorId, job.query, job.mode,
+                ctx.replay() ? null : encodeResumeRequest(ctx.request(), job.mode));
         net.medievalrp.spyglass.api.util.Duration flushTimeout =
                 config.limits().rollbackFlushTimeout();
         // Flush the recorder first so the store has caught up to
@@ -261,6 +283,10 @@ public final class RollbackService {
                                      boolean replayOp) {
         CommandSender sender = job.sender;
         AtomicBoolean cancelFlag = job.cancelFlag;
+        // Encoded once per job: checkpoint() re-writes the whole marker
+        // after every applied window and must carry the same resolved
+        // plan markStart wrote (#49). Null for replays — see runJob.
+        String resumeRequest = replayOp ? null : encodeResumeRequest(request, job.mode);
         long startNanos = System.nanoTime();
         int pageSize = Math.max(100, config.limits().rollbackPageSize());
         int batchSize = config.limits().rollbackBatchSize();
@@ -381,7 +407,7 @@ public final class RollbackService {
                 windowCount++;
                 totalSeen += window.seenDelta();
                 if (window.effects().isEmpty()) {
-                    checkpoint(job, window, totalApplied, totalSkipped);
+                    checkpoint(job, window, totalApplied, totalSkipped, resumeRequest);
                     continue;
                 }
                 // Only join on chunks this job hasn't warmed yet — the
@@ -466,7 +492,7 @@ public final class RollbackService {
                             net.kyori.adventure.text.Component.text(
                                     "Rolling back: " + appliedSoFar + " applied, " + skippedSoFar + " skipped")));
                 }
-                checkpoint(job, window, totalApplied, totalSkipped);
+                checkpoint(job, window, totalApplied, totalSkipped, resumeRequest);
             }
             Throwable readFailed = readerFailure.get();
             if (readFailed != null) {
@@ -769,13 +795,26 @@ public final class RollbackService {
     // Checkpoint AFTER a window's records are applied so a crash
     // resumes past them; the force-overwrite apply makes any overlap
     // from a coarser-than-page checkpoint converge.
-    private void checkpoint(RollbackJob job, Window window, int totalApplied, int totalSkipped) {
+    private void checkpoint(RollbackJob job, Window window, int totalApplied, int totalSkipped,
+                            @org.jetbrains.annotations.Nullable String requestBase64) {
         RollbackResumeStore.Cursor resumeCursor = window.cursorAfter() == null ? null
                 : new RollbackResumeStore.Cursor(
                         window.cursorAfter().occurred(), window.cursorAfter().id());
         resumeStore.markProgress(job.id, job.operatorName, job.operatorId,
-                job.query, job.mode, job.submitTime,
+                job.query, job.mode, requestBase64, job.submitTime,
                 resumeCursor, totalApplied, totalSkipped);
+    }
+
+    /**
+     * The resume marker stores the RESOLVED request (#49) — the same
+     * rule {@link UndoReferenceBson} documents for undo references:
+     * relative params are already anchored, so replaying the plan can
+     * never re-anchor to the resumer's position or clock. The mode
+     * and ceiling ride along for the blob format; resume reads only
+     * the request.
+     */
+    private static String encodeResumeRequest(QueryRequest request, RollbackJob.Mode mode) {
+        return UndoReferenceBson.encodeBase64(request, mode.name(), Instant.now());
     }
 
     private static BlockLocation locationOf(RollbackEffect effect) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackResumeStoreTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackResumeStoreTest.java
@@ -1,0 +1,88 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RollbackResumeStoreTest {
+
+    private static final UUID JOB = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID OPERATOR = UUID.fromString("44444444-4444-4444-4444-444444444444");
+
+    @TempDir
+    Path dir;
+
+    private RollbackResumeStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new RollbackResumeStore(dir, Logger.getLogger("test"));
+    }
+
+    @Test
+    void roundTripsStoredRequestPlan() {
+        store.markStart(JOB, "Alice", OPERATOR, "p:Griefer r:30",
+                RollbackJob.Mode.ROLLBACK, "c29tZS1iYXNlNjQ=");
+
+        var pending = store.listPending();
+        assertThat(pending).hasSize(1);
+        assertThat(pending.get(0).requestBase64()).isEqualTo("c29tZS1iYXNlNjQ=");
+        assertThat(pending.get(0).query()).isEqualTo("p:Griefer r:30");
+    }
+
+    @Test
+    void progressRewritePreservesRequestPlan() {
+        store.markStart(JOB, "Alice", OPERATOR, "p:Griefer",
+                RollbackJob.Mode.ROLLBACK, "c29tZS1iYXNlNjQ=");
+        store.markProgress(JOB, "Alice", OPERATOR, "p:Griefer",
+                RollbackJob.Mode.ROLLBACK, "c29tZS1iYXNlNjQ=", Instant.now(),
+                new RollbackResumeStore.Cursor(Instant.now(), UUID.randomUUID()), 500, 3);
+
+        var pending = store.listPending();
+        assertThat(pending).hasSize(1);
+        assertThat(pending.get(0).requestBase64()).isEqualTo("c29tZS1iYXNlNjQ=");
+        assertThat(pending.get(0).appliedSoFar()).isEqualTo(500);
+        assertThat(pending.get(0).cursor()).isNotNull();
+    }
+
+    @Test
+    void nullRequestPlanWritesNoLineAndReadsBackNull() {
+        store.markStart(JOB, "Alice", OPERATOR, "undo rollback ab12cd34",
+                RollbackJob.Mode.ROLLBACK, null);
+
+        var pending = store.listPending();
+        assertThat(pending).hasSize(1);
+        assertThat(pending.get(0).requestBase64()).isNull();
+    }
+
+    // A marker written by a pre-#49 Spyglass: same key=value shape,
+    // no request line. Must read cleanly with a null plan instead of
+    // failing the whole listPending scan.
+    @Test
+    void legacyMarkerFileReadsWithNullRequestPlan() throws Exception {
+        String legacy = "id=" + JOB + "\n"
+                + "operatorName=Alice\n"
+                + "operatorId=" + OPERATOR + "\n"
+                + "mode=ROLLBACK\n"
+                + "query=p:Griefer r:30\n"
+                + "startedAt=2026-06-01T10:00:00Z\n"
+                + "appliedSoFar=120\n"
+                + "skippedSoFar=4\n";
+        // The store keys markers under <dataDir>/resume/.
+        Files.writeString(dir.resolve("resume").resolve(JOB + ".resume"), legacy,
+                StandardCharsets.UTF_8);
+
+        var pending = store.listPending();
+        assertThat(pending).hasSize(1);
+        assertThat(pending.get(0).requestBase64()).isNull();
+        assertThat(pending.get(0).appliedSoFar()).isEqualTo(120);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -145,6 +145,83 @@ class RollbackServiceTest {
                 true);
     }
 
+    // #49: resume must replay the marker's RESOLVED request — never
+    // re-parse the raw query with the resumer's location/clock context.
+    @Test
+    void resumeReplaysStoredRequestWithoutReparsing() throws Exception {
+        TestFixture fixture = new TestFixture();
+        Instant anchor = Instant.parse("2026-06-01T10:00:00Z");
+        QueryRequest original = new QueryRequest(
+                List.of(new net.medievalrp.spyglass.api.query.QueryPredicate.Range(
+                                "occurred", anchor.minusSeconds(3600), null),
+                        new net.medievalrp.spyglass.api.query.QueryPredicate.Range(
+                                "location.x", 100, 160)),
+                Sort.NEWEST_FIRST, 10_000,
+                java.util.EnumSet.noneOf(Flag.class), true);
+        String encoded = net.medievalrp.spyglass.plugin.storage.UndoReferenceBson
+                .encodeBase64(original, "ROLLBACK", anchor);
+        UUID cursorId = UUID.randomUUID();
+        RollbackResumeStore.Saved saved = new RollbackResumeStore.Saved(
+                UUID.randomUUID(), null, "Alice", "p:Griefer r:30",
+                RollbackJob.Mode.ROLLBACK, anchor,
+                new RollbackResumeStore.Cursor(anchor.minusSeconds(60), cursorId),
+                42, 3, encoded, java.nio.file.Path.of("unused.resume"));
+
+        boolean ok = fixture.subject.resumeFromSaved(saved, fixture.sender);
+
+        assertThat(ok).isTrue();
+        // The whole point: no re-parse — the parser (which would anchor
+        // r:/t: to THIS sender) is never consulted on resume.
+        org.mockito.Mockito.verifyNoInteractions(fixture.parser);
+        // The job ran (synchronous support) against the stored filter:
+        // identical predicates to the original operation's plan, with
+        // the saved cursor continuing against that same filter.
+        org.mockito.ArgumentCaptor<QueryRequest> sent =
+                org.mockito.ArgumentCaptor.forClass(QueryRequest.class);
+        org.mockito.ArgumentCaptor<net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor> cursor =
+                org.mockito.ArgumentCaptor.forClass(
+                        net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor.class);
+        verify(fixture.store, org.mockito.Mockito.atLeastOnce())
+                .queryPage(sent.capture(), cursor.capture(), anyInt());
+        assertThat(sent.getValue().predicates()).isEqualTo(original.predicates());
+        assertThat(cursor.getAllValues().get(0).occurred()).isEqualTo(anchor.minusSeconds(60));
+        assertThat(cursor.getAllValues().get(0).id()).isEqualTo(cursorId);
+    }
+
+    @Test
+    void resumeRefusesLegacyMarkerWithoutStoredRequest() {
+        TestFixture fixture = new TestFixture();
+        RollbackResumeStore.Saved saved = new RollbackResumeStore.Saved(
+                UUID.randomUUID(), null, "Alice", "p:Griefer r:30",
+                RollbackJob.Mode.ROLLBACK, Instant.now(), null, 0, 0,
+                null, java.nio.file.Path.of("unused.resume"));
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        boolean ok = fixture.subject.resumeFromSaved(saved, fixture.sender);
+
+        assertThat(ok).isFalse();
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("Re-run the original command"));
+        verify(fixture.store, never()).queryPage(any(QueryRequest.class), any(), anyInt());
+    }
+
+    @Test
+    void resumeRefusesCorruptStoredRequest() {
+        TestFixture fixture = new TestFixture();
+        RollbackResumeStore.Saved saved = new RollbackResumeStore.Saved(
+                UUID.randomUUID(), null, "Alice", "p:Griefer",
+                RollbackJob.Mode.ROLLBACK, Instant.now(), null, 0, 0,
+                "!!!not-a-reference!!!", java.nio.file.Path.of("unused.resume"));
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        boolean ok = fixture.subject.resumeFromSaved(saved, fixture.sender);
+
+        assertThat(ok).isFalse();
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("unreadable"));
+        verify(fixture.store, never()).queryPage(any(QueryRequest.class), any(), anyInt());
+    }
+
     @Test
     void reportsParamErrors() throws Exception {
         TestFixture fixture = new TestFixture();


### PR DESCRIPTION
resumeFromSaved re-parsed the raw query with the resuming sender's
context, re-anchoring r:/t: defaults to the resumer's position and
clock — a resume from elsewhere (or hours later) targeted a different
region and window, and the saved cursor then paged the wrong match
set. Markers now persist the resolved request (UndoReferenceBson, the
same rule undo references follow); resume decodes and replays it
verbatim, with the parser never consulted. Pre-#49 markers and
undo-replay markers (no stored plan) refuse with a clear message
instead of guessing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
