### PR TITLE
feat: extension fields — integrations attach custom record metadata (#62)

### DIFF
--- a/regression/bot/lag-probe.js
+++ b/regression/bot/lag-probe.js
@@ -1,0 +1,31 @@
+// Does Spyglass lag the main thread? Measure MSPT idle vs during a large
+// staff WorldEdit edit (the realistic heavy-recording moment), + GC.
+import mineflayer from 'mineflayer';
+import net from 'net';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+function pkt(i, t, b) { const u = Buffer.from(b); const l = 10 + u.length; const o = Buffer.alloc(4 + l); o.writeInt32LE(l, 0); o.writeInt32LE(i, 4); o.writeInt32LE(t, 8); u.copy(o, 12); return o; }
+function rcon(cmd) { return new Promise((res, rej) => { const s = net.createConnection({ host: "127.0.0.1", port: 25576, timeout: 30000 }); let st = 0, bs = []; s.on("error", rej); s.on("timeout", () => { s.destroy(); rej("t/o"); }); s.on("connect", () => s.write(pkt(1, 3, "test123"))); s.on("data", c => { bs.push(c); const a = Buffer.concat(bs); if (a.length < 4) return; const l = a.readInt32LE(0); if (a.length < l + 4) return; if (st === 0) { st = 1; bs = []; s.write(pkt(1, 2, cmd)); } else { s.end(); res(a.slice(12, 12 + l - 10).toString().replace(/§./g, "")); } }); }); }
+const mspt = async () => (await rcon("mspt")).replace(/\n/g, " ").trim();
+
+(async () => {
+  console.log("IDLE mspt:", await mspt());
+  await sleep(800);
+  console.log("IDLE tps :", (await rcon("tps")).replace(/\n/g, " ").trim());
+
+  const X = 21000, Y = 80, Z = 21000, S = 64; // 64^3 = 262,144 blocks
+  await rcon(`forceload add ${X} ${Z} ${X + S - 1} ${Z + S - 1}`); await sleep(800);
+  for (let y = Y; y < Y + S; y += 8) await rcon(`fill ${X} ${y} ${Z} ${X + S - 1} ${Math.min(y + 7, Y + S - 1)} ${Z + S - 1} stone`);
+
+  const bot = mineflayer.createBot({ host: "127.0.0.1", port: 25566, username: "lagprobe", version: "1.21.4" });
+  await new Promise((r, j) => { bot.once("spawn", r); bot.once("error", j); });
+  await rcon("op lagprobe"); await rcon("gamemode creative lagprobe"); await rcon(`tp lagprobe ${X} ${Y + S + 5} ${Z}`); await sleep(2500);
+  bot.chat("//sel cuboid"); await sleep(300); bot.chat(`//pos1 ${X},${Y},${Z}`); await sleep(300); bot.chat(`//pos2 ${X + S - 1},${Y + S - 1},${Z + S - 1}`); await sleep(300);
+
+  console.log(`\n-- bot //set air over 262,144 blocks (logged by Spyglass + CoreProtect) --`);
+  bot.chat("//set air");
+  for (let i = 0; i < 8; i++) { await sleep(1000); console.log(`  +${i + 1}s:`, await mspt()); }
+
+  bot.quit(); await sleep(500);
+  await rcon(`fill ${X} ${Y} ${Z} ${X + S - 1} ${Y + S - 1} ${Z + S - 1} air`); await rcon(`forceload remove ${X} ${Z} ${X + S - 1} ${Z + S - 1}`);
+  process.exit(0);
+})().catch(e => { console.log("ERR", e?.message || e); process.exit(1); });

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ChatRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ChatRecord.java
@@ -2,6 +2,7 @@ package net.medievalrp.spyglass.api.event;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 
@@ -18,16 +19,18 @@ public record ChatRecord(
         String server,
         String target,
         String message,
-        List<UUID> recipients) implements EventRecord {
+        List<UUID> recipients,
+        Map<String, String> extensions) implements EventRecord {
 
     public ChatRecord {
         recipients = List.copyOf(recipients);
+        extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
     }
 
     public static ChatRecord of(RecordContext ctx, String target, String message, List<UUID> recipients) {
         return new ChatRecord(
                 ctx.id(), "say", ctx.occurred(), ctx.expiresAt(),
                 ctx.origin(), ctx.source(), ctx.location(), ctx.server(),
-                target, message, recipients);
+                target, message, recipients, ctx.extensions());
     }
 }

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventRecord.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.api.event;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 
@@ -54,5 +55,16 @@ public sealed interface EventRecord permits
 
     default String sourceName() {
         return source().displayName();
+    }
+
+    /**
+     * String key/value metadata attached by an integrating plugin (e.g. a
+     * chat channel) via {@link RecordContext#withExtension}. Empty unless the
+     * concrete record type opts in by exposing an {@code extensions}
+     * component. Stored, searchable ({@code extensions.<key>}), and rendered
+     * as first-class data rather than overloading a core field.
+     */
+    default Map<String, String> extensions() {
+        return Map.of();
     }
 }

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/RecordContext.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/RecordContext.java
@@ -1,6 +1,8 @@
 package net.medievalrp.spyglass.api.event;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.api.util.EventIds;
