### PR TITLE
feat: extension fields — query and display support (#63)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -143,6 +143,8 @@ final class PredicateEvaluator {
             case "afterItem" -> storedItemField(afterItemOf(record), rest);
             case "originalBlock" -> snapshotField(originalBlockOf(record), rest);
             case "newBlock" -> snapshotField(newBlockOf(record), rest);
+            // Plugin-supplied extension fields (extensions.channel, etc.).
+            case "extensions" -> record.extensions().get(rest);
             default -> null;
         };
     }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToSql.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToSql.java
@@ -145,6 +145,12 @@ final class PredicateToSql {
     }
 
     private String column(String fieldPath) {
+        // Extension fields live in the extensions Map(String,String) column;
+        // a path like extensions.channel becomes extensions['channel']. The
+        // key is escaped as a string literal so a hostile param can't break out.
+        if (fieldPath.startsWith("extensions.")) {
+            return "extensions[" + stringLiteral(fieldPath.substring("extensions.".length())) + "]";
+        }
         String column = ClickHouseFieldMapper.columnFor(fieldPath);
         if (column == null) {
             // Two reasons a path can land here:

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -133,6 +133,10 @@ class ClickHouseRecordStoreIT {
                 .map(net.medievalrp.spyglass.api.event.ChatRecord.class::cast)
                 .findFirst().orElseThrow();
         assertThat(chatBack.extensions()).containsEntry("channel", "#OOC");
+        QueryRequest byChannel = new QueryRequest(
+                List.of(new QueryPredicate.Eq("extensions.channel", "#OOC")),
+                Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byChannel).records()).hasSize(1);
 
         QueryRequest breakOnly = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -118,6 +118,10 @@ class MongoRecordStoreIT {
                 .map(net.medievalrp.spyglass.api.event.ChatRecord.class::cast)
                 .findFirst().orElseThrow();
         assertThat(chatBack.extensions()).containsEntry("channel", "#OOC");
+        QueryRequest byChannel = new QueryRequest(
+                List.of(new QueryPredicate.Eq("extensions.channel", "#OOC")),
+                Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byChannel).records()).hasSize(1);
 
         QueryRequest breakOnly = new QueryRequest(
                 List.of(new QueryPredicate.Eq("event", "break")),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -254,6 +254,9 @@ public final class ResultRenderer {
         if (record instanceof TeleportRecord tp && tp.cause() != null && !tp.cause().isBlank()) {
             lines.add(kv("Via", tp.cause()));
         }
+        // Plugin-supplied extension fields (e.g. a chat channel) get their own
+        // hover line, so they're visible even with no DisplayRenderer registered.
+        record.extensions().forEach((key, value) -> lines.add(kv(capitalizeKey(key), value)));
         // Append extra hover lines from a registered DisplayRenderer, if any.
         if (api != null) {
             api.displayRenderer(record.event()).ifPresent(renderer -> {
@@ -385,6 +388,14 @@ public final class ResultRenderer {
             return channel + ": " + message;
         }
         return message;
+    }
+
+    /** Title-cases an extension-field key for its hover label ("channel" -> "Channel"). */
+    private static String capitalizeKey(String key) {
+        if (key == null || key.isEmpty()) {
+            return key;
+        }
+        return Character.toUpperCase(key.charAt(0)) + key.substring(1);
     }
 
     private static String originTag(Origin origin) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockUseRecord;
@@ -156,6 +157,40 @@ class ResultRendererTest {
                 renderer.renderSingle(chatRecord("hi", "hi"), EnumSet.noneOf(Flag.class), true));
 
         assertThat(plain).contains("said hi").doesNotContain("hi: hi");
+    }
+
+    @Test
+    void extensionFieldsAppearInTheHover() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("say")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("say", "said"));
+
+        Instant now = Instant.now();
+        ChatRecord chat = new ChatRecord(
+                UUID.randomUUID(), "say", now, now.plusSeconds(60),
+                Origin.plugin("WhisperNet"), Source.player(PLAYER_ID, "Alice"),
+                new BlockLocation(WORLD_ID, "world", 10, 64, 20), "test",
+                "#OOC", "hi", List.of(), java.util.Map.of("channel", "#OOC"));
+
+        Component hover = extractHover(renderer.renderSingle(chat, EnumSet.noneOf(Flag.class), true));
+        assertThat(hover).as("result line should carry a hover").isNotNull();
+        String hoverPlain = PlainTextComponentSerializer.plainText().serialize(hover);
+        // capitalizeKey turns the extension key into its label.
+        assertThat(hoverPlain).contains("Channel").contains("#OOC");
+    }
+
+    private static Component extractHover(Component component) {
+        HoverEvent<?> hover = component.hoverEvent();
+        if (hover != null && hover.value() instanceof Component value) {
+            return value;
+        }
+        for (Component child : component.children()) {
+            Component found = extractHover(child);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 
     @Test


### PR DESCRIPTION
Makes the extensions added in #62 filterable and visible.

- Query: a field path extensions.<key> filters on the extension. ClickHouse
  maps it to extensions['<key>'] (key escaped as a string literal, so a hostile
  param can't break out); Mongo uses native dot-notation (no change); the
  in-memory PredicateEvaluator resolves it from record.extensions().
- Display: extension fields render as their own hover line (Channel: #OOC),
  visible even with no DisplayRenderer registered.

Verified: store ITs query extensions.channel=#OOC on both backends; renderer
test asserts the field appears in the hover.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
