### PR TITLE
Eliminate large-rollback GC freeze — lean decode + columnar apply (#67)

### DIFF
--- a/docs/report/rollback-bench-results.md
+++ b/docs/report/rollback-bench-results.md
@@ -2,61 +2,59 @@
 
 Head-to-head rollback of a **2,000,376-block** cube (126³), with **both** plugins on the **same ClickHouse** (`127.0.0.1:8123`; Spyglass → `spyglass` db, CoreProtect → `coreprotect` db via the `coreprotect-clickhouse` bridge). Run on `../RP_Server` (Paper 1.21.8, Java 21) under the **6 GB benchmark heap** (`start-bench.sh`), driven by [`regression/bot/compare.js`](../../regression/bot/compare.js). GC from the JVM GC log (`logs/gc-bench.log`).
 
-**Re-run 2026-06-18** on current `main` — after #19 (streaming collect), #44 (storage v2), and #59 (rollback-cap removal). **Two back-to-back runs**; numbers are reported `run1 / run2`. This supersedes the 2026-06-03 run. Two things changed materially since then:
+**Re-run 2026-06-18** on current `main` — after **#67 (lean rollback decode + columnar apply)**, on top of #19 (streaming collect), #44 (storage v2), and #59 (rollback-cap removal). #67 is the change that **eliminates the freeze**:
 
-1. **`/spyglass undo` now completes.** It used to materialize the whole inverse-effect list in heap and OOM'd above ~250 K effects, so the old run skipped it. It now streams, and reverses a 2M cube in ~8.6 s.
-2. **The rollback-time GC freezes are roughly halved.** The dials that drove them — `rollback-page-size` / `rollback-undo-cap` at 1M / 10M — are gone (#59); the engine now streams **16 bounded ~500 K-row windows** instead of one 1M-row window plus a 2M-element live undo list, so the +2 GB old-gen promotion that caused the freezes no longer happens.
+1. **Lean decode.** The rollback read now resolves each ClickHouse row straight to a `RollbackEffect` from a trimmed column list — no `EventRecord` / `Origin` / `Source` / server / target object graph is built. Read wall-clock dropped **6.1 s → ~0.6 s** for a 2M scan.
+2. **Columnar apply.** Simple block-replaces (the bulk of any rollback) are applied from primitive `int` arrays + an interned block-data palette, reporting *counts* instead of a `RollbackResult` object per cell. The apply no longer allocates a promotable object graph, so it stops growing old gen — which is what used to trigger the Mixed-GC freeze under Aikar's `MaxTenuringThreshold=1`.
+
+Net: a 2M rollback drops from **9.6 s** (object path) to **~3.1 s**, and the worst GC pause *during the rollback* drops from **360 ms (4 Mixed pauses)** to **a single ≤9.4 ms pure-young pause — or none** in steady state.
 
 ## TL;DR
 
 | Dimension (2M blocks, ClickHouse) | **Spyglass** | **CoreProtect** | Winner |
 |---|---|---|---|
-| Rollback wall-clock | **8.4 / 9.3 s** (~226 k blk/s) | 12.7 / 12.2 s (~161 k blk/s) | **SG ~1.4×** |
-| Undo / restore-to-air wall-clock | **8.8 / 8.4 s** (now works) | 12.8 / 15.3 s | **SG** |
-| MSPT 5 s-avg during op | **5.3 / 5.5 ms** | 44.1 / 36.7–55.9 ms | **SG** |
-| Worst single tick (MSPT 5 s-max) | **129 / 75 ms** | 276 / 603 ms | **SG** |
-| Sustained TPS during op | **20.0 / 20.0** | 17.1 / 15.7 (min 8–12) | **SG** |
-| Worst GC pause *during the rollback* | **307 / 424 ms** (was 849 ms) | on-main — folds into the tick | — |
+| Rollback wall-clock | **3.8 s** (~520 k blk/s) | 11.6 s (~173 k blk/s) | **SG ~3×** |
+| Undo / restore-to-air wall-clock | **3.5 s** (~572 k blk/s) | 12.6 s | **SG** |
+| MSPT 5 s-avg during op | **4.4 / 4.1 ms** | 83.6 / 36.4 ms | **SG** |
+| Worst single tick (MSPT 5 s-max) | **17.3 ms** | 617 ms | **SG** |
+| Sustained TPS during op | **20.0 / 20.0** | 12.0 / 18.1 (min 9.8) | **SG** |
+| Worst GC pause *during the rollback* (steady state) | **≤9.4 ms** (pure-young; often 0) | on-main — folds into the tick | — |
 
-**Verdict.** On the same ClickHouse, Spyglass rolls back **~1.4× faster** than CoreProtect and holds a real **20 TPS** by doing the apply off-main (main thread ~parked the whole time); CoreProtect applies on-main and sags to ~16–18 TPS (dipping to 8–12) for the *entire* operation. `/spyglass undo` now reverses a 2M rollback in ~8.6 s — the heap blowup that forced it to be skipped is fixed. The rollback-time GC freezes the 2026-06-03 run flagged (3 pauses up to **849 ms**) are down to **one or two ~300–425 ms** Young (Mixed) pauses: the streaming windows removed the +2 GB old-gen promotion and the humongous 1M-row arrays that drove them. They are **reduced, not eliminated** — a 2M rollback still costs a couple of sub-half-second pauses. The *largest* pauses in the run (550–669 ms) are now during the **synthetic 2M ingest flood** (both plugins recording ~4M rows in ~15 s), not the rollback.
+**Verdict.** On the same ClickHouse, Spyglass rolls back **~3× faster** than CoreProtect, holds a real **20 TPS**, and its worst single tick is **17 ms** vs CoreProtect's **617 ms** on-main freeze. The headline change is the **GC freeze is gone**: the apply is now allocation-free (primitive columns + count results), so the rollback never promotes to old gen and never triggers a Mixed collection. A warmed, steady-state 2M rollback fires **at most one ~9 ms pure-young GC, frequently zero** (verified directly against `logs/gc-bench.log`). The old 300–425 ms pauses were Mixed collections; they now only appear transiently when an *unrelated* Mixed cycle is already in flight — JVM metaspace warmup right after boot, or the bench's synthetic 2M-ingest flood firing immediately before the rollback — neither of which is the rollback's own allocation, and neither of which coincides with a rollback in normal play.
 
 ## Results
 
 ```
 Size  | Blocks    | SG rollback        | SG undo            | CP rollback        | CP restore
 ------|-----------|--------------------|--------------------|--------------------|-------------------
-run1  | 2,000,376 |  8.4s 237829 bps   |  8.8s 226159 bps   | 12.7s 157622 bps   | 12.8s 156732 bps
-run2  | 2,000,376 |  9.3s 215140 bps   |  8.4s 239079 bps   | 12.2s 164383 bps   | 15.3s 130966 bps
+2M    | 2,000,376 |  3.8s 520254 bps   |  3.5s 572517 bps   | 11.6s 172595 bps   | 12.6s 159240 bps
 
 MSPT 5 s-AVG during op (max-of-avgs / avg ms):
-run1  | SG rb 6.6/5.3 | SG undo 5.5/4.7 | CP rb 100.6/44.1 | CP restore 102.5/46.7
-run2  | SG rb 6.1/5.5 | SG undo 6.6/5.5 | CP rb  85.1/36.7 | CP restore 122.2/55.9
+2M    | SG rb 4.4/4.1 | SG undo 4.1/4.0 | CP rb 83.6/36.4 | CP restore 102.2/46.5
 
 WORST SINGLE TICK (MSPT 5 s-window max):
-run1  | SG rb 128.8 | SG undo  40.2 | CP rb 276.0 | CP restore 370.8
-run2  | SG rb  74.6 | SG undo 157.4 | CP rb 269.0 | CP restore 603.4
+2M    | SG rb 17.3 | SG undo 16.4 | CP rb 617.3 | CP restore 399.0
 
-TPS (min/avg, derived from MSPT — see caveat):
-run1  | SG rb 20.0/20.0 | SG undo 20.0/20.0 | CP rb 9.9/17.1 | CP restore 9.8/16.9
-run2  | SG rb 20.0/20.0 | SG undo 20.0/20.0 | CP rb 11.8/18.0 | CP restore 8.2/15.7
+TPS (min/avg, derived from MSPT):
+2M    | SG rb 20.0/20.0 | SG undo 20.0/20.0 | CP rb 12.0/18.1 | CP restore 9.8/16.9
 ```
 
-**Where Spyglass spends the rollback** (engine instrumentation, run1 / run2): `query = 5117 / 5492 ms (~60 %)` ≫ `collect = 441 / 377 ms` `prewarm = 34 / 54 ms` `apply = 2296 / 2808 ms (~28 %)`, over **16 windows / 64 chunks**. Still **read-bound on ClickHouse**, not write-bound — the off-main apply is ~2.5 s of the ~9 s. Undo is the same shape in reverse (`query ≈ 4.8–5.3 s`, `apply ≈ 2.3 s`).
+**Where Spyglass spends the rollback** (engine instrumentation, #67): `apply = 2649 ms (~80 %)` ≫ `query = 617 ms` `collect = 199 ms` `prewarm = 28 ms`, over **16 windows / 64 chunks**. The lean decode flipped the profile — a 2M rollback used to be **read-bound** (`query ≈ 6.1 s`); now the read is ~0.6 s and the **off-main, tick-paced apply** is the wall-clock floor (it yields a tick between chunk batches to hold 20 TPS, so wall-clock tracks tick count, not CPU). Undo is the same shape in reverse.
 
-## The GC story (the 2026-06-03 caveat, re-measured)
+## The GC story — the freeze, eliminated (#67)
 
-The old run's headline warning was that the throughput-tuned config (`rollback-page-size`/`rollback-batch-size`/`rollback-undo-cap` = 1M/1M/10M) provoked **3 stop-the-world pauses of 518 / 758 / 849 ms** during a single 2M rollback, by promoting ~2 GB to old gen (the 2M-element live undo list) and allocating humongous 1M-element arrays straight into old gen.
+The 2026-06-03 run provoked **3 stop-the-world pauses up to 849 ms**; the pre-#67 object path was down to **one or two ~300–425 ms Young (Mixed) pauses**. Both were the same mechanism: the rollback **promoted to old gen** under Aikar's `MaxTenuringThreshold=1` (the live undo list, then the per-window effect + `RollbackResult` object graph), which pushed old gen past `InitiatingHeapOccupancyPercent=15` and made G1 run **Mixed** collections mid-rollback.
 
-Those dials are gone. Correlating `logs/gc-bench.log` pause timestamps against the rollback window (the `Spyglass rollback … 8313ms` / `9208ms` log lines):
+#67 makes the apply **allocation-free** for the common case: simple block-replaces are primitive columns + an interned palette, and results are counts, not objects. The rollback no longer grows old gen, so it never triggers a Mixed cycle. Correlating `logs/gc-bench.log` against the rollback window:
 
-| | 2026-06-03 (tuned) | **2026-06-18 (current)** |
+| | object path (this session) | **#67 columnar (steady state)** |
 |---|---|---|
-| Pauses > 500 ms *during the rollback* | 3 | **0** |
-| Worst pause *during the rollback* | **849 ms** | **307 / 424 ms** |
-| Apply windows | 1 (one 1M-row page) | **16 (bounded ~500 K)** |
-| Largest pause anywhere in the run | 849 ms (rollback) | 550 / 669 ms (**ingest flood**, not rollback) |
+| GC pauses *during the rollback* | 4 Young (Mixed) | **0–1 Young (Normal)** |
+| Worst pause *during the rollback* | **360 ms** | **≤9.4 ms** (often 0) |
+| Pause type | Mixed (evacuates old gen) | pure-young, or none |
+| Old-gen growth from the apply | ~+160 MB/run | **~0** |
 
-So the rollback no longer drives the old gen up by 2 GB; it streams. What remains: a 2M rollback still pays one or two ~300–425 ms Young (Mixed) pauses (the apply churns short-lived per-window effect objects), and the heaviest pauses in a bench *run* are now the ingest of 2M edits recorded by both plugins at once — an artificial condition you'd never hit in normal play.
+Measured directly: four consecutive warmed 2M rollbacks logged **9.4 ms, 0, 0, 0** pauses. The only way to still see a ~180 ms pause is to roll back *while a Mixed cycle started by something else is already in flight* — JVM metaspace warmup in the first seconds after boot, or the bench's synthetic 2M-ingest flood (both plugins recording ~4M rows in ~15 s) firing immediately before the rollback. That pause is the unrelated cycle's cost, not the rollback's allocation, and the two don't coincide in normal play.
 
 ### The TPS metric still has the same blind spot
 

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -47,6 +47,7 @@ import net.medievalrp.spyglass.api.event.QuitRecord;
 import net.medievalrp.spyglass.api.event.RollbackOpRecord;
 import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
 import net.medievalrp.spyglass.api.event.TeleportRecord;
 import net.medievalrp.spyglass.api.query.Flag;
 import net.medievalrp.spyglass.api.query.QueryPredicate;
@@ -183,6 +184,22 @@ public final class ClickHouseRecordStore implements RecordStore {
             "entity_type", "entity_id", "entity_nbt",
             "entity_killer_type", "entity_damage_cause");
 
+    // The strictly-needed columns to build a RollbackEffect (#67). Drops
+    // everything streamRollbackEffects never reads vs ROLLBACK_COLUMNS:
+    // expires_at, origin_*, all source_*, server, target, plus the
+    // container_type/amount and entity killer/damage columns that the
+    // effect constructors ignore. Cutting the SELECT this far trims both
+    // the wire response and the per-row decode — there is no Origin,
+    // Source, or record wrapper to allocate, only the effect's own fields.
+    private static final List<String> LEAN_ROLLBACK_COLUMNS = List.of(
+            "id", "event", "occurred",
+            "location_world_id", "location_world_name",
+            "location_x", "location_y", "location_z",
+            "before_material", "before_blockdata", "before_extras",
+            "after_material", "after_blockdata", "after_extras",
+            "slot", "before_item", "after_item",
+            "entity_type", "entity_id", "entity_nbt");
+
     private final PredicateToSql predicateToSql = new PredicateToSql();
     private final Client client;
     private final TableSchema tableSchema;
@@ -192,6 +209,7 @@ public final class ClickHouseRecordStore implements RecordStore {
     private final String summarySelect;
     private final String fullSelect;
     private final String rollbackSelect;
+    private final String leanRollbackSelect;
 
     public ClickHouseRecordStore(String host, int port, String database, String table,
                                  String user, String password, boolean ssl) {
@@ -201,6 +219,7 @@ public final class ClickHouseRecordStore implements RecordStore {
         this.summarySelect = String.join(", ", concat(COMMON_COLUMNS, SUMMARY_EXTRAS));
         this.fullSelect = String.join(", ", concat(COMMON_COLUMNS, SUMMARY_EXTRAS, HEAVY_COLUMNS));
         this.rollbackSelect = String.join(", ", ROLLBACK_COLUMNS);
+        this.leanRollbackSelect = String.join(", ", LEAN_ROLLBACK_COLUMNS);
 
         this.client = new Client.Builder()
                 .addEndpoint((ssl ? "https" : "http") + "://" + host + ":" + port)
@@ -531,8 +550,106 @@ public final class ClickHouseRecordStore implements RecordStore {
         //      damage/projectile/dismount/name). Cuts the network
         //      response ~3x on block-heavy rollbacks and the
         //      decodeRow cost in lockstep.
+        String sql = buildRollbackSql(rollbackSelect, request, cursor, windowLimit);
+
+        // Streaming reader — pulls rows from CH as they arrive instead
+        // of materializing every GenericRecord up front. The OOM at
+        // 1M-row pageSize was the queryAll() materialization step
+        // allocating ~1 KB+ per intermediate GenericRecord (the JDBC
+        // shape, not our slim EventRecord). With Records, each row is
+        // decoded into an EventRecord and the GenericRecord becomes
+        // immediately collectible — peak heap is bounded by the slim
+        // post-decode List<EventRecord> instead of the heavy
+        // intermediate set. Memory at 1M rows drops from ~3 GB to
+        // ~100-200 MB.
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int rowCount = 0;
+        try (Records rows = client.queryRecords(sql).get()) {
+            for (GenericRecord row : rows) {
+                rowCount++;
+                EventRecord record = decodeRow(row, true);
+                if (record != null) {
+                    sink.accept(record);
+                }
+                // Always advance the cursor — even if decodeRow returned
+                // null (unknown event). Skipping over an undecodable row
+                // is fine; freezing on it would loop forever.
+                lastOccurred = row.getInstant("occurred");
+                lastId = net.medievalrp.spyglass.api.util.EventIds.uuidOf(row.getLong("id"));
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("ClickHouse paginated query interrupted", ie);
+        } catch (java.util.concurrent.ExecutionException ex) {
+            Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+            throw new RuntimeException("ClickHouse paginated query failed: " + cause.getMessage(), cause);
+        } catch (RuntimeException ex) {
+            throw new RuntimeException("ClickHouse paginated query failed: " + ex.getMessage(), ex);
+        } catch (Exception ex) {
+            // Records.close() declares throws Exception. In practice
+            // the close path swallows recoverable errors and only
+            // throws on an unrecoverable client-side IO problem.
+            throw new RuntimeException("ClickHouse paginated query close failed: " + ex.getMessage(), ex);
+        }
+        return (rowCount == windowLimit && lastOccurred != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
+    @Override
+    public QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                  int windowLimit, boolean rollback,
+                                                  RollbackEffectSink sink) {
+        // Allocation-lean rollback read (#67): same keyset-streamed scan as
+        // streamRollback, but the trimmed LEAN_ROLLBACK_COLUMNS SELECT and
+        // decodeEffect build only the RollbackEffect the engine applies —
+        // no EventRecord, Origin, Source, server/target, or expires_at is
+        // ever materialized. On a 2M-block rollback that removes the bulk
+        // of the per-row object graph (the firehose that, surviving one
+        // young GC under MaxTenuringThreshold=1, promoted to old gen and
+        // forced the Mixed-GC freeze).
+        String sql = buildRollbackSql(leanRollbackSelect, request, cursor, windowLimit);
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int rowCount = 0;
+        try (Records rows = client.queryRecords(sql).get()) {
+            for (GenericRecord row : rows) {
+                rowCount++;
+                // occurred/id are the cursor coordinates; read per row so a
+                // window that drains mid-page checkpoints at the right
+                // keyset position. Both are transient unless retained as
+                // the window's last.
+                Instant occurred = row.getInstant("occurred");
+                UUID id = net.medievalrp.spyglass.api.util.EventIds.uuidOf(row.getLong("id"));
+                emitEffect(row, rollback, occurred, id, sink);
+                lastOccurred = occurred;
+                lastId = id;
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("ClickHouse paginated query interrupted", ie);
+        } catch (java.util.concurrent.ExecutionException ex) {
+            Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+            throw new RuntimeException("ClickHouse paginated query failed: " + cause.getMessage(), cause);
+        } catch (RuntimeException ex) {
+            throw new RuntimeException("ClickHouse paginated query failed: " + ex.getMessage(), ex);
+        } catch (Exception ex) {
+            throw new RuntimeException("ClickHouse paginated query close failed: " + ex.getMessage(), ex);
+        }
+        return (rowCount == windowLimit && lastOccurred != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
+    // Shared rollback SQL: rollbackable-event filter, keyset cursor in the
+    // configured sort direction, and the spill-to-disk SETTINGS that keep a
+    // large LIMIT under CH's default 1 GiB per-query budget. The only
+    // difference between the record and effect readers is the column list.
+    private String buildRollbackSql(String select, QueryRequest request,
+                                    QueryPage.Cursor cursor, int windowLimit) {
         StringBuilder sql = new StringBuilder("SELECT ")
-                .append(rollbackSelect)
+                .append(select)
                 .append(" FROM ").append(qualifiedTable);
 
         List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
@@ -574,50 +691,91 @@ public final class ClickHouseRecordStore implements RecordStore {
                 .append(", max_memory_usage_for_user = 0")
                 .append(", max_bytes_before_external_sort = 1073741824")
                 .append(", max_bytes_before_external_group_by = 1073741824");
+        return sql.toString();
+    }
 
-        // Streaming reader — pulls rows from CH as they arrive instead
-        // of materializing every GenericRecord up front. The OOM at
-        // 1M-row pageSize was the queryAll() materialization step
-        // allocating ~1 KB+ per intermediate GenericRecord (the JDBC
-        // shape, not our slim EventRecord). With Records, each row is
-        // decoded into an EventRecord and the GenericRecord becomes
-        // immediately collectible — peak heap is bounded by the slim
-        // post-decode List<EventRecord> instead of the heavy
-        // intermediate set. Memory at 1M rows drops from ~3 GB to
-        // ~100-200 MB.
-        Instant lastOccurred = null;
-        UUID lastId = null;
-        int rowCount = 0;
-        try (Records rows = client.queryRecords(sql.toString()).get()) {
-            for (GenericRecord row : rows) {
-                rowCount++;
-                EventRecord record = decodeRow(row, true);
-                if (record != null) {
-                    sink.accept(record);
-                }
-                // Always advance the cursor — even if decodeRow returned
-                // null (unknown event). Skipping over an undecodable row
-                // is fine; freezing on it would loop forever.
-                lastOccurred = row.getInstant("occurred");
-                lastId = net.medievalrp.spyglass.api.util.EventIds.uuidOf(row.getLong("id"));
-            }
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("ClickHouse paginated query interrupted", ie);
-        } catch (java.util.concurrent.ExecutionException ex) {
-            Throwable cause = ex.getCause() == null ? ex : ex.getCause();
-            throw new RuntimeException("ClickHouse paginated query failed: " + cause.getMessage(), cause);
-        } catch (RuntimeException ex) {
-            throw new RuntimeException("ClickHouse paginated query failed: " + ex.getMessage(), ex);
-        } catch (Exception ex) {
-            // Records.close() declares throws Exception. In practice
-            // the close path swallows recoverable errors and only
-            // throws on an unrecoverable client-side IO problem.
-            throw new RuntimeException("ClickHouse paginated query close failed: " + ex.getMessage(), ex);
+    // Emit one row to the sink in the requested direction (rollback reverts;
+    // restore re-applies / undoes an undo). A simple block-replace goes out
+    // as primitives via sink.block() — no effect or snapshot object built;
+    // everything else builds the effect and uses sink.complex(). Mirrors the
+    // per-record-type Rollbackable.rollbackEffect()/restoreEffect() logic
+    // exactly — keep the two in lockstep.
+    private void emitEffect(GenericRecord row, boolean rollback,
+                            Instant occurred, UUID id, RollbackEffectSink sink) {
+        String event = row.getString("event");
+        Class<? extends EventRecord> clazz = EventCatalog.recordClassOf(event);
+        if (clazz == null) {
+            sink.skip(occurred, id);
+            return;
         }
-        return (rowCount == windowLimit && lastOccurred != null)
-                ? new QueryPage.Cursor(lastOccurred, lastId)
-                : null;
+        if (clazz == BlockBreakRecord.class || clazz == BlockPlaceRecord.class) {
+            // Resolve which stored state we write (replacement) vs. expect
+            // currently present (expectedCurrent). rollback writes the
+            // before-state expecting the after-state; restore is the inverse.
+            String replMaterial;
+            String replData;
+            String replExtras;
+            String expData;
+            if (rollback) {
+                replMaterial = row.getString("before_material");
+                replData = row.getString("before_blockdata");
+                replExtras = row.getString("before_extras");
+                expData = row.getString("after_blockdata");
+            } else {
+                replMaterial = row.getString("after_material");
+                replData = row.getString("after_blockdata");
+                replExtras = row.getString("after_extras");
+                expData = row.getString("before_blockdata");
+            }
+            boolean simple = replData != null && (replExtras == null || replExtras.isEmpty());
+            if (simple) {
+                sink.block(row.getUUID("location_world_id"),
+                        row.getInteger("location_x"),
+                        row.getInteger("location_y"),
+                        row.getInteger("location_z"),
+                        replData, expData, occurred, id);
+                return;
+            }
+            // Tile-entity payload (or malformed block-data): object path.
+            BlockLocation location = readLocation(row);
+            BlockSnapshot replacement = BsonBlobs.decodeBlockSnapshotFromColumns(
+                    replMaterial, replData, replExtras);
+            BlockSnapshot expected = rollback
+                    ? BsonBlobs.decodeBlockSnapshotFromColumns(
+                            row.getString("after_material"), row.getString("after_blockdata"),
+                            row.getString("after_extras"))
+                    : BsonBlobs.decodeBlockSnapshotFromColumns(
+                            row.getString("before_material"), row.getString("before_blockdata"),
+                            row.getString("before_extras"));
+            sink.complex(new RollbackEffect.BlockReplace(location, expected, replacement), occurred, id);
+            return;
+        }
+        if (clazz == ContainerDepositRecord.class || clazz == ContainerWithdrawRecord.class) {
+            BlockLocation location = readLocation(row);
+            int slot = row.getInteger("slot");
+            StoredItem before = BsonBlobs.decodeStoredItem(row.getString("before_item"));
+            StoredItem after = BsonBlobs.decodeStoredItem(row.getString("after_item"));
+            sink.complex(rollback
+                    ? new RollbackEffect.ContainerSlotWrite(location, slot, after, before)
+                    : new RollbackEffect.ContainerSlotWrite(location, slot, before, after), occurred, id);
+            return;
+        }
+        if (clazz == EntityDeathRecord.class) {
+            BlockLocation location = readLocation(row);
+            String entityType = row.getString("entity_type");
+            if (rollback) {
+                sink.complex(new RollbackEffect.EntitySpawn(location, entityType,
+                        row.getString("entity_nbt")), occurred, id);
+            } else {
+                UUID entityId = row.getUUID("entity_id");
+                sink.complex(new RollbackEffect.EntityRemove(location, entityType,
+                        entityId == null ? null : entityId.toString()), occurred, id);
+            }
+            return;
+        }
+        // Non-rollbackable row (the event filter should exclude these);
+        // advance the cursor past it.
+        sink.skip(occurred, id);
     }
 
     private static String chTimestamp(Instant when) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
@@ -1,10 +1,15 @@
 package net.medievalrp.spyglass.plugin.storage;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.query.QueryRequest;
 import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.Rollbackable;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public interface RecordStore extends AutoCloseable {
@@ -76,6 +81,82 @@ public interface RecordStore extends AutoCloseable {
             sink.accept(record);
         }
         return page.next();
+    }
+
+    /**
+     * Per-row consumer for {@link #streamRollbackEffects}. Split so the
+     * common case — a simple block-replace — never allocates an effect
+     * object on the hot path (#67): {@link #block} takes primitives and the
+     * two block-data strings the apply engine actually reads, which the
+     * caller folds straight into columnar arrays. Anything that needs more
+     * (a tile-entity block, a container slot, an entity) arrives via
+     * {@link #complex} as a built {@link RollbackEffect}; a matched-but-not
+     * -rollbackable row arrives via {@link #skip}. Every method carries the
+     * row's {@code occurred}/{@code id} so the caller can checkpoint its
+     * cursor at window granularity.
+     */
+    interface RollbackEffectSink {
+        /**
+         * A simple (no tile-entity payload) single-block replace.
+         *
+         * @param blockData    the block-data string to write
+         * @param expectedData the expected-current block-data for the #27
+         *     state check, or {@code null} for no check
+         */
+        void block(UUID worldId, int x, int y, int z, String blockData,
+                   @Nullable String expectedData, Instant occurred, UUID id);
+
+        /** Any effect that isn't a simple block-replace (rare). */
+        void complex(RollbackEffect effect, Instant occurred, UUID id);
+
+        /** A matched row that is not rollbackable — advance the cursor only. */
+        void skip(Instant occurred, UUID id);
+    }
+
+    /**
+     * Stream a rollback read window as resolved {@link RollbackEffect}s
+     * rather than {@link EventRecord}s (#67). This is the allocation-lean
+     * path the rollback/undo engine uses: the only objects a backend must
+     * build per row are the effect itself (location + the one or two block
+     * snapshots / item / entity fields it needs) plus the cursor
+     * coordinates — never the record wrapper, origin, source, server, or
+     * target. On a million-row rollback that is the difference between
+     * rebuilding a full forensic record graph per row and rebuilding only
+     * what the apply engine reads, which keeps young-gen churn low enough
+     * that windows die before Aikar's {@code MaxTenuringThreshold=1}
+     * promotes them (the cause of the large-rollback GC freeze).
+     *
+     * @param rollback {@code true} to emit {@link Rollbackable#rollbackEffect()}
+     *     (revert), {@code false} to emit {@link Rollbackable#restoreEffect()}
+     *     (re-apply / undo-of-undo).
+     *
+     * <p>Default implementation rides {@link #streamRollback}: it builds the
+     * full record and resolves the effect from it, so stores without a lean
+     * decoder (Mongo, in-memory test doubles) keep working at today's
+     * allocation profile. The ClickHouse backend overrides it with a
+     * trimmed-column decode that never materializes the record.
+     */
+    default QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                   int windowLimit, boolean rollback,
+                                                   RollbackEffectSink sink) {
+        return streamRollback(request, cursor, windowLimit, record -> {
+            if (!(record instanceof Rollbackable rollbackable)) {
+                sink.skip(record.occurred(), record.id());
+                return;
+            }
+            RollbackEffect effect = rollback
+                    ? rollbackable.rollbackEffect()
+                    : rollbackable.restoreEffect();
+            if (effect instanceof RollbackEffect.BlockReplace br
+                    && br.replacement() != null && br.replacement().simple()) {
+                net.medievalrp.spyglass.api.util.BlockLocation loc = br.location();
+                String expected = br.expectedCurrent() == null ? null : br.expectedCurrent().blockData();
+                sink.block(loc.worldId(), loc.x(), loc.y(), loc.z(),
+                        br.replacement().blockData(), expected, record.occurred(), record.id());
+            } else {
+                sink.complex(effect, record.occurred(), record.id());
+            }
+        });
     }
 
     /**

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
@@ -53,6 +53,24 @@ public final class SynthesizingRecordStore implements RecordStore {
     }
 
     @Override
+    public QueryPage.Cursor streamRollback(QueryRequest request, QueryPage.Cursor cursor,
+                                           int windowLimit, RecordSink sink) {
+        // Rollback reads the real recorded events, never the synthesized
+        // rolled-* receipts — you don't roll back a rollback's audit
+        // trail. Delegate straight through so the concrete store's
+        // wire-streaming reader is used (the interface default would route
+        // back through queryPage and materialize a full page list).
+        return delegate.streamRollback(request, cursor, windowLimit, sink);
+    }
+
+    @Override
+    public QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                  int windowLimit, boolean rollback,
+                                                  RollbackEffectSink sink) {
+        return delegate.streamRollbackEffects(request, cursor, windowLimit, rollback, sink);
+    }
+
+    @Override
     public void close() {
         delegate.close();
     }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -377,6 +377,134 @@ class ClickHouseRecordStoreIT {
                 .containsExactlyElementsOf(pagedIds);
         assertThat(streamRounds).isEqualTo(pageRounds);
     }
+
+    @Test
+    void streamRollbackEffectsDecodesSimpleBlocksLeanly() {
+        // #67: the rollback engine reads via streamRollbackEffects. A simple
+        // block-replace must arrive as primitives (block-data + expected),
+        // in the correct direction; a tile-entity block falls back to a
+        // built effect.
+        Instant base = Instant.now().minusSeconds(600);
+        BlockSnapshot air = new BlockSnapshot(
+                org.bukkit.Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot stone = new BlockSnapshot(
+                org.bukkit.Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot sign = new BlockSnapshot(
+                org.bukkit.Material.OAK_SIGN, "minecraft:oak_sign",
+                List.of(), List.of("hello"), List.of(), List.of(), null);
+        Origin origin = Origin.player();
+        Source source = Source.player(ALICE, "Alice");
+        List<EventRecord> records = new java.util.ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            records.add(new BlockBreakRecord(UUID.randomUUID(), "break",
+                    base.plusSeconds(i), base.plusSeconds(7200), origin, source,
+                    new BlockLocation(WORLD, "world", i, 64, 0), "test", "STONE", stone, air));
+        }
+        // A tile-entity block: before=sign (non-simple) => object path.
+        records.add(new BlockBreakRecord(UUID.randomUUID(), "break",
+                base.plusSeconds(10), base.plusSeconds(7200), origin, source,
+                new BlockLocation(WORLD, "world", 50, 64, 0), "test", "OAK_SIGN", sign, air));
+        store.save(records);
+        flushAsyncInserts();
+
+        QueryRequest request = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "break")),
+                Sort.NEWEST_FIRST, 1000, EnumSet.noneOf(Flag.class), false);
+
+        List<int[]> blocks = new java.util.ArrayList<>();
+        List<String> blockData = new java.util.ArrayList<>();
+        List<String> expectedData = new java.util.ArrayList<>();
+        java.util.List<net.medievalrp.spyglass.api.rollback.RollbackEffect> complex =
+                new java.util.ArrayList<>();
+        int[] skips = {0};
+        store.streamRollbackEffects(request, null, 1000, true,
+                new RecordStore.RollbackEffectSink() {
+                    @Override
+                    public void block(UUID world, int x, int y, int z, String data,
+                                      String expected, Instant occurred, UUID id) {
+                        blocks.add(new int[]{x, y, z});
+                        blockData.add(data);
+                        expectedData.add(expected);
+                    }
+
+                    @Override
+                    public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                                        Instant occurred, UUID id) {
+                        complex.add(effect);
+                    }
+
+                    @Override
+                    public void skip(Instant occurred, UUID id) {
+                        skips[0]++;
+                    }
+                });
+
+        assertThat(blocks).hasSize(5);
+        assertThat(skips[0]).isZero();
+        // rollback writes the before-state (stone), expects the after (air).
+        assertThat(blockData).containsOnly("minecraft:stone");
+        assertThat(expectedData).containsOnly("minecraft:air");
+        // The sign block fell back to a built BlockReplace effect.
+        assertThat(complex).hasSize(1);
+        assertThat(complex.get(0))
+                .isInstanceOf(net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace.class);
+    }
+
+    @Test
+    void streamRollbackEffectsDecodesContainerSlotWriteToComplex() {
+        // #67: a container deposit is not a block-replace — it must decode
+        // to a ContainerSlotWrite via the object path, in the right
+        // direction (rollback undoes the deposit: expect the deposited item,
+        // restore the pre-deposit slot).
+        Instant now = Instant.now().minusSeconds(120);
+        net.medievalrp.spyglass.api.event.StoredItem diamond =
+                new net.medievalrp.spyglass.api.event.StoredItem(3, "DIAMOND", "data");
+        store.save(List.of(new net.medievalrp.spyglass.api.event.ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", now, now.plusSeconds(7200),
+                Origin.player(), Source.player(ALICE, "Alice"),
+                new BlockLocation(WORLD, "world", 5, 64, 5), "test", "CHEST",
+                "CHEST", 3, 1, null, diamond)));
+        flushAsyncInserts();
+
+        QueryRequest request = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "deposit")),
+                Sort.NEWEST_FIRST, 1000, EnumSet.noneOf(Flag.class), false);
+
+        java.util.List<net.medievalrp.spyglass.api.rollback.RollbackEffect> complex =
+                new java.util.ArrayList<>();
+        int[] blocks = {0};
+        store.streamRollbackEffects(request, null, 1000, true,
+                new RecordStore.RollbackEffectSink() {
+                    @Override
+                    public void block(UUID world, int x, int y, int z, String data,
+                                      String expected, Instant occurred, UUID id) {
+                        blocks[0]++;
+                    }
+
+                    @Override
+                    public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                                        Instant occurred, UUID id) {
+                        complex.add(effect);
+                    }
+
+                    @Override
+                    public void skip(Instant occurred, UUID id) {
+                    }
+                });
+
+        assertThat(blocks[0]).isZero();
+        assertThat(complex).hasSize(1);
+        assertThat(complex.get(0))
+                .isInstanceOf(net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite.class);
+        var slot = (net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite) complex.get(0);
+        assertThat(slot.slot()).isEqualTo(3);
+        // rollback: expect the deposited diamond, restore the empty slot.
+        assertThat(slot.expectedCurrent()).isNotNull();
+        assertThat(slot.expectedCurrent().material()).isEqualTo("DIAMOND");
+        assertThat(slot.replacement()).isNull();
+    }
     @Test
     void itemFieldFiltersPostFilterInMemory() {
         // #32: iname:/ilore:/ench: paths live inside opaque BSON on CH.

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/StreamRollbackEffectsTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/StreamRollbackEffectsTest.java
@@ -1,0 +1,168 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the default {@link RecordStore#streamRollbackEffects} routing (#67):
+ * simple block-replaces are emitted as primitives, tile-entity blocks as
+ * objects, non-rollbackable rows as cursor-only skips — in the requested
+ * direction. The ClickHouse lean override is exercised by its IT.
+ */
+class StreamRollbackEffectsTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+
+    private static BlockSnapshot snapshot(Material material, String data) {
+        return new BlockSnapshot(material, data, List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    private static BlockSnapshot signSnapshot() {
+        // Non-empty signFront => not simple => object path.
+        return new BlockSnapshot(Material.OAK_SIGN, "minecraft:oak_sign",
+                List.of(), List.of("line"), List.of(), List.of(), null);
+    }
+
+    private static BlockBreakRecord block(BlockSnapshot before, BlockSnapshot after, int x) {
+        Instant now = Instant.now();
+        return new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD, "world", x, 64, 0), "srv", "STONE", before, after);
+    }
+
+    private static ChatRecord chat() {
+        Instant now = Instant.now();
+        return new ChatRecord(UUID.randomUUID(), "chat", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Bob"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv", null,
+                "hello", List.of(), java.util.Map.of());
+    }
+
+    /** In-memory store: the default streamRollbackEffects rides query(). */
+    private static RecordStore storeOf(List<EventRecord> records) {
+        return new RecordStore() {
+            @Override
+            public void save(List<EventRecord> r) {
+            }
+
+            @Override
+            public QueryResult query(QueryRequest request) {
+                return new QueryResult(records, List.of());
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        record Block(UUID world, int x, int y, int z, String data, String expected) {
+        }
+
+        final List<Block> blocks = new java.util.ArrayList<>();
+        final List<RollbackEffect> complex = new java.util.ArrayList<>();
+        int skips;
+
+        @Override
+        public void block(UUID world, int x, int y, int z, String data, String expected,
+                          Instant occurred, UUID id) {
+            blocks.add(new Block(world, x, y, z, data, expected));
+        }
+
+        @Override
+        public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+            complex.add(effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skips++;
+        }
+    }
+
+    private static QueryRequest request() {
+        return new QueryRequest(List.of(), Sort.NEWEST_FIRST, 1000,
+                java.util.EnumSet.noneOf(net.medievalrp.spyglass.api.query.Flag.class), false);
+    }
+
+    @Test
+    void routesSimpleBlockToPrimitivesInRollbackDirection() {
+        BlockSnapshot stone = snapshot(Material.STONE, "minecraft:stone");
+        BlockSnapshot air = snapshot(Material.AIR, "minecraft:air");
+        // A break: before=stone, after=air.
+        RecordStore store = storeOf(List.of(block(stone, air, 7)));
+        CapturingSink sink = new CapturingSink();
+
+        store.streamRollbackEffects(request(), null, 1000, true, sink);
+
+        assertThat(sink.complex).isEmpty();
+        assertThat(sink.skips).isZero();
+        assertThat(sink.blocks).hasSize(1);
+        CapturingSink.Block b = sink.blocks.get(0);
+        // rollback writes the before-state (stone), expects the after (air).
+        assertThat(b.data()).isEqualTo("minecraft:stone");
+        assertThat(b.expected()).isEqualTo("minecraft:air");
+        assertThat(b.x()).isEqualTo(7);
+        assertThat(b.world()).isEqualTo(WORLD);
+    }
+
+    @Test
+    void restoreDirectionSwapsReplacementAndExpected() {
+        BlockSnapshot stone = snapshot(Material.STONE, "minecraft:stone");
+        BlockSnapshot air = snapshot(Material.AIR, "minecraft:air");
+        RecordStore store = storeOf(List.of(block(stone, air, 0)));
+        CapturingSink sink = new CapturingSink();
+
+        store.streamRollbackEffects(request(), null, 1000, false, sink);
+
+        assertThat(sink.blocks).hasSize(1);
+        CapturingSink.Block b = sink.blocks.get(0);
+        // restore re-applies the after-state (air), expects the before (stone).
+        assertThat(b.data()).isEqualTo("minecraft:air");
+        assertThat(b.expected()).isEqualTo("minecraft:stone");
+    }
+
+    @Test
+    void routesTileEntityBlockToComplex() {
+        BlockSnapshot sign = signSnapshot();
+        BlockSnapshot air = snapshot(Material.AIR, "minecraft:air");
+        // before=sign (non-simple); rollback writes the sign => object path.
+        RecordStore store = storeOf(List.of(block(sign, air, 0)));
+        CapturingSink sink = new CapturingSink();
+
+        store.streamRollbackEffects(request(), null, 1000, true, sink);
+
+        assertThat(sink.blocks).isEmpty();
+        assertThat(sink.complex).hasSize(1);
+        assertThat(sink.complex.get(0)).isInstanceOf(RollbackEffect.BlockReplace.class);
+    }
+
+    @Test
+    void routesNonRollbackableToSkip() {
+        RecordStore store = storeOf(List.of(chat()));
+        CapturingSink sink = new CapturingSink();
+
+        store.streamRollbackEffects(request(), null, 1000, true, sink);
+
+        assertThat(sink.blocks).isEmpty();
+        assertThat(sink.complex).isEmpty();
+        assertThat(sink.skips).isEqualTo(1);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -21,7 +21,6 @@ import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.medievalrp.spyglass.api.SpyglassApi;
-import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.param.ParamParseException;
 import net.medievalrp.spyglass.api.query.Flag;
 import net.medievalrp.spyglass.api.query.QueryRequest;
@@ -29,9 +28,9 @@ import net.medievalrp.spyglass.api.query.QueryResult;
 import net.medievalrp.spyglass.api.query.Sort;
 import net.medievalrp.spyglass.api.rollback.RollbackEffect;
 import net.medievalrp.spyglass.api.rollback.RollbackResult;
-import net.medievalrp.spyglass.api.rollback.Rollbackable;
 import net.medievalrp.spyglass.plugin.command.param.QueryStringParser;
 import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.rollback.BlockColumns;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import net.medievalrp.spyglass.plugin.storage.UndoReferenceBson;
@@ -306,9 +305,10 @@ public final class RollbackService {
         // the audit emit).
         long queryNanos = 0L, collectNanos = 0L, prewarmNanos = 0L, applyNanos = 0L;
         int windowCount = 0;
-        // Chunks already pre-warmed by an earlier window of this job.
+        // Chunks already pre-warmed by an earlier window of this job. Doubles
+        // as the distinct-chunk tally for the summary (every effect's chunk
+        // lands here), so no separate string set is built per applied cell.
         Map<UUID, Set<Long>> warmedChunks = new HashMap<>();
-        java.util.HashSet<String> chunkKeys = new java.util.HashSet<>();
         java.util.LinkedHashMap<String, Integer> skipCounts = new java.util.LinkedHashMap<>();
         // Per-world bounding boxes of applied writes — recorded into the
         // operation reference so search synthesis (#22) and operators
@@ -335,7 +335,8 @@ public final class RollbackService {
         // the per-page query+collect+prewarm stalls that cost 13.8s at
         // the old 20K default.
         final int windowSize = applyWindow;
-        final Window readDone = new Window(List.of(), java.util.Map.of(), null, 0);
+        final Window readDone = new Window(
+                java.util.Map.of(), List.of(), java.util.Map.of(), java.util.Map.of(), null, 0);
         // One slot, not two: a deeper queue only grows the in-flight
         // live set that MTT=1 promotes (see applyWindow). One queued +
         // one applying + one accumulating still overlaps read with
@@ -353,20 +354,44 @@ public final class RollbackService {
                     return t;
                 });
         final net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor readerStart = startCursor;
+        final boolean rollbackDirection = mode == RollbackMode.ROLLBACK;
         reader.execute(() -> {
-            WindowAccumulator acc = new WindowAccumulator(windowSize, mode, foldNanos);
+            WindowAccumulator acc = new WindowAccumulator(windowSize, foldNanos);
             try {
                 net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor cur = readerStart;
                 int seen = 0;
                 while (!cancelFlag.get() && seen < hardLimit) {
                     int ask = Math.min(pageSize, hardLimit - seen);
                     int seenBefore = acc.seen();
-                    cur = store.streamRollback(request, cur, ask, record -> {
-                        acc.take(record);
-                        if (acc.full()) {
-                            putWindow(ready, acc.drain());
-                        }
-                    });
+                    // Lean effect stream (#67): the store folds each row
+                    // straight into the columnar accumulator in the requested
+                    // direction. A simple block-replace arrives as primitives
+                    // (no effect/snapshot object); only tile-entity blocks,
+                    // containers, and entities arrive as built effects.
+                    cur = store.streamRollbackEffects(request, cur, ask, rollbackDirection,
+                            new net.medievalrp.spyglass.plugin.storage.RecordStore.RollbackEffectSink() {
+                                @Override
+                                public void block(UUID worldId, int x, int y, int z, String blockData,
+                                                  String expectedData, Instant occurred, UUID id) {
+                                    acc.block(worldId, x, y, z, blockData, expectedData, occurred, id);
+                                    if (acc.full()) {
+                                        putWindow(ready, acc.drain());
+                                    }
+                                }
+
+                                @Override
+                                public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+                                    acc.complex(effect, occurred, id);
+                                    if (acc.full()) {
+                                        putWindow(ready, acc.drain());
+                                    }
+                                }
+
+                                @Override
+                                public void skip(Instant occurred, UUID id) {
+                                    acc.skip(occurred, id);
+                                }
+                            });
                     int got = acc.seen() - seenBefore;
                     seen += got;
                     if (cur == null || got < ask) {
@@ -410,7 +435,7 @@ public final class RollbackService {
                 }
                 windowCount++;
                 totalSeen += window.seenDelta();
-                if (window.effects().isEmpty()) {
+                if (window.isEmpty()) {
                     checkpoint(job, window, totalApplied, totalSkipped, resumeRequest);
                     continue;
                 }
@@ -438,19 +463,43 @@ public final class RollbackService {
                     preWarmChunks(freshChunks).join();
                     prewarmNanos += System.nanoTime() - tPrewarm;
                 }
-                List<RollbackResult> results;
+                // Apply: simple block-replaces via the columnar engine path
+                // (counts only, no per-cell objects — the apply-side fix that
+                // stops old-gen promotion under MTT=1), the rare complex
+                // effects via the object path. Both run their writes off-main
+                // and yield by tick, so TPS stays at ~20.
                 long tApply = System.nanoTime();
+                RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                List<RollbackResult> complexResults = List.of();
                 try {
-                    java.util.concurrent.CompletableFuture<List<RollbackResult>> fut =
-                            new java.util.concurrent.CompletableFuture<>();
-                    List<RollbackEffect> effects = window.effects();
-                    support.onMainThread(() ->
-                            engine.applyAllChunked(effects, sender, support, batchSize, cancelFlag)
-                                    .whenComplete((r, err) -> {
-                                        if (err != null) fut.completeExceptionally(err);
-                                        else fut.complete(r);
-                                    }));
-                    results = fut.join();
+                    for (Map.Entry<UUID, BlockColumns> worldCols : window.columnsByWorld().entrySet()) {
+                        BlockColumns cols = worldCols.getValue();
+                        if (cols.count() == 0) {
+                            continue;
+                        }
+                        UUID worldId = worldCols.getKey();
+                        java.util.concurrent.CompletableFuture<RollbackEngine.ApplyCounts> fut =
+                                new java.util.concurrent.CompletableFuture<>();
+                        support.onMainThread(() ->
+                                engine.applyColumnsChunked(worldId, cols, sender, support, batchSize, cancelFlag)
+                                        .whenComplete((c, err) -> {
+                                            if (err != null) fut.completeExceptionally(err);
+                                            else fut.complete(c);
+                                        }));
+                        counts.add(fut.join());
+                    }
+                    if (!window.complex().isEmpty()) {
+                        java.util.concurrent.CompletableFuture<List<RollbackResult>> fut =
+                                new java.util.concurrent.CompletableFuture<>();
+                        List<RollbackEffect> complex = window.complex();
+                        support.onMainThread(() ->
+                                engine.applyAllChunked(complex, sender, support, batchSize, cancelFlag)
+                                        .whenComplete((r, err) -> {
+                                            if (err != null) fut.completeExceptionally(err);
+                                            else fut.complete(r);
+                                        }));
+                        complexResults = fut.join();
+                    }
                 } catch (java.util.concurrent.CompletionException ex) {
                     Throwable cause = ex.getCause() == null ? ex : ex.getCause();
                     logger.warning("Spyglass " + mode.label() + " window apply failed: " + cause);
@@ -460,22 +509,18 @@ public final class RollbackService {
                     return;
                 }
                 applyNanos += System.nanoTime() - tApply;
-                for (RollbackResult r : results) {
-                    if (r instanceof RollbackResult.Applied applied) {
+                // Columnar block-replace counts.
+                totalApplied += (int) counts.applied;
+                totalSkipped += (int) counts.skipped();
+                totalErrors += (int) counts.errors();
+                mergeSkip(skipCounts, "block changed", counts.blockChanged);
+                mergeSkip(skipCounts, "Unparseable blockdata", counts.unparseable);
+                mergeSkip(skipCounts, "invalid location", counts.invalidLocation);
+                mergeSkip(skipCounts, "Cancelled by operator", counts.cancelled);
+                // The rare complex effects' per-cell results.
+                for (RollbackResult r : complexResults) {
+                    if (r instanceof RollbackResult.Applied) {
                         totalApplied++;
-                        BlockLocation loc = locationOf(applied.effect());
-                        if (loc != null) {
-                            chunkKeys.add(loc.worldId() + ":"
-                                    + (loc.x() >> 4) + ":" + (loc.z() >> 4));
-                            int[] box = worldBoxes.computeIfAbsent(loc.worldId(), k ->
-                                    new int[]{loc.x(), loc.y(), loc.z(), loc.x(), loc.y(), loc.z()});
-                            box[0] = Math.min(box[0], loc.x());
-                            box[1] = Math.min(box[1], loc.y());
-                            box[2] = Math.min(box[2], loc.z());
-                            box[3] = Math.max(box[3], loc.x());
-                            box[4] = Math.max(box[4], loc.y());
-                            box[5] = Math.max(box[5], loc.z());
-                        }
                     } else if (r instanceof RollbackResult.Skipped skipped) {
                         totalSkipped++;
                         skipCounts.merge(skipped.reason().message(), 1, Integer::sum);
@@ -486,6 +531,24 @@ public final class RollbackService {
                             totalErrors++;
                         }
                     }
+                }
+                // Per-world bounding box of this window (block + complex). A
+                // superset of the applied box — safe: the op reference is only
+                // emitted when applied > 0, and synthesis (#22) re-filters
+                // within it.
+                for (Map.Entry<UUID, int[]> boxEntry : window.boxes().entrySet()) {
+                    int[] wb = boxEntry.getValue();
+                    worldBoxes.merge(boxEntry.getKey(),
+                            new int[]{wb[0], wb[1], wb[2], wb[3], wb[4], wb[5]},
+                            (a, b) -> {
+                                a[0] = Math.min(a[0], b[0]);
+                                a[1] = Math.min(a[1], b[1]);
+                                a[2] = Math.min(a[2], b[2]);
+                                a[3] = Math.max(a[3], b[3]);
+                                a[4] = Math.max(a[4], b[4]);
+                                a[5] = Math.max(a[5], b[5]);
+                                return a;
+                            });
                 }
                 job.appliedCount.set(totalApplied);
                 job.skippedCount.set(totalSkipped);
@@ -529,13 +592,18 @@ public final class RollbackService {
         // Folding happens on the reader thread; pull its tally into the
         // collect slot so the breakdown still accounts for it.
         collectNanos = foldNanos.get();
+        // Distinct chunks touched == every chunk that was pre-warmed.
+        int chunkCount = 0;
+        for (Set<Long> set : warmedChunks.values()) {
+            chunkCount += set.size();
+        }
         logger.info(String.format(
                 "Spyglass %s %s timings: query=%dms collect=%dms prewarm=%dms apply=%dms"
                         + " | %d windows, %d chunks, %d applied, %dms total",
                 mode.label(), job.shortId(),
                 queryNanos / 1_000_000L, collectNanos / 1_000_000L,
                 prewarmNanos / 1_000_000L, applyNanos / 1_000_000L,
-                windowCount, chunkKeys.size(), totalApplied, elapsedMs));
+                windowCount, chunkCount, totalApplied, elapsedMs));
         // One reference blob serves both audiences: the undo ledger row
         // (written before the summary so "done" implies /undo is ready)
         // and the rollback-op event record that searches synthesize the
@@ -592,7 +660,7 @@ public final class RollbackService {
             }
         }
         Summary summary = new Summary(totalApplied, totalSkipped, totalErrors,
-                chunkKeys.size(), elapsedMs);
+                chunkCount, elapsedMs);
         boolean undoUnavailableFinal = undoUnavailable;
         support.onMainThread(() -> deliverStreamingSummary(
                 sender, mode, summary, skipCounts, undoUnavailableFinal));
@@ -664,15 +732,29 @@ public final class RollbackService {
         this.applyWindow = Math.max(1, windowSize);
     }
 
-    // One bounded unit of the streaming pipeline (#19): the effects to
-    // apply, the chunks to pre-warm for them, the keyset position after
-    // the last record folded in (for crash-resume checkpoints), and how
-    // many records were consumed to build it.
-    private record Window(List<RollbackEffect> effects,
+    // One bounded unit of the streaming pipeline (#19, #67): simple
+    // block-replaces as columnar primitives (per world), the rare complex
+    // effects as objects, the chunks to pre-warm, the per-world bounding
+    // box, the keyset position after the last row folded in (for
+    // crash-resume checkpoints), and how many rows were consumed to build it.
+    private record Window(Map<UUID, BlockColumns> columnsByWorld,
+                          List<RollbackEffect> complex,
                           Map<UUID, Set<Long>> prewarmChunks,
+                          Map<UUID, int[]> boxes,
                           @org.jetbrains.annotations.Nullable
                           net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor cursorAfter,
                           int seenDelta) {
+        boolean isEmpty() {
+            if (!complex.isEmpty()) {
+                return false;
+            }
+            for (BlockColumns cols : columnsByWorld.values()) {
+                if (cols.count() > 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     // Unwinds the reader when the consumer tore the pipeline down.
@@ -691,61 +773,104 @@ public final class RollbackService {
         }
     }
 
-    // Folds streamed records into windows on the reader thread: effect
-    // direction by mode, prewarm chunk set, and the running keyset
-    // position. Single-threaded by construction (one reader).
+    // Folds streamed rows into windows on the reader thread (#67): simple
+    // block-replaces into primitive BlockColumns (per world, with an
+    // interned block-data palette), complex effects into an object list,
+    // plus the prewarm chunk set, per-world box, and keyset position.
+    // Single-threaded by construction (one reader).
     private static final class WindowAccumulator {
 
-        // Snapshot canonicalizer. Each decoded record carries its own
-        // BlockSnapshot copies, and effects outlive the record while
-        // their window queues for apply — under stock Aikar flags
-        // (MTT=1) those survivors promote to old gen, and two ~120 B
-        // snapshots per effect were most of the promoted bytes. Bulk
-        // rollbacks repeat a handful of materials, so interning turns
-        // the retained pair into two pointers. Bounded: high-entropy
-        // data (unique container payloads) resets the epoch instead of
-        // growing without limit.
+        // Snapshot canonicalizer for the COMPLEX path only: those effects
+        // outlive the row while their window queues for apply, and under
+        // stock Aikar flags (MTT=1) survivors promote to old gen. Simple
+        // blocks never reach here — they are primitives in BlockColumns,
+        // and their block-data is interned in the column palette instead.
         private static final int INTERN_CAP = 4096;
         private final Map<net.medievalrp.spyglass.api.event.BlockSnapshot,
                 net.medievalrp.spyglass.api.event.BlockSnapshot> snapshotCache = new HashMap<>();
 
         private final int windowSize;
-        private final RollbackMode mode;
+        private final int columnInitialCapacity;
         private final java.util.concurrent.atomic.AtomicLong foldNanos;
-        private List<RollbackEffect> effects;
+        private Map<UUID, BlockColumns> columnsByWorld;
+        private List<RollbackEffect> complex;
         private Map<UUID, Set<Long>> prewarm;
+        private Map<UUID, int[]> boxes;
         private java.time.Instant lastOccurred;
         private UUID lastId;
+        private int effectCount;
         private int seen;
         private int drainedSeen;
 
-        WindowAccumulator(int windowSize, RollbackMode mode,
+        WindowAccumulator(int windowSize,
                           java.util.concurrent.atomic.AtomicLong foldNanos) {
             this.windowSize = windowSize;
-            this.mode = mode;
+            // Single-world is the norm, so the first world's columns grow to
+            // ~windowSize; cap the initial allocation so a rare many-world
+            // window doesn't over-reserve per world.
+            this.columnInitialCapacity = Math.min(Math.max(windowSize, 16), 16_384);
             this.foldNanos = foldNanos;
-            this.effects = new ArrayList<>();
-            this.prewarm = new HashMap<>();
+            reset();
         }
 
-        void take(EventRecord record) {
+        private void reset() {
+            this.columnsByWorld = new HashMap<>();
+            this.complex = new ArrayList<>();
+            this.prewarm = new HashMap<>();
+            this.boxes = new HashMap<>();
+            this.effectCount = 0;
+        }
+
+        // Simple block-replace: folded straight into primitive columns,
+        // block-data interned to a palette id — no effect/snapshot object.
+        void block(UUID worldId, int x, int y, int z, String blockData,
+                   String expectedData, java.time.Instant occurred, UUID id) {
             long start = System.nanoTime();
             seen++;
-            // Always advance the cursor, even for non-rollbackable
-            // records — freezing on one would re-read it forever.
-            lastOccurred = record.occurred();
-            lastId = record.id();
-            if (record instanceof Rollbackable rollbackable) {
-                effects.add(intern(mode == RollbackMode.ROLLBACK
-                        ? rollbackable.rollbackEffect()
-                        : rollbackable.restoreEffect()));
-                BlockLocation loc = record.location();
-                if (loc != null) {
-                    long packed = ((long) (loc.x() >> 4) << 32) | ((loc.z() >> 4) & 0xFFFFFFFFL);
-                    prewarm.computeIfAbsent(loc.worldId(), k -> new HashSet<>()).add(packed);
-                }
+            effectCount++;
+            lastOccurred = occurred;
+            lastId = id;
+            BlockColumns cols = columnsByWorld.computeIfAbsent(
+                    worldId, k -> new BlockColumns(columnInitialCapacity));
+            cols.add(x, y, z, cols.intern(blockData), cols.intern(expectedData));
+            recordChunkAndBox(worldId, x, y, z);
+            foldNanos.addAndGet(System.nanoTime() - start);
+        }
+
+        // Container / entity / tile-entity block / custom: kept as an
+        // object and applied via the proven object path.
+        void complex(RollbackEffect effect, java.time.Instant occurred, UUID id) {
+            long start = System.nanoTime();
+            seen++;
+            effectCount++;
+            lastOccurred = occurred;
+            lastId = id;
+            complex.add(intern(effect));
+            BlockLocation loc = locationOf(effect);
+            if (loc != null) {
+                recordChunkAndBox(loc.worldId(), loc.x(), loc.y(), loc.z());
             }
             foldNanos.addAndGet(System.nanoTime() - start);
+        }
+
+        // A matched-but-not-rollbackable row: advance the cursor only.
+        // Freezing on one would re-read it forever.
+        void skip(java.time.Instant occurred, UUID id) {
+            seen++;
+            lastOccurred = occurred;
+            lastId = id;
+        }
+
+        private void recordChunkAndBox(UUID worldId, int x, int y, int z) {
+            long packed = ((long) (x >> 4) << 32) | ((z >> 4) & 0xFFFFFFFFL);
+            prewarm.computeIfAbsent(worldId, k -> new HashSet<>()).add(packed);
+            int[] box = boxes.computeIfAbsent(worldId, k -> new int[]{x, y, z, x, y, z});
+            if (x < box[0]) box[0] = x;
+            if (y < box[1]) box[1] = y;
+            if (z < box[2]) box[2] = z;
+            if (x > box[3]) box[3] = x;
+            if (y > box[4]) box[4] = y;
+            if (z > box[5]) box[5] = z;
         }
 
         private RollbackEffect intern(RollbackEffect effect) {
@@ -772,7 +897,7 @@ public final class RollbackService {
         }
 
         boolean full() {
-            return effects.size() >= windowSize;
+            return effectCount >= windowSize;
         }
 
         int seen() {
@@ -784,15 +909,21 @@ public final class RollbackService {
         }
 
         Window drain() {
-            Window window = new Window(effects, prewarm,
+            Window window = new Window(columnsByWorld, complex, prewarm, boxes,
                     lastOccurred == null ? null
                             : new net.medievalrp.spyglass.plugin.storage.QueryPage.Cursor(
                                     lastOccurred, lastId),
                     seen - drainedSeen);
             drainedSeen = seen;
-            effects = new ArrayList<>();
-            prewarm = new HashMap<>();
+            reset();
             return window;
+        }
+    }
+
+    private static void mergeSkip(java.util.LinkedHashMap<String, Integer> skipCounts,
+                                  String reason, long count) {
+        if (count > 0) {
+            skipCounts.merge(reason, (int) count, Integer::sum);
         }
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/BlockColumns.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/BlockColumns.java
@@ -1,0 +1,242 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Primitive, columnar representation of one world's <em>simple</em>
+ * block-replace effects within a rollback window (#67).
+ *
+ * <p>The object path represents a window as a {@code List} of
+ * {@link net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace},
+ * each holding two {@link net.medievalrp.spyglass.api.event.BlockSnapshot}
+ * objects, and produces a {@code RollbackResult} object per cell. On a
+ * 2M-block rollback that graph lives across the multi-tick apply and, under
+ * Aikar's {@code MaxTenuringThreshold=1}, promotes wholesale to old gen —
+ * the allocation that forces the Mixed-GC freeze.
+ *
+ * <p>This holds the same information as parallel {@code int} arrays plus a
+ * small interned block-data palette: a cell is its x/y/z, the palette id of
+ * the block-data to write, and the palette id of the expected-current
+ * block-data ({@code -1} = no expected check). The footprint is
+ * reference-free primitives that cost almost nothing to evacuate and never
+ * drag a graph into old gen, so a window can survive a young GC without
+ * provoking a Mixed collection. Only blocks with no tile-entity payload
+ * (the overwhelming majority of a bulk rollback) live here; containers,
+ * signs, banners, entities, and non-simple blocks stay on the object path.
+ *
+ * <p>Not thread-safe: filled by the single reader thread, then read — after
+ * the queue handoff establishes happens-before — by the apply threads.
+ */
+@ApiStatus.Internal
+public final class BlockColumns {
+
+    private int[] xs;
+    private int[] ys;
+    private int[] zs;
+    private int[] replId;
+    private int[] expId;
+    private int count;
+
+    // Tiny per-window palette: a bulk rollback repeats a handful of
+    // materials, so each cell carries an int id into this shared table
+    // instead of its own block-data string reference.
+    private String[] palette = new String[16];
+    private int paletteCount;
+    private final Map<String, Integer> paletteIndex = new HashMap<>();
+
+    // Running bounds for the physics-suppression box and the operation
+    // reference, accumulated on add() so neither needs a second pass.
+    private int minX = Integer.MAX_VALUE;
+    private int minY = Integer.MAX_VALUE;
+    private int minZ = Integer.MAX_VALUE;
+    private int maxX = Integer.MIN_VALUE;
+    private int maxY = Integer.MIN_VALUE;
+    private int maxZ = Integer.MIN_VALUE;
+
+    public BlockColumns(int initialCapacity) {
+        int cap = Math.max(16, initialCapacity);
+        xs = new int[cap];
+        ys = new int[cap];
+        zs = new int[cap];
+        replId = new int[cap];
+        expId = new int[cap];
+    }
+
+    /** Intern a block-data string to its palette id; {@code -1} for null. */
+    public int intern(@Nullable String blockData) {
+        if (blockData == null) {
+            return -1;
+        }
+        Integer existing = paletteIndex.get(blockData);
+        if (existing != null) {
+            return existing;
+        }
+        if (paletteCount == palette.length) {
+            palette = Arrays.copyOf(palette, palette.length * 2);
+        }
+        int id = paletteCount;
+        palette[paletteCount++] = blockData;
+        paletteIndex.put(blockData, id);
+        return id;
+    }
+
+    /** Append one cell. {@code expPaletteId} of {@code -1} = no expected check. */
+    public void add(int x, int y, int z, int replPaletteId, int expPaletteId) {
+        if (count == xs.length) {
+            int n = xs.length * 2;
+            xs = Arrays.copyOf(xs, n);
+            ys = Arrays.copyOf(ys, n);
+            zs = Arrays.copyOf(zs, n);
+            replId = Arrays.copyOf(replId, n);
+            expId = Arrays.copyOf(expId, n);
+        }
+        xs[count] = x;
+        ys[count] = y;
+        zs[count] = z;
+        replId[count] = replPaletteId;
+        expId[count] = expPaletteId;
+        count++;
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (z < minZ) minZ = z;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+        if (z > maxZ) maxZ = z;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    /** Distinct block-data strings interned so far (the dedup factor). */
+    public int paletteSize() {
+        return paletteCount;
+    }
+
+    public int x(int i) {
+        return xs[i];
+    }
+
+    public int y(int i) {
+        return ys[i];
+    }
+
+    public int z(int i) {
+        return zs[i];
+    }
+
+    /** Block-data string to write at cell {@code i}. */
+    public String replData(int i) {
+        return palette[replId[i]];
+    }
+
+    /** Expected-current block-data at cell {@code i}, or null for no check. */
+    @Nullable
+    public String expData(int i) {
+        int id = expId[i];
+        return id < 0 ? null : palette[id];
+    }
+
+    public int minX() {
+        return minX;
+    }
+
+    public int minY() {
+        return minY;
+    }
+
+    public int minZ() {
+        return minZ;
+    }
+
+    public int maxX() {
+        return maxX;
+    }
+
+    public int maxY() {
+        return maxY;
+    }
+
+    public int maxZ() {
+        return maxZ;
+    }
+
+    /**
+     * Permutation of {@code [0, count)} ordered by chunk (cx, then cz) then
+     * ascending Y — identical ordering to the object path's comparator.
+     * Bottom-up Y matters: restoring a support block before the gravel above
+     * it stops the gravel re-spawning as a falling entity. Packs
+     * (relCx, relCz, y, index) into a long and sorts primitives — no boxing
+     * on the hot path; falls back to a boxed comparator only when the
+     * coordinate span is too wide to pack (multi-region rollbacks).
+     */
+    public int[] chunkSortedOrder() {
+        int n = count;
+        int[] order = new int[n];
+        for (int i = 0; i < n; i++) {
+            order[i] = i;
+        }
+        if (n <= 1) {
+            return order;
+        }
+        int loCx = Integer.MAX_VALUE;
+        int hiCx = Integer.MIN_VALUE;
+        int loCz = Integer.MAX_VALUE;
+        int hiCz = Integer.MIN_VALUE;
+        for (int i = 0; i < n; i++) {
+            int cx = xs[i] >> 4;
+            int cz = zs[i] >> 4;
+            if (cx < loCx) loCx = cx;
+            if (cx > hiCx) hiCx = cx;
+            if (cz < loCz) loCz = cz;
+            if (cz > hiCz) hiCz = cz;
+        }
+        int cxBits = bitsFor((long) hiCx - loCx);
+        int czBits = bitsFor((long) hiCz - loCz);
+        int yBits = bitsFor((long) maxY - minY);
+        int idxBits = bitsFor(n - 1);
+        if (cxBits + czBits + yBits + idxBits <= 62) {
+            int yPos = idxBits;
+            int czPos = yPos + yBits;
+            int cxPos = czPos + czBits;
+            long idxMask = (1L << idxBits) - 1L;
+            long[] composite = new long[n];
+            for (int i = 0; i < n; i++) {
+                long relCx = (long) ((xs[i] >> 4) - loCx);
+                long relCz = (long) ((zs[i] >> 4) - loCz);
+                long relY = (long) (ys[i] - minY);
+                composite[i] = (relCx << cxPos) | (relCz << czPos) | (relY << yPos) | (long) i;
+            }
+            Arrays.sort(composite);
+            for (int i = 0; i < n; i++) {
+                order[i] = (int) (composite[i] & idxMask);
+            }
+            return order;
+        }
+        Integer[] boxed = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            boxed[i] = i;
+        }
+        Arrays.sort(boxed, (a, b) -> {
+            int c = Integer.compare(xs[a] >> 4, xs[b] >> 4);
+            if (c != 0) return c;
+            c = Integer.compare(zs[a] >> 4, zs[b] >> 4);
+            if (c != 0) return c;
+            c = Integer.compare(ys[a], ys[b]);
+            if (c != 0) return c;
+            return Integer.compare(a, b);
+        });
+        for (int i = 0; i < n; i++) {
+            order[i] = boxed[i];
+        }
+        return order;
+    }
+
+    private static int bitsFor(long span) {
+        return span <= 0L ? 0 : 64 - Long.numberOfLeadingZeros(span);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -836,6 +836,294 @@ public final class RollbackEngine {
         }
     }
 
+    // ----- Columnar apply (#67) -----------------------------------------
+    // Allocation-lean apply for simple block-replaces: reads coordinates and
+    // block-data from primitive BlockColumns + a shared palette instead of a
+    // List<RollbackEffect.BlockReplace>, and reports counts instead of a
+    // RollbackResult object per cell. Same off-main chunk cadence as
+    // applyChunkBatchParallel (TPS stays at ~20), but a 2M window's live set
+    // is now reference-free primitives that don't promote to old gen under
+    // MaxTenuringThreshold=1 — removing the apply-side allocation that, with
+    // lean decode, was the last driver of the Mixed-GC rollback freeze.
+    // Containers/signs/banners/entities/custom effects stay on the object
+    // path (runContainerAndLeftover / applyAllChunked) — they are rare and
+    // need per-cell state handling the columnar fast path deliberately omits.
+
+    /** Counts produced by {@link #applyColumnsChunked} — no per-cell objects. */
+    @ApiStatus.Internal
+    public static final class ApplyCounts {
+        public long applied;
+        public long blockChanged;
+        public long unparseable;
+        public long invalidLocation;
+        public long cancelled;
+
+        /** Total skipped across every benign and error reason. */
+        public long skipped() {
+            return blockChanged + unparseable + invalidLocation + cancelled;
+        }
+
+        /** Skips that are real failures (parity with RollbackReason.Error). */
+        public long errors() {
+            return unparseable + cancelled;
+        }
+
+        public void add(ApplyCounts other) {
+            applied += other.applied;
+            blockChanged += other.blockChanged;
+            unparseable += other.unparseable;
+            invalidLocation += other.invalidLocation;
+            cancelled += other.cancelled;
+        }
+    }
+
+    public CompletableFuture<ApplyCounts> applyColumnsChunked(
+            UUID worldId, BlockColumns cols, CommandSender sender,
+            ServiceSupport scheduler, int batchSize,
+            java.util.concurrent.atomic.AtomicBoolean cancelFlag) {
+        if (!Bukkit.isPrimaryThread()) {
+            throw new IllegalStateException("RollbackEngine.applyColumnsChunked must run on the main thread.");
+        }
+        CompletableFuture<ApplyCounts> done = new CompletableFuture<>();
+        ApplyCounts counts = new ApplyCounts();
+        int total = cols.count();
+        if (total == 0) {
+            done.complete(counts);
+            return done;
+        }
+        World world = Bukkit.getWorld(worldId);
+        if (world == null) {
+            counts.invalidLocation += total;
+            done.complete(counts);
+            return done;
+        }
+        if (physicsBlocker != null) {
+            long handle = physicsBlocker.enter(worldId,
+                    cols.minX(), cols.minY(), cols.minZ(),
+                    cols.maxX(), cols.maxY(), cols.maxZ());
+            done.whenComplete((r, t) -> physicsBlocker.exit(handle));
+        }
+        // Sort off-main (chunk-grouped, bottom-up Y), then apply on main.
+        Runnable stageOne = () -> {
+            int[] order = cols.chunkSortedOrder();
+            scheduler.onMainThread(() -> applyColumnBatch(
+                    world, cols, order, 0, counts, sender, scheduler, batchSize, done, cancelFlag));
+        };
+        if (worldWriteExecutor != null) {
+            java.util.concurrent.CompletableFuture.runAsync(stageOne, worldWriteExecutor);
+        } else {
+            stageOne.run();
+        }
+        return done;
+    }
+
+    private void applyColumnBatch(World world, BlockColumns cols, int[] order, int from,
+                                  ApplyCounts counts, CommandSender sender, ServiceSupport scheduler,
+                                  int batchSize, CompletableFuture<ApplyCounts> done,
+                                  java.util.concurrent.atomic.AtomicBoolean cancelFlag) {
+        int total = cols.count();
+        if (cancelFlag.get()) {
+            counts.cancelled += total - from;
+            done.complete(counts);
+            return;
+        }
+        if (from >= total) {
+            done.complete(counts);
+            return;
+        }
+        final org.bukkit.plugin.Plugin ticketHolder = chunkTicketHolder;
+        int parallelism = Math.max(1, worldWriteParallelism);
+        int maxBatchChunks = Math.max(parallelism, worldWriteBatchChunks);
+        // Resolve up to maxBatchChunks chunks on the main thread: contiguous
+        // runs of the sorted order share a chunk, so one walk groups them.
+        List<ColChunk> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
+        int cursor = from;
+        while (cursor < total && batch.size() < maxBatchChunks) {
+            int startIdx = order[cursor];
+            int cx = cols.x(startIdx) >> 4;
+            int cz = cols.z(startIdx) >> 4;
+            int rangeEnd = cursor + 1;
+            while (rangeEnd < total) {
+                int idx = order[rangeEnd];
+                if ((cols.x(idx) >> 4) != cx || (cols.z(idx) >> 4) != cz) {
+                    break;
+                }
+                rangeEnd++;
+            }
+            boolean ticketAdded = false;
+            if (ticketHolder != null) {
+                try {
+                    ticketAdded = world.addPluginChunkTicket(cx, cz, ticketHolder);
+                } catch (Throwable ignored) {
+                }
+            }
+            ChunkDirectWriter.ChunkContext ctx = ChunkDirectWriter.prepareChunk(world, cx, cz);
+            batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
+            cursor = rangeEnd;
+        }
+        final int batchEnd = cursor;
+
+        // Main-thread post: finish/resend each chunk, release tickets, sum
+        // the per-chunk counts, then advance. The heavy palette writes
+        // already happened off-main (or inline when no executor is wired).
+        Runnable afterWrites = () -> scheduler.onMainThread(() -> {
+            for (ColChunk cc : batch) {
+                if (cc.ctx == null) {
+                    // prepareChunk failed: write this chunk's cells on the
+                    // main thread via the single-block fallback.
+                    writeColumnChunkMain(world, cols, order, cc);
+                } else {
+                    ChunkDirectWriter.finishChunk(cc.ctx);
+                }
+                try {
+                    ChunkResender.resend(world, cc.cx, cc.cz);
+                } catch (RuntimeException ignored) {
+                }
+                if (cc.ticketAdded && ticketHolder != null) {
+                    try {
+                        world.removePluginChunkTicket(cc.cx, cc.cz, ticketHolder);
+                    } catch (Throwable ignored) {
+                    }
+                }
+                counts.applied += cc.applied;
+                counts.blockChanged += cc.blockChanged;
+                counts.unparseable += cc.unparseable;
+            }
+            if (sender instanceof Player p) {
+                p.sendActionBar(Component.text("Rolling back " + batchEnd + " / " + total));
+            }
+            applyColumnBatch(world, cols, order, batchEnd, counts, sender, scheduler, batchSize, done, cancelFlag);
+        });
+
+        if (worldWriteExecutor != null) {
+            @SuppressWarnings("unchecked")
+            CompletableFuture<Void>[] futures = new CompletableFuture[batch.size()];
+            for (int b = 0; b < batch.size(); b++) {
+                ColChunk cc = batch.get(b);
+                futures[b] = java.util.concurrent.CompletableFuture.runAsync(
+                        () -> writeColumnChunk(cols, order, cc), worldWriteExecutor);
+            }
+            java.util.concurrent.CompletableFuture.allOf(futures)
+                    .whenComplete((v, t) -> afterWrites.run());
+        } else {
+            for (ColChunk cc : batch) {
+                writeColumnChunk(cols, order, cc);
+            }
+            afterWrites.run();
+        }
+    }
+
+    // Worker-thread half: parse + write one chunk's cells from the columns.
+    // No chunk-system access (prepareChunk already ran on main) — only the
+    // locked LevelChunkSection write. Counts land on the work unit.
+    private void writeColumnChunk(BlockColumns cols, int[] order, ColChunk cc) {
+        if (cc.ctx == null) {
+            return; // handled on the main thread in writeColumnChunkMain
+        }
+        long applied = 0;
+        long changed = 0;
+        long unparse = 0;
+        for (int k = cc.from; k < cc.rangeEnd; k++) {
+            int idx = order[k];
+            int x = cols.x(idx);
+            int y = cols.y(idx);
+            int z = cols.z(idx);
+            org.bukkit.block.data.BlockData bd;
+            try {
+                bd = blockDataFor(cols.replData(idx));
+            } catch (RuntimeException thrown) {
+                bd = null;
+            }
+            if (bd == null) {
+                unparse++;
+                continue;
+            }
+            String exp = cols.expData(idx);
+            if (exp != null) {
+                org.bukkit.block.data.BlockData expBd;
+                try {
+                    expBd = blockDataFor(exp);
+                } catch (RuntimeException thrown) {
+                    expBd = null;
+                }
+                // Expected-state check (#27): skip when the live block no
+                // longer matches what this op expected — same semantics as
+                // the object path's matches().
+                if (expBd != null && cc.ctx.currentStateMatches(x, y, z, expBd) == 0) {
+                    changed++;
+                    continue;
+                }
+            }
+            cc.ctx.writeBlock(x, y, z, bd);
+            applied++;
+        }
+        cc.applied = applied;
+        cc.blockChanged = changed;
+        cc.unparseable = unparse;
+    }
+
+    // Main-thread fallback for a chunk whose prepareChunk failed: single
+    // block writes with the expected check via Bukkit.
+    private void writeColumnChunkMain(World world, BlockColumns cols, int[] order, ColChunk cc) {
+        long applied = 0;
+        long changed = 0;
+        long unparse = 0;
+        for (int k = cc.from; k < cc.rangeEnd; k++) {
+            int idx = order[k];
+            int x = cols.x(idx);
+            int y = cols.y(idx);
+            int z = cols.z(idx);
+            org.bukkit.block.data.BlockData bd;
+            try {
+                bd = blockDataFor(cols.replData(idx));
+            } catch (RuntimeException thrown) {
+                bd = null;
+            }
+            if (bd == null) {
+                unparse++;
+                continue;
+            }
+            String exp = cols.expData(idx);
+            if (exp != null) {
+                Block block = world.getBlockAt(x, y, z);
+                if (!exp.equals(block.getBlockData().getAsString())) {
+                    changed++;
+                    continue;
+                }
+            }
+            ChunkDirectWriter.writeBlock(world, x, y, z, bd);
+            applied++;
+        }
+        cc.applied = applied;
+        cc.blockChanged = changed;
+        cc.unparseable = unparse;
+    }
+
+    // One chunk's columnar work unit: the [from, rangeEnd) slice of the
+    // sorted order that lands in (cx, cz). counts are filled by the worker
+    // (ctx != null) or the main fallback (ctx == null) before being summed.
+    private static final class ColChunk {
+        final int cx;
+        final int cz;
+        final int from;
+        final int rangeEnd;
+        final ChunkDirectWriter.ChunkContext ctx;
+        final boolean ticketAdded;
+        volatile long applied;
+        volatile long blockChanged;
+        volatile long unparseable;
+
+        ColChunk(int cx, int cz, int from, int rangeEnd,
+                 ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded) {
+            this.cx = cx;
+            this.cz = cz;
+            this.from = from;
+            this.rangeEnd = rangeEnd;
+            this.ctx = ctx;
+            this.ticketAdded = ticketAdded;
+        }
+    }
+
 
     // Containers (one batched apply per chest) then leftover entity
     // ops and custom handlers. Called once the block phase drains.

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -30,6 +30,7 @@ import net.medievalrp.spyglass.api.rollback.RollbackReason;
 import net.medievalrp.spyglass.api.rollback.RollbackResult;
 import net.medievalrp.spyglass.plugin.command.param.QueryStringParser;
 import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.rollback.BlockColumns;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import org.bukkit.Material;
@@ -38,6 +39,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 class RollbackServiceTest {
+
+    // Fixed world so records fold into one per-world BlockColumns (#67);
+    // the columnar accumulator keys columns by world id.
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
 
     private static BlockBreakRecord record() {
         Instant now = Instant.now();
@@ -52,7 +57,7 @@ class RollbackServiceTest {
                 now.plusSeconds(60),
                 Origin.player(),
                 Source.player(UUID.randomUUID(), "Alice"),
-                new net.medievalrp.spyglass.api.util.BlockLocation(UUID.randomUUID(), "world", 0, 64, 0),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 0, 64, 0),
                 "test",
                 "STONE",
                 stone,
@@ -90,6 +95,15 @@ class RollbackServiceTest {
             // per-test queryPage stubs keep driving the pipeline.
             when(store.streamRollback(any(QueryRequest.class), any(),
                     org.mockito.ArgumentMatchers.anyInt(), any()))
+                    .thenCallRealMethod();
+            // #67: the rollback path now reads via streamRollbackEffects.
+            // Its default delegates to streamRollback (above) → queryPage
+            // and resolves each record to its RollbackEffect exactly as a
+            // lean backend would, so the per-test queryPage stubs keep
+            // driving the pipeline. Run the real default.
+            when(store.streamRollbackEffects(any(QueryRequest.class), any(),
+                    org.mockito.ArgumentMatchers.anyInt(),
+                    org.mockito.ArgumentMatchers.anyBoolean(), any()))
                     .thenCallRealMethod();
             RollbackJobQueue queue = new RollbackJobQueue();
             // Test resume store points at a temp dir — no real
@@ -140,6 +154,33 @@ class RollbackServiceTest {
                 10_000,
                 java.util.EnumSet.noneOf(Flag.class),
                 true);
+    }
+
+    // Simple block-replaces (the test records) take the columnar engine
+    // path (#67): stub it to report every folded cell as applied.
+    private static void stubColumnarApplied(TestFixture fixture) {
+        when(fixture.engine.applyColumnsChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    BlockColumns cols = inv.getArgument(1);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
+                });
+    }
+
+    // Stub the columnar path to skip every folded cell as "block changed".
+    private static void stubColumnarBlockChanged(TestFixture fixture) {
+        when(fixture.engine.applyColumnsChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    BlockColumns cols = inv.getArgument(1);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.blockChanged = cols.count();
+                    return CompletableFuture.completedFuture(counts);
+                });
     }
 
     // #49: resume must replay the marker's RESOLVED request — never
@@ -266,12 +307,7 @@ class RollbackServiceTest {
         // (terminator), so the loop exits cleanly after one iteration.
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
 
         fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
@@ -291,19 +327,16 @@ class RollbackServiceTest {
         BlockBreakRecord c = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(a, b, c), null));
-        when(fixture.engine.applyAllChunked(
+        when(fixture.engine.applyColumnsChunked(
                 ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
                 .thenAnswer(inv -> {
-                    List<RollbackEffect> effects = inv.getArgument(0);
-                    // One-effect windows: the apply must never see more than
-                    // the configured window's worth of effects at once.
-                    assertThat(effects).hasSize(1);
-                    RollbackEffect.BlockReplace replace = (RollbackEffect.BlockReplace) effects.get(0);
-                    RollbackEffect inverse = new RollbackEffect.BlockReplace(
-                            replace.location(), replace.replacement(), replace.expectedCurrent());
-                    return CompletableFuture.completedFuture(
-                            List.<RollbackResult>of(new RollbackResult.Applied(effects.get(0), inverse)));
+                    BlockColumns cols = inv.getArgument(1);
+                    // One-effect windows: each apply sees exactly one cell.
+                    assertThat(cols.count()).isEqualTo(1);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
                 });
         fixture.subject.applyWindowForTests(1);
         List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
@@ -312,45 +345,49 @@ class RollbackServiceTest {
 
         // 3 records folded through 1-effect windows = 3 separate applies,
         // summed into one final tally.
-        verify(fixture.engine, org.mockito.Mockito.times(3)).applyAllChunked(
+        verify(fixture.engine, org.mockito.Mockito.times(3)).applyColumnsChunked(
                 ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any());
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any());
         assertThat(ServiceTestSupport.plainTexts(messages))
                 .anyMatch(line -> line.contains("3 reversals") && !line.contains("skipped"));
     }
 
     @Test
-    void internsRepeatedSnapshotsAcrossFoldedEffects() throws Exception {
+    void foldsRepeatedBlockDataIntoDedupedPalette() throws Exception {
         TestFixture fixture = new TestFixture();
         when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt()))
                 .thenReturn(sampleRequest());
-        // Distinct records, structurally equal snapshots — the fold
-        // must collapse the retained copies to one canonical instance
-        // per distinct snapshot (the queued-window live set is what
-        // MTT=1 promotes to old gen).
+        // Distinct records, identical block-data — the columnar fold (#67)
+        // collapses both cells into one BlockColumns whose palette holds one
+        // entry per distinct block-data (stone + air), so the per-cell cost
+        // is two int ids, not a graph of snapshot objects that MTT=1 would
+        // promote to old gen.
         BlockBreakRecord a = record();
         BlockBreakRecord b = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(a, b), null));
-        java.util.concurrent.atomic.AtomicReference<List<RollbackEffect>> captured =
+        java.util.concurrent.atomic.AtomicReference<BlockColumns> captured =
                 new java.util.concurrent.atomic.AtomicReference<>();
-        when(fixture.engine.applyAllChunked(
+        when(fixture.engine.applyColumnsChunked(
                 ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
                 .thenAnswer(inv -> {
-                    captured.set(inv.getArgument(0));
-                    return CompletableFuture.completedFuture(List.<RollbackResult>of());
+                    BlockColumns cols = inv.getArgument(1);
+                    captured.set(cols);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
                 });
         ServiceTestSupport.captureMessages(fixture.sender);
 
         fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
 
-        List<RollbackEffect> effects = captured.get();
-        assertThat(effects).hasSize(2);
-        RollbackEffect.BlockReplace first = (RollbackEffect.BlockReplace) effects.get(0);
-        RollbackEffect.BlockReplace second = (RollbackEffect.BlockReplace) effects.get(1);
-        assertThat(first.expectedCurrent()).isSameAs(second.expectedCurrent());
-        assertThat(first.replacement()).isSameAs(second.replacement());
+        BlockColumns cols = captured.get();
+        assertThat(cols).isNotNull();
+        assertThat(cols.count()).isEqualTo(2);
+        // Two cells, each writing stone and expecting air = 4 intern calls,
+        // but only the two distinct strings land in the palette.
+        assertThat(cols.paletteSize()).isEqualTo(2);
     }
 
     @Test
@@ -375,12 +412,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Skipped(r.rollbackEffect(),
-                                new RollbackReason.BlockChanged(r.location(), r.originalBlock(), r.newBlock())))));
+        stubColumnarBlockChanged(fixture);
         List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
 
         fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
@@ -400,12 +432,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         ServiceTestSupport.captureMessages(operator);
 
         fixture.subject.execute(operator, "a:break", RollbackMode.ROLLBACK);
@@ -435,12 +462,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         ServiceTestSupport.captureMessages(operator);
 
         fixture.subject.execute(operator, "a:break", RollbackMode.ROLLBACK);
@@ -461,12 +483,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         ServiceTestSupport.captureMessages(operator);
         java.util.concurrent.atomic.AtomicBoolean consumed = new java.util.concurrent.atomic.AtomicBoolean();
 
@@ -489,12 +506,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         ServiceTestSupport.captureMessages(operator);
 
         fixture.subject.execute(operator, "a:break", RollbackMode.ROLLBACK);
@@ -523,9 +535,9 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        when(fixture.engine.applyAllChunked(
+        when(fixture.engine.applyColumnsChunked(
                 ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
                 .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("apply boom")));
         ServiceTestSupport.captureMessages(operator);
 
@@ -543,12 +555,7 @@ class RollbackServiceTest {
         BlockBreakRecord r = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
                 .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(r), null));
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(r.location(), r.originalBlock(), r.newBlock());
-        when(fixture.engine.applyAllChunked(
-                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        List.of(new RollbackResult.Applied(r.rollbackEffect(), inverse))));
+        stubColumnarApplied(fixture);
         ServiceTestSupport.captureMessages(fixture.sender);
 
         fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/BlockColumnsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/BlockColumnsTest.java
@@ -1,0 +1,97 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the columnar rollback store (#67). */
+class BlockColumnsTest {
+
+    @Test
+    void internDedupesEqualStringsAndHandlesNull() {
+        BlockColumns cols = new BlockColumns(16);
+        int stone = cols.intern("minecraft:stone");
+        int air = cols.intern("minecraft:air");
+        assertThat(cols.intern("minecraft:stone")).isEqualTo(stone);
+        assertThat(cols.intern("minecraft:air")).isEqualTo(air);
+        assertThat(stone).isNotEqualTo(air);
+        assertThat(cols.intern(null)).isEqualTo(-1);
+        // Two distinct strings interned, regardless of how many lookups.
+        assertThat(cols.paletteSize()).isEqualTo(2);
+    }
+
+    @Test
+    void addStoresCellsAndResolvesPalette() {
+        BlockColumns cols = new BlockColumns(2);
+        int stone = cols.intern("minecraft:stone");
+        int air = cols.intern("minecraft:air");
+        cols.add(10, 64, 20, stone, air);
+        cols.add(11, 65, 21, air, -1); // -1 expected == no check
+
+        assertThat(cols.count()).isEqualTo(2);
+        assertThat(cols.x(0)).isEqualTo(10);
+        assertThat(cols.y(0)).isEqualTo(64);
+        assertThat(cols.z(0)).isEqualTo(20);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:stone");
+        assertThat(cols.expData(0)).isEqualTo("minecraft:air");
+        assertThat(cols.replData(1)).isEqualTo("minecraft:air");
+        assertThat(cols.expData(1)).isNull();
+    }
+
+    @Test
+    void growsBeyondInitialCapacity() {
+        BlockColumns cols = new BlockColumns(2);
+        int id = cols.intern("minecraft:stone");
+        for (int i = 0; i < 100; i++) {
+            cols.add(i, 64, 0, id, -1);
+        }
+        assertThat(cols.count()).isEqualTo(100);
+        assertThat(cols.x(99)).isEqualTo(99);
+        assertThat(cols.replData(99)).isEqualTo("minecraft:stone");
+    }
+
+    @Test
+    void tracksMinMaxBounds() {
+        BlockColumns cols = new BlockColumns(8);
+        int id = cols.intern("minecraft:stone");
+        cols.add(5, 70, -3, id, -1);
+        cols.add(-2, 64, 9, id, -1);
+        cols.add(8, 80, 4, id, -1);
+        assertThat(cols.minX()).isEqualTo(-2);
+        assertThat(cols.minY()).isEqualTo(64);
+        assertThat(cols.minZ()).isEqualTo(-3);
+        assertThat(cols.maxX()).isEqualTo(8);
+        assertThat(cols.maxY()).isEqualTo(80);
+        assertThat(cols.maxZ()).isEqualTo(9);
+    }
+
+    @Test
+    void chunkSortedOrderGroupsByChunkThenAscendingY() {
+        BlockColumns cols = new BlockColumns(8);
+        int id = cols.intern("minecraft:stone");
+        // Two chunks: (0,0) and (1,0). Insert out of order, high Y first.
+        cols.add(2, 100, 2, id, -1);   // chunk (0,0)
+        cols.add(20, 64, 2, id, -1);   // chunk (1,0)
+        cols.add(3, 50, 3, id, -1);    // chunk (0,0), lower Y
+        cols.add(21, 200, 5, id, -1);  // chunk (1,0), higher Y
+
+        int[] order = cols.chunkSortedOrder();
+        assertThat(order).hasSize(4);
+        // Chunk (0,0) cells first, ascending Y (the y=50 cell then y=100).
+        assertThat(cols.x(order[0]) >> 4).isEqualTo(0);
+        assertThat(cols.x(order[1]) >> 4).isEqualTo(0);
+        assertThat(cols.y(order[0])).isLessThanOrEqualTo(cols.y(order[1]));
+        // Then chunk (1,0), ascending Y.
+        assertThat(cols.x(order[2]) >> 4).isEqualTo(1);
+        assertThat(cols.x(order[3]) >> 4).isEqualTo(1);
+        assertThat(cols.y(order[2])).isLessThanOrEqualTo(cols.y(order[3]));
+    }
+
+    @Test
+    void chunkSortedOrderHandlesEmptyAndSingle() {
+        assertThat(new BlockColumns(4).chunkSortedOrder()).isEmpty();
+        BlockColumns one = new BlockColumns(4);
+        one.add(1, 2, 3, one.intern("minecraft:stone"), -1);
+        assertThat(one.chunkSortedOrder()).containsExactly(0);
+    }
+}


### PR DESCRIPTION
Closes #67.

## What

Make a **2M-block rollback freeze-free** on stock Aikar flags, while staying leaner and faster than CoreProtect.

| 2M blocks, same ClickHouse | before (object path) | **after (#67)** | CoreProtect |
|---|---|---|---|
| Rollback wall-clock | 9.6 s | **3.1–3.8 s** | 11.6 s |
| Worst GC pause *during rollback* | **360 ms** (4 Mixed pauses) | **≤9.4 ms** (1 pure-young, often 0) | on-main |
| Worst single tick (MSPT) | — | **17 ms** | 617 ms |
| TPS during op | 20 | **20** | 12–18 |

~3× faster than CoreProtect, flat 20 TPS, and the freeze is gone. Storage is untouched (still leaner than CP).

## Root cause

The freeze was **old-gen promotion under `MaxTenuringThreshold=1`**, not an apply-threading problem (a STW Mixed GC freezes every thread). Two allocators fed it:
1. The read rebuilt a full `EventRecord` graph (UUID, Instants, `Origin`, `Source`, server/target, two `BlockSnapshot`s) per row, then discarded all but a `BlockReplace`.
2. The apply allocated a `RollbackResult.Applied` + a (never-read) inverse `BlockReplace` + a boxed-`Integer` index per cell.

Both survived the multi-tick window apply and promoted, pushing old gen past `IHOP=15%` → G1 ran **Mixed** collections mid-rollback. The earlier flag-tuning A/B proved tuning only *relocates* the freeze; the fix is to stop allocating.

## How

- **Lean decode** — `RecordStore.streamRollbackEffects` resolves each row straight to a `RollbackEffect` from a trimmed column list; the ClickHouse override skips the record/origin/source/server/target build. Read time **6.1 s → 0.6 s**.
- **Columnar apply** — simple block-replaces fold into primitive `BlockColumns` (packed coords + an interned block-data palette) and apply via `RollbackEngine.applyColumnsChunked`, returning **counts** instead of a per-cell `RollbackResult`. The apply no longer promotes to old gen, so the rollback never triggers a Mixed cycle. Containers / signs / entities / non-simple blocks keep the **unchanged** object path.
- **Wrapper fix** — `SynthesizingRecordStore` now delegates the rollback read straight through (it was routing back through `queryPage` and materializing a full 500K-row page list).

The residual ~180 ms pause only appears when an *unrelated* Mixed cycle is already in flight (JVM metaspace warmup right after boot, or the bench's synthetic 2M-ingest flood firing immediately before the rollback) — not the rollback's own allocation, and not a condition that coincides with a rollback in normal play.

## Verification

- `verify-rollback-count.js`: **262144 / 262144** restored (0 missed, 0 corrupted).
- Direct GC-log proof: four consecutive warmed 2M rollbacks logged **9.4 ms, 0, 0, 0** pauses.
- `compare.js` same-run vs CoreProtect: SG 3.8 s / worst tick 17 ms vs CP 11.6 s / 617 ms.
- Use-case suite (complex path): entity-kill (D1) and item drop/pickup custody (C7) pass; container cases erred only on pre-existing bot choreography flakiness.
- New tests: `BlockColumnsTest`, `StreamRollbackEffectsTest`, ClickHouse IT parity for simple-block + container decode.
- `./gradlew check` green (all modules, ITs under Docker, jacoco floors — none lowered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)