### PR TITLE
Rollback force-overwrites recorded blocks (#69)

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -70,6 +70,12 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `-ex` | `-extended` | Show extra detail columns |
 | `-nod:<keys>` | `-nodefault:` | Suppress defaults (e.g. `-nod:r,t`) |
 
+## Rollback behavior
+
+Rollback and restore **force-overwrite**: each matched block is set back to its recorded state regardless of what is there now (matching the original Omniscience and CoreProtect). This is what you want for grief recovery — if water, lava, fire, or falling blocks drifted into a griefed area after the edit, the rollback still restores the original blocks over them. It also means a rollback re-run is idempotent (re-applies to the same state) and a `/spyglass undo` cleanly reverses it.
+
+The trade-off: a rollback does not skip a cell just because someone changed it afterward, so a rollback scoped to one player can overwrite a *legitimate* later edit by another player in those exact cells. Scope the rollback (by player, region `r:`, and time `t:`) to the grief you mean to revert; review with `/spyglass lookup` first if unsure.
+
 ## Explosion grief
 
 Player-lit TNT records the igniter as the source — `p:<griefer>` searches and rollbacks cover the crater directly. Chained, dispensed, or redstone-primed TNT and mob explosions (creeper, wither) are entity-attributed: sweep those with `c:tnt`, `c:creeper`, etc.

--- a/regression/bot/_rollback-proof.js
+++ b/regression/bot/_rollback-proof.js
@@ -1,0 +1,216 @@
+// Explicit before/after block count around a //set-air -> /sg rollback.
+// Every count is vanilla `/fill ... replace` over RCON (server-side ground
+// truth), never Spyglass's own numbers. Usage: node _rollback-proof.js [SIDE]
+//
+// Stages, all counted independently:
+//   0. /fill stone baseline (unlogged)                 -> expect SIDE^3 stone
+//   1. bot //set air (LOGGED), Y-slabbed for keepalive
+//   1.5 count BEFORE rollback                           -> expect 0 stone, all air
+//   2. /sg rollback p:<bot>
+//   3. count AFTER rollback                             -> expect all stone, 0 air
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+const SIDE = parseInt(process.argv[2] || '64', 10);
+// Fresh region away from earlier tests; Y kept so per-chunk*fullY <= 32768.
+const X0 = 24000, Y0 = 72, Z0 = 24000;
+const X1 = X0 + SIDE - 1, Y1 = Y0 + SIDE - 1, Z1 = Z0 + SIDE - 1;
+const VOL = SIDE * SIDE * SIDE;
+const CX0 = X0 >> 4, CZ0 = Z0 >> 4, CX1 = X1 >> 4, CZ1 = Z1 >> 4;
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+const countOf = s => { const m = s && s.match(/(\d[\d,]*)\s+block/i); return m ? parseInt(m[1].replace(/,/g, ''), 10) : 0; };
+
+// Chunk-tiled fill: one /fill per 16x16 column over full Y (<= 32768 for
+// Y span <= 128), summed. Works at any SIDE (the 8-high slab in the older
+// script overflows the cap once SIDE > 64).
+async function fill(block, filter) {
+    let total = 0;
+    for (let cx = CX0; cx <= CX1; cx++) {
+        for (let cz = CZ0; cz <= CZ1; cz++) {
+            const bx0 = Math.max(X0, cx << 4), bx1 = Math.min(X1, (cx << 4) + 15);
+            const bz0 = Math.max(Z0, cz << 4), bz1 = Math.min(Z1, (cz << 4) + 15);
+            const r = await rcon(`fill ${bx0} ${Y0} ${bz0} ${bx1} ${Y1} ${bz1} ${block}${filter ? ` replace ${filter}` : ''}`);
+            total += countOf(r);
+        }
+    }
+    return total;
+}
+// Non-destructive count of `target`: count via target->glass, then restore
+// glass->target. Net world state unchanged, so the rollback still has real
+// work to do afterward.
+async function countKeep(target) {
+    const n = await fill('glass', target);
+    await fill(target, 'glass');
+    return n;
+}
+// Fill an arbitrary box with stone, chunk-tiled (<=32768/column for Y<=128).
+async function fillBox(ax0, ay0, az0, ax1, ay1, az1) {
+    for (let cx = ax0 >> 4; cx <= ax1 >> 4; cx++) {
+        for (let cz = az0 >> 4; cz <= az1 >> 4; cz++) {
+            const bx0 = Math.max(ax0, cx << 4), bx1 = Math.min(ax1, (cx << 4) + 15);
+            const bz0 = Math.max(az0, cz << 4), bz1 = Math.min(az1, (cz << 4) + 15);
+            await rcon(`fill ${bx0} ${ay0} ${bz0} ${bx1} ${ay1} ${bz1} stone`);
+        }
+    }
+}
+// 1-block stone shell on all six faces around the cube.
+async function sealShell() {
+    await fillBox(X0 - 1, Y0 - 1, Z0 - 1, X1 + 1, Y0 - 1, Z1 + 1); // bottom
+    await fillBox(X0 - 1, Y1 + 1, Z0 - 1, X1 + 1, Y1 + 1, Z1 + 1); // top
+    await fillBox(X0 - 1, Y0, Z0 - 1, X1 + 1, Y1, Z0 - 1);         // north
+    await fillBox(X0 - 1, Y0, Z1 + 1, X1 + 1, Y1, Z1 + 1);         // south
+    await fillBox(X0 - 1, Y0, Z0, X0 - 1, Y1, Z1);                 // west
+    await fillBox(X1 + 1, Y0, Z0, X1 + 1, Y1, Z1);                 // east
+}
+function waitChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+
+const BOT = 'rbp' + Date.now().toString(36).slice(-4);
+
+(async () => {
+    log(`Region ${SIDE}^3 = ${VOL.toLocaleString()} blocks @ (${X0},${Y0},${Z0})..(${X1},${Y1},${Z1})`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(1500);
+
+    log('Stage 0: /fill stone baseline (RCON, unlogged)…');
+    // Open cube (no seal): generated-terrain fluid WILL flow into the air
+    // pocket between //set and the rollback. Force-overwrite (#69) must
+    // restore stone over that drift -> a clean 2M/2M anyway.
+    await fill('air');
+    const filled = await fill('stone');
+    log(`  BEFORE EDIT  -> stone = ${filled.toLocaleString()} / air = ${(VOL - filled).toLocaleString()}   (expect ${VOL.toLocaleString()} stone)`);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + SIDE / 2} ${Y1 + 4} ${Z0 + SIDE / 2}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1500);
+
+    log('Stage 1: bot //set air over the cube (LOGGED, Y-slabbed)…');
+    let weAffected = 0;
+    for (let ys = Y0; ys <= Y1; ys += 16) {
+        const ye = Math.min(Y1, ys + 15);
+        bot.chat('//sel cuboid'); await sleep(150);
+        bot.chat(`//pos1 ${X0},${ys},${Z0}`); await sleep(150);
+        bot.chat(`//pos2 ${X1},${ye},${Z1}`); await sleep(150);
+        const done = waitChat(bot, /(blocks? have been changed|operation completed|affected)/i, 180000);
+        bot.chat('//set air');
+        const msg = await done;
+        const m = msg && msg.match(/(\d[\d,]*)/);
+        if (m) weAffected += parseInt(m[1].replace(/,/g, ''), 10);
+        await sleep(300);
+    }
+    log(`  WorldEdit //set air affected ${weAffected.toLocaleString()} blocks total`);
+    await sleep(8000); // let the recorder drain to ClickHouse
+
+    const chq = encodeURIComponent(`SELECT count() FROM spyglass.event_records WHERE event='break' AND source_player_name='${BOT}'`);
+    let recorded = '?';
+    try { recorded = (await (await fetch(`http://localhost:8123/?query=${chq}`)).text()).trim(); } catch { }
+    log(`  Spyglass recorded ${Number(recorded).toLocaleString()} break events for ${BOT}`);
+
+    log('Stage 1.5: COUNT after //set air (independent /fill replace)…');
+    const stoneMid = await fill('glass', 'stone'); // no stone left => 0, non-destructive
+    const airMid = await countKeep('air');         // count air, restore to air
+    log(`  after //set air -> stone = ${stoneMid.toLocaleString()} / air = ${airMid.toLocaleString()}`);
+
+    // Stage 1.6: DETERMINISTIC drift — overwrite every cell with dirt
+    // (UNLOGGED) so the live state no longer matches the recorded 'air'.
+    // Old skip-if-changed would skip all of these; force-overwrite (#69)
+    // must restore stone over them. Dirt is solid (no flow) so the count
+    // is exact, and it stands in for any post-edit change (water/lava/etc.).
+    log('Stage 1.6: overwrite the cube with DIRT (unlogged drift)…');
+    await fill('dirt');
+    const dirtMid = await fill('glass', 'dirt');   // count dirt, leaves glass...
+    await fill('dirt', 'glass');                    // ...restore glass->dirt
+    log(`  before rollback -> dirt = ${dirtMid.toLocaleString()} (cube no longer matches recorded air)`);
+
+    log('Stage 2: /sg rollback p:' + BOT + ' t:1h -g …');
+    let summary = null;
+    const h = m => { if (/(reversals|No results|rolled back|applied)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    const t0 = Date.now();
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    while (summary == null && Date.now() - t0 < 180000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    log(`  rollback line: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none/timeout)'}  (${Date.now() - t0}ms)`);
+    await sleep(5000);
+
+    log('Stage 3: COUNT AFTER ROLLBACK (independent /fill replace)…');
+    const stoneAfter = await fill('glass', 'stone');   // stone -> glass
+    const airAfter = await fill('bedrock', 'air');      // air -> bedrock
+    const corrupted = VOL - stoneAfter - airAfter;
+
+    log('\n──────── BEFORE / AFTER (server-side counts) ────────');
+    log(`  volume:                 ${VOL.toLocaleString()}`);
+    log(`  before edit:            stone ${filled.toLocaleString()}  / air ${(VOL - filled).toLocaleString()}`);
+    log(`  after //set air:        stone ${stoneMid.toLocaleString()}  / air ${airMid.toLocaleString()}`);
+    log(`  drift injected:         dirt  ${dirtMid.toLocaleString()}  (live state changed away from recorded air)`);
+    log(`  after /sg rollback:     stone ${stoneAfter.toLocaleString()}  / air ${airAfter.toLocaleString()}  / corrupted(dirt) ${corrupted.toLocaleString()}`);
+    log(`  rollback claimed:       ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none)'}`);
+    // Force-overwrite contract (#69): the rollback restores every recorded
+    // block over the dirt drift. PASS = full stone, no air, no leftover dirt.
+    // (Old skip-if-changed would leave all ${VOL} as dirt: stone 0.)
+    const pass = filled === VOL && dirtMid === VOL
+        && stoneAfter === VOL && airAfter === 0 && corrupted === 0;
+    log(`\n  VERDICT: ${pass
+        ? `PASS — cube was changed to ${VOL.toLocaleString()} dirt; force-overwrite restored all ${VOL.toLocaleString()} back to stone.`
+        : 'FAIL — rollback did not force-overwrite the drift.'}`);
+
+    // Diagnostic: if anything is left over, the restored stone is now glass
+    // and air is bedrock; probe what the leftover blocks actually are.
+    if (!pass && corrupted > 0) {
+        log('\n──────── PROBE: what are the leftover blocks? ────────');
+        for (const t of ['stone', 'glass', 'bedrock', 'dirt', 'cobblestone', 'water', 'lava', 'gravel', 'sand', 'cave_air', 'void_air']) {
+            const n = await fill('diamond_block', t);
+            if (n > 0) log(`  ${t}: ${n.toLocaleString()}`);
+            if (n > 0) await fill(t, 'diamond_block'); // restore the probe
+        }
+    }
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} air`);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(pass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -89,7 +89,9 @@ public final class RollbackService {
     }
 
     // Re-submit an interrupted rollback as a fresh job. Idempotent:
-    // already-applied cells skip with "block changed" on the re-run.
+    // force-overwrite (#69) makes already-applied cells re-apply to the same
+    // recorded state on the re-run, so an overlap from a coarse checkpoint
+    // converges rather than erroring.
     //
     // Replays the marker's RESOLVED request verbatim (#49) — never
     // re-parse saved.query() here: r:/t: defaults would re-anchor to

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -27,7 +27,6 @@ import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import net.medievalrp.spyglass.plugin.util.BlockLocations;
-import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
 import net.medievalrp.spyglass.plugin.util.ChunkDirectWriter;
 import net.medievalrp.spyglass.plugin.util.ChunkResender;
 import net.medievalrp.spyglass.plugin.util.ItemSerialization;
@@ -693,28 +692,14 @@ public final class RollbackEngine {
                 nonSimpleMask.set(j);
                 continue;
             }
-            // Expected-state check (#27): same semantics as the slow
-            // path's matches() — interned NMS states make identity equal
-            // to material+blockData equality. Skipping here is what keeps
-            // a p:<actor> rollback from clobbering another player's newer
-            // edit, and makes re-runs report skips instead of re-applying.
-            BlockSnapshot expected = effect.expectedCurrent();
-            if (expected != null) {
-                org.bukkit.block.data.BlockData expectedBd;
-                try {
-                    expectedBd = blockDataFor(expected.blockData());
-                } catch (RuntimeException thrown) {
-                    expectedBd = null;
-                }
-                if (expectedBd != null
-                        && work.ctx.currentStateMatches(loc.x(), loc.y(), loc.z(), expectedBd) == 0) {
-                    resultArray[targetIndex] = new RollbackResult.Skipped(effect,
-                            new RollbackReason.BlockChanged(loc, expected,
-                                    snapshotOfCurrent(work.ctx, loc)));
-                    writes[j] = null;
-                    continue;
-                }
-            }
+            // Force-overwrite (#69): restore the recorded block regardless
+            // of the live state — matching the original Omniscience and
+            // CoreProtect, and the documented contract in
+            // RollbackEngineChaosTest. A grief rollback must put the block
+            // back even if water/lava/fire/falling-blocks drifted into the
+            // gap after the edit; those changes are unlogged, so nothing
+            // should protect them. Cross-actor cases are handled by scoping
+            // the rollback, not by a per-cell live-state guard.
             work.ctx.writeBlock(loc.x(), loc.y(), loc.z(), bd);
             if (replacement.simple()) {
                 // No tile entity to apply; the palette write is the whole
@@ -729,19 +714,6 @@ public final class RollbackEngine {
         }
         work.writes = writes;
         work.nonSimpleMask = nonSimpleMask;
-    }
-
-    // Mismatch reporting only — allocates a Bukkit BlockData wrapper, so
-    // it stays off the per-block hot path.
-    private static BlockSnapshot snapshotOfCurrent(
-            ChunkDirectWriter.ChunkContext ctx, BlockLocation loc) {
-        org.bukkit.block.data.BlockData current = ctx.readBlockData(loc.x(), loc.y(), loc.z());
-        if (current == null) {
-            return null;
-        }
-        return new BlockSnapshot(current.getMaterial(), current.getAsString(),
-                java.util.List.of(), java.util.List.of(), java.util.List.of(),
-                java.util.List.of(), null);
     }
 
     // Main-thread half: apply tile-entity state for the non-simple blocks
@@ -765,18 +737,9 @@ public final class RollbackEngine {
                     BlockLocation loc = effect.location();
                     try {
                         if (work.ctx == null) {
-                            // prepareChunk failed for this chunk; run the
-                            // expected-state check (#27) via Bukkit, then
-                            // fall back to a single-block write here on main.
-                            Block current = world.getBlockAt(loc.x(), loc.y(), loc.z());
-                            BlockSnapshot expected = effect.expectedCurrent();
-                            if (expected != null
-                                    && !expected.blockData().equals(current.getBlockData().getAsString())) {
-                                resultArray[targetIndex] = new RollbackResult.Skipped(effect,
-                                        new RollbackReason.BlockChanged(loc, expected,
-                                                BlockSnapshots.capture(current.getState())));
-                                continue;
-                            }
+                            // prepareChunk failed for this chunk; force-write
+                            // the recorded block here on main (#69 — no
+                            // live-state guard, same as the fast path).
                             ChunkDirectWriter.writeBlock(
                                     world, loc.x(), loc.y(), loc.z(), writes[j]);
                         }
@@ -1038,22 +1001,9 @@ public final class RollbackEngine {
                 unparse++;
                 continue;
             }
-            String exp = cols.expData(idx);
-            if (exp != null) {
-                org.bukkit.block.data.BlockData expBd;
-                try {
-                    expBd = blockDataFor(exp);
-                } catch (RuntimeException thrown) {
-                    expBd = null;
-                }
-                // Expected-state check (#27): skip when the live block no
-                // longer matches what this op expected — same semantics as
-                // the object path's matches().
-                if (expBd != null && cc.ctx.currentStateMatches(x, y, z, expBd) == 0) {
-                    changed++;
-                    continue;
-                }
-            }
+            // Force-overwrite (#69): write the recorded block regardless of
+            // the live state (no conflict guard) — restores grief even where
+            // unlogged drift (water/lava/fire/falling) moved into the gap.
             cc.ctx.writeBlock(x, y, z, bd);
             applied++;
         }
@@ -1063,10 +1013,9 @@ public final class RollbackEngine {
     }
 
     // Main-thread fallback for a chunk whose prepareChunk failed: single
-    // block writes with the expected check via Bukkit.
+    // block writes, force-overwrite (#69 — no live-state guard).
     private void writeColumnChunkMain(World world, BlockColumns cols, int[] order, ColChunk cc) {
         long applied = 0;
-        long changed = 0;
         long unparse = 0;
         for (int k = cc.from; k < cc.rangeEnd; k++) {
             int idx = order[k];
@@ -1083,19 +1032,10 @@ public final class RollbackEngine {
                 unparse++;
                 continue;
             }
-            String exp = cols.expData(idx);
-            if (exp != null) {
-                Block block = world.getBlockAt(x, y, z);
-                if (!exp.equals(block.getBlockData().getAsString())) {
-                    changed++;
-                    continue;
-                }
-            }
             ChunkDirectWriter.writeBlock(world, x, y, z, bd);
             applied++;
         }
         cc.applied = applied;
-        cc.blockChanged = changed;
         cc.unparseable = unparse;
     }
 
@@ -1491,14 +1431,13 @@ public final class RollbackEngine {
             return new RollbackResult.Skipped(effect, new RollbackReason.InvalidLocation(effect.location()));
         }
 
+        // Force-overwrite (#69): restore the recorded block regardless of
+        // the live state — no conflict guard, matching the fast path and the
+        // original Omniscience / CoreProtect.
         Block block = world.get().getBlockAt(effect.location().x(), effect.location().y(), effect.location().z());
-        BlockSnapshot actual = BlockSnapshots.capture(block.getState());
-        if (!matches(effect.expectedCurrent(), actual)) {
-            return new RollbackResult.Skipped(effect, new RollbackReason.BlockChanged(effect.location(), effect.expectedCurrent(), actual));
-        }
-
         applySnapshot(block, effect.replacement());
-        RollbackEffect inverse = new RollbackEffect.BlockReplace(effect.location(), effect.replacement(), actual);
+        RollbackEffect inverse = new RollbackEffect.BlockReplace(
+                effect.location(), effect.replacement(), effect.expectedCurrent());
         return new RollbackResult.Applied(effect, inverse);
     }
 
@@ -1541,10 +1480,6 @@ public final class RollbackEngine {
         BlockState state = block.getState();
         state.setBlockData(Bukkit.createBlockData(snapshot.blockData()));
         applyTilePayload(block, state, snapshot);
-    }
-
-    private boolean matches(BlockSnapshot expected, BlockSnapshot actual) {
-        return expected.material() == actual.material() && expected.blockData().equals(actual.blockData());
     }
 
     private boolean matches(StoredItem expected, int slot, ItemStack current) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngineChaosTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngineChaosTest.java
@@ -25,13 +25,15 @@ import org.mockito.MockedStatic;
 /**
  * Chaos tests for {@link RollbackEngine}'s bulk apply path.
  *
- * <p>Spyglass rolls back by <b>force-overwrite</b>: the chunked apply
- * path restores every effect to its logged state without first checking
- * whether the live block still matches what was recorded. (Conflict
- * detection — skip-if-changed — was an Spyglass behaviour that the
- * NMS-direct-section rewrite intentionally dropped; transparency comes
- * from the rolled-place / rolled-break audit records instead.) These
- * tests pin that contract:
+ * <p>Spyglass rolls back by <b>force-overwrite</b>: the apply path
+ * restores every effect to its logged state without first checking
+ * whether the live block still matches what was recorded — matching the
+ * original Omniscience and CoreProtect. A grief rollback must put the
+ * block back even where unlogged drift (water/lava/fire/falling blocks)
+ * moved into the gap after the edit. (#69 removed the expected-state
+ * skip that had crept into the parallel and columnar paths, so all apply
+ * paths now honor this contract; transparency comes from the
+ * rolled-place / rolled-break audit records instead.) These tests pin it:
  *
  * <ul>
  *   <li>every effect is reported {@link RollbackResult.Applied}, even


### PR DESCRIPTION
Closes #69.

## Problem
Block rollback skipped any cell whose live block no longer matched the recorded after-state (the #27 expected-state check). For grief recovery that's wrong: water/lava/fire/falling blocks that drift into a griefed area after the edit are no longer the recorded `air`, so the rollback left them — restoring a region pocked with fluid/holes instead of the original blocks. (Surfaced by a 2M before/after count: an open cube left 297 cells of water+lava that flowed in before the rollback fired.)

## Why force-overwrite is correct
- **Original Omniscience** (501warhead) `BlockEntry.rollback()` force-overwrites (`setType(originalData.getMaterial())`), no live-state guard.
- **CoreProtect** does the same.
- Spyglass's own `RollbackEngineChaosTest` already **documents force-overwrite as the contract** and asserts it — the skip-check had only crept into the parallel + columnar paths, contradicting the sync path, the resume "force-overwrite converges" logic, and undo retry-safety.

## Change
Removed the expected-state skip from every **block** apply path: parallel `writeChunkPalettes` + its `ctx==null` fallback, columnar `writeColumnChunk` + main fallback, and the slow `applyBlockReplace`; deleted the now-dead `snapshotOfCurrent` / `matches(BlockSnapshot,BlockSnapshot)` helpers. **Container-slot writes keep** their expected check (force-overwriting item slots can wipe items a player legitimately added after the event — deliberately out of scope).

## Verification
- Live 2M proof ([regression/bot/_rollback-proof.js](regression/bot/_rollback-proof.js)): a 126³ cube changed to **2,000,376 dirt** after the logged edit is fully restored to stone by the rollback — **0 skipped, 0 corrupted** (server-side `/fill` counts, independent of the plugin). Under the old behavior all 2M would have been skipped (dirt ≠ recorded air).
- `RollbackEngineChaosTest` (force-overwrite contract) green; `./gradlew check` green.
- `commands.md` documents force-overwrite + cross-actor scoping guidance.

## Trade-off (documented)
A rollback no longer skips a cell just because it changed afterward, so a single-player-scoped rollback can overwrite a *legitimate* later edit by another player in those exact cells. Operators scope by player/region/time — same as CoreProtect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)