### PR TITLE
feat: DisplayRenderer.leadingTags so hooks can prefix result lines (#57)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/extension/DisplayRenderer.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/extension/DisplayRenderer.java
@@ -64,4 +64,22 @@ public interface DisplayRenderer {
     default List<Component> hoverLines(EventRecord record) {
         return List.of();
     }
+
+    /**
+     * Leading tags rendered at the front of the result line — immediately
+     * after the origin tag (e.g. {@code [WhisperNet]}) and before the actor
+     * name. Each entry becomes its own bracket-style label, so a hook that
+     * parks context in a record field (a chat channel, a faction, a world
+     * shard) can surface it up front:
+     * "{@code [WhisperNet] [OOC] Alice said: hi}".
+     *
+     * <p>Return fully-formed components (including any brackets and colour);
+     * Spyglass appends each followed by a single space and does not wrap
+     * them. Return an empty list (the default) to add nothing. Same threading
+     * and error-handling contract as {@link #renderTarget}: main-thread only,
+     * and a {@code null}/throwing result falls back to no leading tags.
+     */
+    default List<Component> leadingTags(EventRecord record) {
+        return List.of();
+    }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -84,6 +84,12 @@ public final class ResultRenderer {
         if (!tag.isEmpty()) {
             builder.append(Component.text(tag + " ", NamedTextColor.AQUA));
         }
+        // Extension-supplied leading tags (e.g. WhisperNet's channel) render
+        // between the origin tag and the actor name. Components arrive
+        // fully formed; we just space them out.
+        for (Component leadingTag : leadingTags(record)) {
+            builder.append(leadingTag).append(Component.space());
+        }
         builder.append(Component.text(displaySourceName(record), NamedTextColor.GREEN))
                 .append(Component.text(" " + verb(record), NamedTextColor.WHITE));
         int qty = quantityOf(record);
@@ -143,6 +149,27 @@ public final class ResultRenderer {
                                     Component.text("Click to teleport", NamedTextColor.GRAY))));
         }
         return builder.build();
+    }
+
+    /**
+     * Leading tags contributed by a registered {@link DisplayRenderer} for
+     * this record's event. Mirrors the {@code renderTarget} contract: a
+     * {@code null} return or a thrown {@link RuntimeException} yields no tags.
+     */
+    private List<Component> leadingTags(EventRecord record) {
+        if (api == null) {
+            return List.of();
+        }
+        return api.displayRenderer(record.event())
+                .map(renderer -> {
+                    try {
+                        List<Component> tags = renderer.leadingTags(record);
+                        return tags == null ? List.<Component>of() : tags;
+                    } catch (RuntimeException ex) {
+                        return List.<Component>of();
+                    }
+                })
+                .orElse(List.of());
     }
 
     private static ClickEvent teleportClick(BlockLocation loc) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -81,6 +81,45 @@ class ResultRendererTest {
     }
 
     @Test
+    void leadingTagsRenderBeforeTheActorName() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        DisplayRenderer custom = new DisplayRenderer() {
+            @Override
+            public List<Component> leadingTags(net.medievalrp.spyglass.api.event.EventRecord record) {
+                return List.of(Component.text("[OOC]"));
+            }
+        };
+        when(api.displayRenderer("sculk")).thenReturn(Optional.of(custom));
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+
+        assertThat(plain).contains("[OOC]");
+        assertThat(plain.indexOf("[OOC]"))
+                .as("leading tag must render before the actor name")
+                .isLessThan(plain.indexOf("Alice"));
+    }
+
+    @Test
+    void throwingLeadingTagsFallsBackToNoTags() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        DisplayRenderer custom = new DisplayRenderer() {
+            @Override
+            public List<Component> leadingTags(net.medievalrp.spyglass.api.event.EventRecord record) {
+                throw new IllegalStateException("boom");
+            }
+        };
+        when(api.displayRenderer("sculk")).thenReturn(Optional.of(custom));
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(useRecord(), EnumSet.noneOf(Flag.class), true);
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+
+        assertThat(plain).contains("Alice").doesNotContain("[OOC]");
+    }
+
+    @Test
     void extendedFlagAppendsLocationLine() {
         SpyglassApi api = mock(SpyglassApi.class);
         when(api.displayRenderer("sculk")).thenReturn(Optional.empty());


### PR DESCRIPTION
Adds a backward-compatible default method to the DisplayRenderer extension
point. ResultRenderer renders each leading tag from the registered renderer
between the origin tag and the actor name, with the same null/throw -> fallback
contract as renderTarget. Lets a hook that parks context in a record field
(e.g. WhisperNet's channel in ChatRecord.target) surface it up front:
"[WhisperNet] [OOC] Alice said: hi".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
