### PR TITLE
fix: rollback reverts the whole matched set, not just the newest N (#59)

### DIFF
--- a/regression/bot/verify-rollback-count.js
+++ b/regression/bot/verify-rollback-count.js
@@ -1,0 +1,170 @@
+// Independent before/after COUNT of a //set-air → /sg rollback cycle.
+//
+// Goal: prove whether the rollback ACTUALLY restores every block, not
+// trust the plugin's "applied" number. All counts come from vanilla
+// /fill ... replace over RCON (server-side ground truth), never Spyglass.
+//
+// Flow:
+//   1. /fill stone over the whole cube via RCON (UNLOGGED baseline).
+//   2. bot //set air over the cube (LOGGED by Spyglass -> break events).
+//   3. bot /sg rollback p:<bot> r:150 t:1h        (should restore stone).
+//   4. Count, per chunk, how much stone came back vs air left vs other:
+//        stone_restored = sum over chunks of  /fill glass replace stone
+//        air_remaining  =                     /fill bedrock replace air
+//        corrupted      = VOL - stone_restored - air_remaining
+//
+// A perfect rollback => stone_restored == VOL, air_remaining == 0.
+
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+// ── region: SIDE³, placed remote & high so it's pure air to start ──
+const SIDE = 64;
+const X0 = 20000, Y0 = 70, Z0 = 20000;
+const X1 = X0 + SIDE - 1, Y1 = Y0 + SIDE - 1, Z1 = Z0 + SIDE - 1;
+const VOL = SIDE * SIDE * SIDE;
+const CX0 = X0 >> 4, CZ0 = Z0 >> 4, CX1 = X1 >> 4, CZ1 = Z1 >> 4;
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+const countOf = s => { const m = s && s.match(/(\d[\d,]*)\s+block/i); return m ? parseInt(m[1].replace(/,/g, ''), 10) : 0; };
+
+// /fill <block> [replace <filter>] over the whole cube, tiled into
+// 8-high slabs (64*64*8 = 32768 = the vanilla /fill cap). Returns the
+// summed "filled N blocks" count.
+async function fillCube(block, filter) {
+    let total = 0;
+    for (let y = Y0; y <= Y1; y += 8) {
+        const yb = Math.min(y + 7, Y1);
+        const r = await rcon(`fill ${X0} ${y} ${Z0} ${X1} ${yb} ${Z1} ${block}${filter ? ` replace ${filter}` : ''}`);
+        total += countOf(r);
+    }
+    return total;
+}
+// Per-chunk stone count (16x16x64 = 16384 <= cap). Converts stone->glass.
+async function stonePerChunk() {
+    const rows = [];
+    for (let cx = CX0; cx <= CX1; cx++) {
+        for (let cz = CZ0; cz <= CZ1; cz++) {
+            const bx0 = Math.max(X0, cx << 4), bx1 = Math.min(X1, (cx << 4) + 15);
+            const bz0 = Math.max(Z0, cz << 4), bz1 = Math.min(Z1, (cz << 4) + 15);
+            const r = await rcon(`fill ${bx0} ${Y0} ${bz0} ${bx1} ${Y1} ${bz1} glass replace stone`);
+            rows.push({ cx, cz, stone: countOf(r) });
+        }
+    }
+    return rows;
+}
+function waitChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+
+const BOT = 'rbc' + Date.now().toString(36).slice(-4);
+
+(async () => {
+    log(`Region ${SIDE}³ = ${VOL} blocks @ (${X0},${Y0},${Z0})..(${X1},${Y1},${Z1}); chunks x[${CX0}..${CX1}] z[${CZ0}..${CZ1}]`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(1500);
+
+    log('Stage 0: /fill stone baseline (RCON, unlogged)…');
+    await fillCube('air');               // clean slate
+    const filled = await fillCube('stone');
+    log(`  baseline stone written: ${filled} (expect ${VOL})`);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + SIDE / 2} ${Y1 + 4} ${Z0 + SIDE / 2}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1500);
+
+    log('Stage 1: bot //set air over the cube (LOGGED)…');
+    bot.chat('//sel cuboid'); await sleep(400);
+    bot.chat(`//pos1 ${X0},${Y0},${Z0}`); await sleep(400);
+    bot.chat(`//pos2 ${X1},${Y1},${Z1}`); await sleep(400);
+    const setDone = waitChat(bot, /(blocks? have been changed|operation completed|affected)/i, 120000);
+    bot.chat('//set air');
+    const setMsg = await setDone;
+    log(`  WE: ${(setMsg || '(no confirmation)').trim()}`);
+    await sleep(7000);  // let the WAL-batched recorder drain to ClickHouse
+
+    // sanity: how many break events did Spyglass record for this bot?
+    const chq = encodeURIComponent(`SELECT count() FROM spyglass.event_records WHERE event='break' AND source_player_name='${BOT}'`);
+    let recorded = '?';
+    try { recorded = (await (await fetch(`http://localhost:8123/?query=${chq}`)).text()).trim(); } catch { }
+    log(`  Spyglass recorded ${recorded} break events for ${BOT} (expect ~${VOL})`);
+
+    log('Stage 2: /sg rollback p:' + BOT + ' t:1h -g …');
+    let summary = null;
+    const h = m => { if (/(reversals|No results|rolled back|applied)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    const t0 = Date.now();
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    while (summary == null && Date.now() - t0 < 120000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    const rbMs = Date.now() - t0;
+    log(`  rollback line: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none/timeout)'}  (${rbMs}ms)`);
+    await sleep(4000);  // let post-main resend/finish settle
+
+    log('Stage 3: independent COUNT (RCON /fill replace)…');
+    const perChunk = await stonePerChunk();              // stone->glass, per chunk
+    const stone = perChunk.reduce((a, r) => a + r.stone, 0);
+    const air = await fillCube('bedrock', 'air');        // air->bedrock
+    const corrupted = VOL - stone - air;
+
+    log('\n──────── PER-CHUNK STONE RESTORED (of 4096 each) ────────');
+    for (let cx = CX0; cx <= CX1; cx++) {
+        const row = perChunk.filter(r => r.cx === cx).map(r => String(r.stone).padStart(5)).join(' ');
+        log(`  cx=${cx}:  ${row}`);
+    }
+    log('\n──────── RESULT ────────');
+    log(`  volume:           ${VOL}`);
+    log(`  stone restored:   ${stone}   (${(100 * stone / VOL).toFixed(1)}%)`);
+    log(`  air remaining:    ${air}   (${(100 * air / VOL).toFixed(1)}%)  <- NOT restored`);
+    log(`  corrupted/other:  ${corrupted}   (${(100 * corrupted / VOL).toFixed(1)}%)  <- wrong block`);
+    log(`  rollback claimed: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none)'}`);
+    const pass = stone === VOL && air === 0 && corrupted === 0;
+    log(`\n  VERDICT: ${pass ? 'PASS — every block restored.' : 'FAIL — rollback did not fully restore the cube.'}`);
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} air`);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(pass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -42,6 +42,11 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public final class RollbackService {
 
+    // Fixed streaming read window (see usage in runJob). Formerly the
+    // limits.rollback-page-size knob; since #19 it has no heap/GC effect
+    // and is a query-efficiency default operators never need to tune.
+    private static final int STREAM_PAGE_SIZE = 500_000;
+
     private final SpyglassApi api;
     private final QueryStringParser parser;
     private final SpyglassConfig config;
@@ -82,16 +87,6 @@ public final class RollbackService {
 
     public void wireQueue() {
         jobQueue.setRunner(this::runJob);
-    }
-
-    // The rollback record cap (limits.rollback-result). <= 0 means
-    // "no cap" — run until the page cursor is exhausted — so a large
-    // grief rollback isn't silently truncated at N records. (Same
-    // 0-means-unbounded convention as defaults.radius=0 => global.)
-    // Mapped to MAX_VALUE so the streaming loop's hardLimit never trips.
-    private int rollbackResultLimit() {
-        int configured = config.limits().rollbackResult();
-        return configured <= 0 ? Integer.MAX_VALUE : configured;
     }
 
     // Re-submit an interrupted rollback as a fresh job. Idempotent:
@@ -200,7 +195,12 @@ public final class RollbackService {
     public void execute(CommandSender sender, String raw, RollbackMode mode) {
         QueryRequest request;
         try {
-            request = forceNoGroup(parser.parse(sender, raw, rollbackResultLimit()), mode);
+            // No record cap: a rollback reverts everything its query matches,
+            // bounded by limits.max-radius and the time window. The streaming
+            // engine keeps heap flat regardless of size (#19), so a cap would
+            // only ever silently half-restore a grief and mark the rest rolled
+            // back. MAX_VALUE => the store query and apply loop never truncate.
+            request = forceNoGroup(parser.parse(sender, raw, Integer.MAX_VALUE), mode);
         } catch (ParamParseException ex) {
             sender.sendMessage(Feedback.error(ex.getMessage()));
             return;
@@ -288,7 +288,11 @@ public final class RollbackService {
         // plan markStart wrote (#49). Null for replays — see runJob.
         String resumeRequest = replayOp ? null : encodeResumeRequest(request, job.mode);
         long startNanos = System.nanoTime();
-        int pageSize = Math.max(100, config.limits().rollbackPageSize());
+        // Streaming read window (#19): how many records each keyset query
+        // pulls off the wire before folding into a bounded apply window.
+        // Pure query-efficiency with no heap/GC cost, so it is a fixed
+        // internal default rather than an operator-facing knob.
+        int pageSize = STREAM_PAGE_SIZE;
         int batchSize = config.limits().rollbackBatchSize();
         int hardLimit = request.limit();
         int totalApplied = initialApplied;

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -97,12 +97,9 @@ public record SpyglassConfig(
                 new Limits(
                         root.node("limits", "max-radius").getInt(250),
                         root.node("limits", "search-result").getInt(1_000),
-                        root.node("limits", "rollback-result").getInt(10_000),
                         root.node("limits", "chat-dump").getInt(50),
                         root.node("limits", "rollback-batch-size").getInt(4_000),
                         Duration.parse(root.node("limits", "rollback-flush-timeout").getString("30s")),
-                        root.node("limits", "rollback-page-size").getInt(20_000),
-                        root.node("limits", "rollback-undo-cap").getInt(5_000_000),
                         // Tick-budget cap for the per-tick world-write phase.
                         // 50 ms = one full tick. Default 15 ms (~30% of a
                         // tick) keeps server TPS at or near 20 even during
@@ -244,9 +241,8 @@ public record SpyglassConfig(
     public record Defaults(boolean enabled, int radius, Duration time) {
     }
 
-    public record Limits(int maxRadius, int searchResult, int rollbackResult, int chatDump,
+    public record Limits(int maxRadius, int searchResult, int chatDump,
                          int rollbackBatchSize, Duration rollbackFlushTimeout,
-                         int rollbackPageSize, int rollbackUndoCap,
                          long rollbackTickBudgetMs) {
     }
 

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -88,47 +88,51 @@ defaults {
 }
 
 limits {
+  # The hard ceiling on how far a r:<radius> search or rollback reaches
+  # from the operator; an r: above it is clamped down to it. This is the
+  # practical size bound on a rollback: you can only revert blocks within
+  # max-radius of where you stand, so there is no separate "max blocks"
+  # cap. A rollback reverts everything its query matches inside this
+  # radius and the time window, however many that is; the streaming
+  # engine keeps heap flat regardless, so raising this only costs
+  # wall-clock on very large reverts, never memory.
   max-radius = 250
+
+  # Max rows a /sg search renders, and the cap on ip: reverse lookups.
+  # A display/scan bound only; it does not affect rollback.
   search-result = 1000
-  # Max records a single rollback / restore reverts. 0 = unlimited (run
-  # until the query is exhausted) so a large grief rollback isn't silently
-  # truncated; heap stays bounded regardless via the streaming windows, so
-  # there is no resource reason to cap this. Set a positive cap only if
-  # you want operators to need explicit confirmation for huge reverts.
-  rollback-result = 0
+
+  # Max lines one chat-history dump prints at a time.
   chat-dump = 50
-  # How many block-replace effects the rollback engine processes per
-  # tick before yielding back to the main thread. Simple block writes
-  # fan out to the off-main worker pool, so this budgets the main-thread
-  # share of a page (tile entities, containers, leftovers, per-batch
-  # bookkeeping) — 4000/tick lands well under the 50ms tick budget in
-  # the common case. Lower this if you have many tile-entity rollbacks
-  # (chests, signs, banners), or if your TPS dips during a rollback.
+
+  # Main-thread block-replace effects processed per tick before yielding.
+  # Simple writes fan out to the off-main worker pool, so this budgets
+  # only the main-thread share of a page (tile entities, containers,
+  # leftovers, per-batch bookkeeping). 4000/tick stays well under a 50ms
+  # tick in the common case. Lower it if you do many tile-entity
+  # rollbacks (chests, signs, banners) or see TPS dip during a rollback.
   rollback-batch-size = 4000
+
+  # Cap on the main-thread time the per-tick world-write phase may spend,
+  # in milliseconds (50ms is one whole tick). The default 15ms (about 30%
+  # of a tick) holds TPS at or near 20 even during a multi-million-block
+  # rollback. Raise it for faster wall-clock in a maintenance window, at
+  # the cost of TPS while the rollback runs.
+  rollback-tick-budget-ms = 15
+
   # Max time a rollback waits for the recorder queue to drain to the
-  # store before running its query. Closes the read-your-writes hole
-  # where a recent burst (e.g. //set 0 over a region) leaves events
-  # queued in the JVM that the store hasn't seen yet — without this the
-  # rollback silently misses them and only partially restores the world.
-  # On timeout the rollback proceeds anyway and warns the operator that
-  # the most recent events may be missed.
+  # store before it queries. Closes the read-your-writes hole where a
+  # fresh burst (e.g. //set 0 over a region) is still queued in the JVM
+  # and not yet visible to the store; without it the rollback would miss
+  # those blocks and only partially restore the area. On timeout it
+  # proceeds anyway and warns the operator that the newest events may be
+  # missed.
   rollback-flush-timeout = 30s
-  # Read window — how many records each keyset query asks the store
-  # for. Since #19 the rollback engine streams records off the wire
-  # and folds them straight into small bounded apply windows that live
-  # for tens of milliseconds, so this dial no longer affects memory or
-  # lag in either direction — it is purely a query-efficiency knob:
-  # bigger windows = fewer keyset round trips. 500000 runs a 2M-block
-  # rollback (or undo — same pipeline) in 4 reads. There is little
-  # reason to change it.
-  rollback-page-size = 500000
-  # OBSOLETE (#17): undo is replay-by-reference — an undo operation
-  # stores the original op's resolved query plus a time ceiling, and
-  # /spyglass undo re-streams those records through the engine in the
-  # opposite direction. Nothing is captured per effect, so there is
-  # nothing to cap; any size of operation is undoable. The key is
-  # parsed but ignored, kept so existing configs load unchanged.
-  rollback-undo-cap = 10000000
+
+  # Removed knobs (a rollback no longer caps the number of blocks it
+  # reverts): rollback-result, rollback-page-size, rollback-undo-cap.
+  # Any of these left in an old config is ignored. A rollback now always
+  # reverts everything its query matches; max-radius above is the bound.
 }
 
 tool {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -117,9 +117,6 @@ class RollbackServiceTest {
         private static SpyglassConfig sampleConfig(boolean rolledAuditSynthesized) {
             SpyglassConfig cfg = mock(SpyglassConfig.class);
             SpyglassConfig.Limits limits = mock(SpyglassConfig.Limits.class);
-            when(limits.rollbackResult()).thenReturn(10_000);
-            when(limits.rollbackPageSize()).thenReturn(5_000);
-            when(limits.rollbackUndoCap()).thenReturn(50_000);
             when(limits.rollbackBatchSize()).thenReturn(200);
             when(limits.rollbackFlushTimeout())
                     .thenReturn(new net.medievalrp.spyglass.api.util.Duration(30L));
@@ -234,6 +231,25 @@ class RollbackServiceTest {
         assertThat(ServiceTestSupport.plainTexts(messages))
                 .anyMatch(line -> line.contains("bad param"));
         verify(fixture.api, never()).query(any(QueryRequest.class));
+    }
+
+    // #59: a rollback must request an UNCAPPED parse so the store returns
+    // every matching record. The removed limits.rollback-result cap was
+    // applied here as the overrideLimit; with sort=NEWEST_FIRST it left a
+    // large grief only partially restored (the newest N) while the op
+    // marked the whole query rolled back, so the remainder was unreachable.
+    @Test
+    void rollbackRequestsAnUncappedParse() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt()))
+                .thenReturn(sampleRequest());
+
+        fixture.subject.execute(fixture.sender, "p:Griefer t:1h", RollbackMode.ROLLBACK);
+
+        verify(fixture.parser).parse(
+                ArgumentMatchers.eq(fixture.sender),
+                ArgumentMatchers.eq("p:Griefer t:1h"),
+                ArgumentMatchers.eq(Integer.MAX_VALUE));
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/UndoServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/UndoServiceTest.java
@@ -48,12 +48,9 @@ class UndoServiceTest {
         SpyglassConfig.Limits limits = new SpyglassConfig.Limits(
                 250,         // maxRadius
                 1_000,       // searchResult
-                10_000,      // rollbackResult
                 50,          // chatDump
                 4_000,       // rollbackBatchSize
                 Duration.parse("30s"),  // rollbackFlushTimeout
-                20_000,      // rollbackPageSize
-                5_000_000,   // rollbackUndoCap
                 40L);        // rollbackTickBudgetMs
         return mock(SpyglassConfig.class, invocation -> {
             if ("limits".equals(invocation.getMethod().getName())) return limits;


### PR DESCRIPTION
limits.rollback-result capped how many records a rollback applied (code
default 10000, though the shipped template said 0/unlimited). With the
NEWEST_FIRST sort that cap meant a rollback only ever reverted the newest
N effects, while the rollback-op it wrote covered the whole query
predicate - so RolledSynthesis treated the un-applied remainder as
already rolled back and a re-run found nothing. A grief larger than the
cap was silently half-restored, with the leftover blocks unreachable.

Remove the cap: a rollback now reverts everything its query matches,
bounded by limits.max-radius and the time window; the streaming engine
(#19) keeps heap flat regardless of size. Also drop two redundant knobs
in the same block: rollback-page-size (now a fixed internal default -
pure query-efficiency with no heap/GC cost since #19) and rollback-undo-
cap (dead: parsed but never enforced). Remaining limits knobs are
documented in config.conf; leftover removed keys in old configs are
ignored.

Verified on Paper 1.21.8 with an independent RCON block count (not the
plugin's own output): a 262144-block //set air + /sg rollback restores
10000/262144 (3.8%, half-filled chunks) when capped at 10000, versus
262144/262144 (100%) with the cap removed - same world ops, same config,
only the jar differs. Adds a JUnit regression asserting a rollback parses
uncapped, plus regression/bot/verify-rollback-count.js as the harness.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
