### PR TITLE
fix: chat result line shows the message, not just the target/channel (#61)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -327,7 +327,7 @@ public final class ResultRenderer {
             // One row per rollback/restore/undo operation (#22); the
             // mode rides in target. Renders "<operator> ran ROLLBACK".
             case RollbackOpRecord op -> upperOrEmpty(op.mode());
-            case ChatRecord chat -> chat.target();
+            case ChatRecord chat -> chatText(chat);
             case CommandRecord command -> "/" + command.target();
             // Join's "target" in the data model is the player's own
             // name, which duplicates the source — show the IP instead
@@ -368,6 +368,23 @@ public final class ResultRenderer {
             case ItemPickupRecord pickup -> pickup.amount();
             default -> 0;
         };
+    }
+
+    /**
+     * Inline text for a chat record: the message is the content, so always
+     * show it. When {@code target} is a distinct value (a channel/scope a hook
+     * like WhisperNet parked there, not the message), prefix it — "#OOC: hi" —
+     * so the log stays readable even with no {@link DisplayRenderer} registered.
+     * Vanilla chat stores target == message (its aggregation key), so this just
+     * yields the message.
+     */
+    private static String chatText(ChatRecord chat) {
+        String message = chat.message() == null ? "" : chat.message();
+        String channel = chat.target();
+        if (channel != null && !channel.isEmpty() && !channel.equals(message)) {
+            return channel + ": " + message;
+        }
+        return message;
     }
 
     private static String originTag(Origin origin) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockUseRecord;
+import net.medievalrp.spyglass.api.event.ChatRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.api.extension.DisplayRenderer;
@@ -117,6 +118,44 @@ class ResultRendererTest {
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
 
         assertThat(plain).contains("Alice").doesNotContain("[OOC]");
+    }
+
+    private static ChatRecord chatRecord(String target, String message) {
+        Instant now = Instant.now();
+        return new ChatRecord(
+                UUID.randomUUID(), "say",
+                now, now.plusSeconds(60),
+                Origin.plugin("WhisperNet"),
+                Source.player(PLAYER_ID, "Alice"),
+                new BlockLocation(WORLD_ID, "world", 10, 64, 20),
+                "test",
+                target, message, List.of());
+    }
+
+    @Test
+    void chatShowsMessageWithChannelPrefixWhenTargetDiffers() {
+        // WhisperNet shape: channel parked in target, no DisplayRenderer registered.
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("say")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("say", "said"));
+
+        String plain = PlainTextComponentSerializer.plainText().serialize(
+                renderer.renderSingle(chatRecord("#OOC", "hi"), EnumSet.noneOf(Flag.class), true));
+
+        assertThat(plain).contains("said #OOC: hi");
+    }
+
+    @Test
+    void vanillaChatShowsJustTheMessage() {
+        // Vanilla shape: target == message (the aggregation key) -> no "hi: hi".
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("say")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("say", "said"));
+
+        String plain = PlainTextComponentSerializer.plainText().serialize(
+                renderer.renderSingle(chatRecord("hi", "hi"), EnumSet.noneOf(Flag.class), true));
+
+        assertThat(plain).contains("said hi").doesNotContain("hi: hi");
     }
 
     @Test


### PR DESCRIPTION
ResultRenderer rendered ChatRecord.target after "said". Vanilla chat stores
target == message so it showed the message by luck, but WhisperNet parks the
channel in target, so the line showed the channel and the message never
appeared without WhisperNet's DisplayRenderer loaded. Render the message
instead, prefixing target as a channel only when it differs (#OOC: hi), so
chat logs stay readable independent of any hook. target stays = message for
vanilla (its aggregation key) — renderer-only change, no listener/storage churn.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