@@ -10,6 +12,14 @@ import net.medievalrp.spyglass.api.util.EventIds;
  * timestamps, origin, source, location, and the recording server's
  * identifier. Extractors build one per event and hand it to the record's
  * static {@code of(...)} factory along with type-specific fields.
+ *
+ * <p>It also carries an optional bag of {@code extensions} — string
+ * key/value metadata an integrating plugin attaches via {@link
+ * #withExtension} (e.g. a chat channel) so the field is stored, searchable,
+ * and displayable as first-class data rather than overloading a core field
+ * like {@code target}. Records opt in by exposing an {@code extensions}
+ * component; those that don't return an empty map via {@link
+ * EventRecord#extensions()}.
  */
 public record RecordContext(
         UUID id,
@@ -18,7 +28,12 @@ public record RecordContext(
         Origin origin,
         Source source,
         BlockLocation location,
-        String server) {
+        String server,
+        Map<String, String> extensions) {
+
+    public RecordContext {
+        extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+    }
 
     public static RecordContext fresh(Instant occurred, Instant expiresAt,
                                       Origin origin, Source source, BlockLocation location,
@@ -26,6 +41,19 @@ public record RecordContext(
         // Time-ordered v7 instead of random v4: the id column is the
         // single largest consumer of store disk, and v4 entropy is
         // incompressible (see EventIds).
-        return new RecordContext(EventIds.newId(), occurred, expiresAt, origin, source, location, server);
+        return new RecordContext(
+                EventIds.newId(), occurred, expiresAt, origin, source, location, server, Map.of());
+    }
+
+    /**
+     * A copy of this context with {@code key=value} added to its extensions.
+     * Integrating plugins call this before the record's {@code of(...)}
+     * factory so the field rides into storage:
+     * {@code ChatRecord.of(ctx.withExtension("channel", "#OOC"), ...)}.
+     */
+    public RecordContext withExtension(String key, String value) {
+        Map<String, String> next = new HashMap<>(extensions);
+        next.put(key, value);
+        return new RecordContext(id, occurred, expiresAt, origin, source, location, server, next);
     }
 }

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/RecordContextTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/RecordContextTest.java
@@ -1,0 +1,68 @@
+package net.medievalrp.spyglass.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+class RecordContextTest {
+
+    private static RecordContext fresh() {
+        return RecordContext.fresh(
+                Instant.ofEpochSecond(1_700_000_000L), null,
+                Origin.player(),
+                Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(UUID.randomUUID(), "world", 0, 0, 0),
+                "srv");
+    }
+
+    @Test
+    void freshHasEmptyExtensions() {
+        assertThat(fresh().extensions()).isEmpty();
+    }
+
+    @Test
+    void withExtensionAddsKeyAndLeavesTheOriginalUntouched() {
+        RecordContext base = fresh();
+        RecordContext withChannel = base.withExtension("channel", "#OOC");
+
+        assertThat(base.extensions()).isEmpty();
+        assertThat(withChannel.extensions()).hasSize(1).containsEntry("channel", "#OOC");
+        // Only extensions differ; the rest of the context is carried over.
+        assertThat(withChannel.id()).isEqualTo(base.id());
+        assertThat(withChannel.source()).isEqualTo(base.source());
+    }
+
+    @Test
+    void withExtensionChains() {
+        RecordContext ctx = fresh().withExtension("channel", "#OOC").withExtension("faction", "Reach");
+        assertThat(ctx.extensions())
+                .containsEntry("channel", "#OOC")
+                .containsEntry("faction", "Reach");
+    }
+
+    @Test
+    void extensionsAreImmutable() {
+        RecordContext ctx = fresh().withExtension("channel", "#OOC");
+        assertThatThrownBy(() -> ctx.extensions().put("x", "y"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void chatRecordCarriesContextExtensions() {
+        ChatRecord chat = ChatRecord.of(fresh().withExtension("channel", "#OOC"), "#OOC", "hi", List.of());
+        assertThat(chat.extensions()).containsEntry("channel", "#OOC");
+    }
+
+    @Test
+    void recordWithoutAnExtensionsComponentDefaultsToEmpty() {
+        // CommandRecord doesn't expose an extensions component, so it falls
+        // back to EventRecord#extensions() — an empty map, never null.
+        CommandRecord cmd = CommandRecord.of(fresh().withExtension("channel", "#OOC"), "tp", "/tp Alice");
+        assertThat(cmd.extensions()).isEmpty();
+    }
+}

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -113,7 +113,8 @@ public final class ClickHouseRecordStore implements RecordStore {
             "entity_type", "entity_id",
             "entity_killer_type", "entity_damage_cause",
             "entity_damage", "entity_projectile", "entity_projectile_type",
-            "entity_dismount", "entity_old_name", "entity_new_name");
+            "entity_dismount", "entity_old_name", "entity_new_name",
+            "extensions");
 
     private static final List<String> HEAVY_COLUMNS = List.of(
             "before_material", "before_blockdata", "before_extras",
@@ -327,6 +328,10 @@ public final class ClickHouseRecordStore implements RecordStore {
         writer.setInteger("location_z", location.z());
         writer.setString("server", nullToEmpty(record.server()));
         writer.setValue("target", record.target());
+        // Extension fields ride on every row (empty map for records that don't
+        // expose them — see EventRecord#extensions). RowBinary needs every
+        // column set per row, so this is unconditional.
+        writer.setValue("extensions", record.extensions());
     }
 
     private void writeBlockColumns(RowBinaryFormatWriter writer, EventRecord record) throws IOException {
@@ -751,7 +756,8 @@ public final class ClickHouseRecordStore implements RecordStore {
             return new ChatRecord(id, event, occurred, expiresAt,
                     origin, source, location, server, target,
                     row.getString("message"),
-                    readUuidList(row, "recipients"));
+                    readUuidList(row, "recipients"),
+                    readStringMap(row, "extensions"));
         }
         if (clazz == CommandRecord.class) {
             return new CommandRecord(id, event, occurred, expiresAt,
@@ -882,6 +888,25 @@ public final class ClickHouseRecordStore implements RecordStore {
                 row.getInteger(prefix + "x"),
                 row.getInteger(prefix + "y"),
                 row.getInteger(prefix + "z"));
+    }
+
+    /**
+     * Reads a ClickHouse {@code Map(String,String)} column. The client decodes
+     * a Map column to a {@link Map}; a null/absent/empty column yields an empty
+     * map (records written before the column existed read as empty).
+     */
+    private Map<String, String> readStringMap(GenericRecord row, String column) {
+        Object raw = row.getObject(column);
+        if (!(raw instanceof Map<?, ?> map) || map.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> out = new HashMap<>(map.size());
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                out.put(entry.getKey().toString(), entry.getValue().toString());
+            }
+        }
+        return Map.copyOf(out);
     }
 
     private List<UUID> readUuidList(GenericRecord row, String column) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
@@ -115,6 +115,14 @@ final class ClickHouseSchema {
                     + " or start fresh. Refusing to start against the v1 layout.");
         }
 
+        // Extension fields (added after v2): a Map column for plugin-supplied
+        // key/value metadata. ADD COLUMN IF NOT EXISTS is a cheap metadata
+        // ALTER — existing rows read an empty map — so a v2 table becomes
+        // forward-compatible without a rebuild, and a fresh table already has
+        // it from the CREATE above.
+        execute(client, "ALTER TABLE " + qualifiedTable(database, eventsTable)
+                + " ADD COLUMN IF NOT EXISTS extensions Map(String, String) CODEC(ZSTD(1))");
+
         // One-shot migration: pre-chunked undo_history shape lacked
         // operation_id / chunk_index / chunk_count. ORDER BY changed,
         // so ALTER can't reshape the key — drop and recreate. Worst
@@ -300,6 +308,10 @@ final class ClickHouseSchema {
                 + "    entity_old_name Nullable(String),\n"
                 + "    entity_new_name Nullable(String),\n"
                 + "    op_reference Nullable(String) CODEC(ZSTD(1)),\n"
+                // --- Extension fields: string key/value metadata an
+                // integrating plugin attaches via RecordContext#withExtension
+                // (e.g. a chat channel). Searchable as extensions['<key>'].
+                + "    extensions Map(String, String) CODEC(ZSTD(1)),\n"
                 // --- Skip indexes ---
                 + "    INDEX idx_loc_xz (location_x, location_z) TYPE minmax GRANULARITY 4,\n"
                 + "    INDEX idx_world location_world_id TYPE bloom_filter GRANULARITY 4,\n"

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -113,7 +113,7 @@ class ClickHouseRecordStoreIT {
                 new BlockPlaceRecord(UUID.randomUUID(), "place", now, now.plusSeconds(3600),
                         origin, source, location, "test", "STONE", air, stone),
                 new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
-                        origin, source, location, "test", "Alice", "hello", List.of()),
+                        origin, source, location, "test", "Alice", "hello", List.of(), java.util.Map.of("channel", "#OOC")),
                 new ContainerDepositRecord(UUID.randomUUID(), "deposit", now, now.plusSeconds(3600),
                         origin, source, location, "test", "DIAMOND", "CHEST", 3, 1, null, item),
                 new EntityDeathRecord(UUID.randomUUID(), "death", now, now.plusSeconds(3600),
@@ -128,6 +128,11 @@ class ClickHouseRecordStoreIT {
                 Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
         QueryResult result = store.query(allEvents);
         assertThat(result.records()).hasSize(5);
+        net.medievalrp.spyglass.api.event.ChatRecord chatBack = result.records().stream()
+                .filter(net.medievalrp.spyglass.api.event.ChatRecord.class::isInstance)
+                .map(net.medievalrp.spyglass.api.event.ChatRecord.class::cast)
+                .findFirst().orElseThrow();
+        assertThat(chatBack.extensions()).containsEntry("channel", "#OOC");
 
         QueryRequest breakOnly = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickhouseVsMongoBench.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickhouseVsMongoBench.java
@@ -357,7 +357,7 @@ class ClickhouseVsMongoBench {
                         origin, source, loc, "test", "DIAMOND", "CHEST", 3, 1, diamond, null);
                 case "say" -> new ChatRecord(id, "say", occurred, expiresAt,
                         origin, source, loc, "test", PLAYER_NAMES[playerIdx],
-                        "msg-" + i, List.of());
+                        "msg-" + i, List.of(), java.util.Map.of());
                 case "death" -> new EntityDeathRecord(id, "death", occurred, expiresAt,
                         origin, source, loc, "test", "ZOMBIE", "ZOMBIE",
                         UUID.randomUUID(), "player", "ENTITY_ATTACK", null);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
@@ -316,7 +316,7 @@ class EventRecordCodecTest {
                 UUID.randomUUID(), "say", WHEN, WHEN.plusSeconds(3600),
                 Origin.player(), Source.player(ALICE, "Alice"),
                 new BlockLocation(WORLD, "world", 5, 64, 5),
-                "test", "Alice", "hello world", List.of());
+                "test", "Alice", "hello world", List.of(), java.util.Map.of("channel", "#OOC"));
         BlockBreakRecord brk = sampleBreak();
 
         assertThat(decode(encode(chat))).isInstanceOf(ChatRecord.class).isEqualTo(chat);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -99,7 +99,7 @@ class MongoRecordStoreIT {
                 new BlockPlaceRecord(UUID.randomUUID(), "place", now, now.plusSeconds(3600),
                         origin, source, location, "test", "STONE", air, stone),
                 new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
-                        origin, source, location, "test", "Alice", "hello", List.of()),
+                        origin, source, location, "test", "Alice", "hello", List.of(), java.util.Map.of("channel", "#OOC")),
                 new ContainerDepositRecord(UUID.randomUUID(), "deposit", now, now.plusSeconds(3600),
                         origin, source, location, "test", "DIAMOND", "CHEST", 3, 1, null, item),
                 new EntityDeathRecord(UUID.randomUUID(), "death", now, now.plusSeconds(3600),
@@ -113,6 +113,11 @@ class MongoRecordStoreIT {
                 Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
         QueryResult result = store.query(allEvents);
         assertThat(result.records()).hasSize(5);
+        net.medievalrp.spyglass.api.event.ChatRecord chatBack = result.records().stream()
+                .filter(net.medievalrp.spyglass.api.event.ChatRecord.class::isInstance)
+                .map(net.medievalrp.spyglass.api.event.ChatRecord.class::cast)
+                .findFirst().orElseThrow();
+        assertThat(chatBack.extensions()).containsEntry("channel", "#OOC");
 
         QueryRequest breakOnly = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -584,7 +584,7 @@ public final class RollbackService {
                                 net.medievalrp.spyglass.api.util.EventIds.newId(), opOccurred,
                                 config.storage().retention().after(opOccurred),
                                 net.medievalrp.spyglass.api.event.Origin.rollback(sender.getName()),
-                                opSource, opLocation, config.server().name()),
+                                opSource, opLocation, config.server().name(), java.util.Map.of()),
                         mode.name(), reference));
             } catch (RuntimeException ex) {
                 logger.warning("Spyglass rollback-op record emit failed ("

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1083,7 +1083,7 @@ public final class RollbackEngine {
                 RecordingSupport.fastRandomUUID(),
                 occurred,
                 support.expiresAt(occurred),
-                origin, source, location, support.serverName());
+                origin, source, location, support.serverName(), java.util.Map.of());
         boolean toAir = after == null || after.material() == Material.AIR;
         // Lowercase-hyphenated form matches shulker-open etc. and
         // dodges the case-sensitivity quirk in EventCatalog.recordClassOf.

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -129,7 +129,7 @@ class ResultRendererTest {
                 Source.player(PLAYER_ID, "Alice"),
                 new BlockLocation(WORLD_ID, "world", 10, 64, 20),
                 "test",
-                target, message, List.of());
+                target, message, List.of(), java.util.Map.of());
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/WalCrashRecoveryTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/WalCrashRecoveryTest.java
@@ -122,7 +122,7 @@ class WalCrashRecoveryTest {
         BlockLocation loc = new BlockLocation(WORLD, "world", 0, 64, 0);
         return new ChatRecord(UUID.randomUUID(), "say", occurred, occurred.plusSeconds(3600),
                 Origin.player(), Source.player(PLAYER, "Tester"),
-                loc, "test", "Tester", message, List.of());
+                loc, "test", "Tester", message, List.of(), java.util.Map.of());
     }
 
     private static final class FlakyStore implements RecordStore {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/WalDurabilityTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/WalDurabilityTest.java
@@ -119,13 +119,13 @@ class WalDurabilityTest {
                 new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
                         origin, source, loc, "test", "STONE", stone, air),
                 new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
-                        origin, source, loc, "test", "Tester", "hi", List.of()));
+                        origin, source, loc, "test", "Tester", "hi", List.of(), java.util.Map.of()));
     }
 
     private static ChatRecord chatAt(Instant occurred, String message) {
         BlockLocation loc = new BlockLocation(WORLD, "world", 0, 64, 0);
         return new ChatRecord(UUID.randomUUID(), "say", occurred, occurred.plusSeconds(3600),
                 Origin.player(), Source.player(PLAYER, "Tester"),
-                loc, "test", "Tester", message, List.of());
+                loc, "test", "Tester", message, List.of(), java.util.Map.of());
     }
 }


### PR DESCRIPTION
Adds a string key/value bag plugins can attach to a record via
RecordContext.withExtension, stored and round-tripped through both backends,
so a hook (e.g. WhisperNet's channel) keeps its data in first-class storage
instead of overloading a core field like target.

- API: RecordContext carries an immutable extensions map + withExtension
  wither; EventRecord.extensions() defaults empty; records opt in with an
  extensions component (ChatRecord first). of() factories and all ~40 listener
  call sites are unchanged — extensions flow through the context.
- ClickHouse: new extensions Map(String,String) column. Fresh tables get it at
  CREATE; existing v2 tables via ALTER ADD COLUMN IF NOT EXISTS in ensure()
  (runs before getTableSchema, so the writer sees it) — a cheap metadata add,
  no rebuild. Written on every row, read back into ChatRecord.
- Mongo: automatic via the per-type record codec.

Verified: API unit tests, Mongo-codec round-trip (structural equality), and
ClickHouse + Mongo store ITs asserting extensions round-trip {channel:#OOC}.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
