### PR TITLE
Direction-specific lean rollback read — reliably-zero GC pauses at 2M (#83)

### DIFF
--- a/regression/bot/_distribution-proof.js
+++ b/regression/bot/_distribution-proof.js
@@ -1,0 +1,175 @@
+// Heterogeneous before/after distribution check for rollback fidelity.
+// Builds a cube whose every Y-layer is a different block type (cycling 8
+// types), griefs it with //set air (LOGGED), rolls back, then verifies —
+// PER LAYER, server-side — that each layer came back 100% its own type.
+// Per-layer (not just per-type aggregate) catches a wrong-type write or an
+// equal-count swap that a uniform or aggregate test would miss.
+// Usage: node _distribution-proof.js [SIDE]
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+const SIDE = parseInt(process.argv[2] || '64', 10);
+const X0 = 26000, Y0 = 72, Z0 = 26000;
+const X1 = X0 + SIDE - 1, Y1 = Y0 + SIDE - 1, Z1 = Z0 + SIDE - 1;
+const VOL = SIDE * SIDE * SIDE;
+const LAYER = SIDE * SIDE;
+const CX0 = X0 >> 4, CZ0 = Z0 >> 4, CX1 = X1 >> 4, CZ1 = Z1 >> 4;
+// 8 full, solid, simple block types (no gravity/fluid/tile-entity); none is
+// the diamond_block marker used for counting.
+const TYPES = ['stone', 'dirt', 'cobblestone', 'oak_planks', 'glass', 'gold_block', 'bricks', 'sandstone'];
+const typeOf = y => TYPES[(y - Y0) % TYPES.length];
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+const countOf = s => { const m = s && s.match(/(\d[\d,]*)\s+block/i); return m ? parseInt(m[1].replace(/,/g, ''), 10) : 0; };
+
+// Count `type` over the whole cube via type->diamond_block, then restore.
+async function countKeep(type) {
+    let n = 0;
+    for (let cx = CX0; cx <= CX1; cx++) for (let cz = CZ0; cz <= CZ1; cz++) {
+        const bx0 = Math.max(X0, cx << 4), bx1 = Math.min(X1, (cx << 4) + 15);
+        const bz0 = Math.max(Z0, cz << 4), bz1 = Math.min(Z1, (cz << 4) + 15);
+        n += countOf(await rcon(`fill ${bx0} ${Y0} ${bz0} ${bx1} ${Y1} ${bz1} diamond_block replace ${type}`));
+    }
+    for (let cx = CX0; cx <= CX1; cx++) for (let cz = CZ0; cz <= CZ1; cz++) {
+        const bx0 = Math.max(X0, cx << 4), bx1 = Math.min(X1, (cx << 4) + 15);
+        const bz0 = Math.max(Z0, cz << 4), bz1 = Math.min(Z1, (cz << 4) + 15);
+        await rcon(`fill ${bx0} ${Y0} ${bz0} ${bx1} ${Y1} ${bz1} ${type} replace diamond_block`);
+    }
+    return n;
+}
+function waitChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+
+const BOT = 'rbd' + Date.now().toString(36).slice(-4);
+
+(async () => {
+    log(`Region ${SIDE}^3 = ${VOL.toLocaleString()} blocks @ (${X0},${Y0},${Z0}); ${TYPES.length} types in Y-layers`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(1500);
+
+    // Stage 0: lay each Y-layer as its own type (RCON, UNLOGGED). One /fill
+    // per layer (SIDE*SIDE <= 32768 for SIDE<=181).
+    log('Stage 0: build the layered mix (RCON, unlogged)…');
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} air`);
+    const expected = {};
+    for (let y = Y0; y <= Y1; y++) {
+        const t = typeOf(y);
+        await rcon(`fill ${X0} ${y} ${Z0} ${X1} ${y} ${Z1} ${t}`);
+        expected[t] = (expected[t] || 0) + LAYER;
+    }
+    log('  expected distribution (by construction):');
+    for (const t of TYPES) log(`     ${t.padEnd(12)} ${expected[t].toLocaleString()}`);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + SIDE / 2} ${Y1 + 4} ${Z0 + SIDE / 2}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1500);
+
+    log('Stage 1: bot //set air over the cube (LOGGED, Y-slabbed)…');
+    let weAffected = 0;
+    for (let ys = Y0; ys <= Y1; ys += 16) {
+        const ye = Math.min(Y1, ys + 15);
+        bot.chat('//sel cuboid'); await sleep(150);
+        bot.chat(`//pos1 ${X0},${ys},${Z0}`); await sleep(150);
+        bot.chat(`//pos2 ${X1},${ye},${Z1}`); await sleep(150);
+        const done = waitChat(bot, /(blocks? have been changed|operation completed|affected)/i, 180000);
+        bot.chat('//set air');
+        const msg = await done;
+        const m = msg && msg.match(/(\d[\d,]*)/);
+        if (m) weAffected += parseInt(m[1].replace(/,/g, ''), 10);
+        await sleep(300);
+    }
+    log(`  WorldEdit //set air affected ${weAffected.toLocaleString()} blocks; cube is now air`);
+    await sleep(8000);
+
+    log('Stage 2: /sg rollback p:' + BOT + ' t:1h -g …');
+    let summary = null;
+    const h = m => { if (/(reversals|No results|rolled back|applied)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    const t0 = Date.now();
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    while (summary == null && Date.now() - t0 < 180000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    log(`  rollback: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(timeout)'}  (${Date.now() - t0}ms)`);
+    await sleep(5000);
+
+    // Stage 3: PER-LAYER verify — each layer must be 100% its own type.
+    // Destructive (replaces the expected type with diamond per layer); we're
+    // done after this. A layer short of SIDE^2 means a wrong-type / missing
+    // write at some position in that layer.
+    log('Stage 3: per-layer verification (server-side /fill replace)…');
+    const after = {};
+    let badLayers = 0;
+    let worstLayer = null;
+    for (let y = Y0; y <= Y1; y++) {
+        const t = typeOf(y);
+        const n = countOf(await rcon(`fill ${X0} ${y} ${Z0} ${X1} ${y} ${Z1} diamond_block replace ${t}`));
+        after[t] = (after[t] || 0) + n;
+        if (n !== LAYER) {
+            badLayers++;
+            if (worstLayer == null || n < worstLayer.n) worstLayer = { y, t, n };
+        }
+    }
+    const totalCorrect = Object.values(after).reduce((a, b) => a + b, 0);
+
+    log('\n──────── DISTRIBUTION: expected vs after rollback ────────');
+    let allMatch = true;
+    for (const t of TYPES) {
+        const ok = (after[t] || 0) === expected[t];
+        if (!ok) allMatch = false;
+        log(`  ${t.padEnd(12)} expected ${expected[t].toLocaleString().padStart(9)}  after ${(after[t] || 0).toLocaleString().padStart(9)}  ${ok ? 'OK' : 'MISMATCH'}`);
+    }
+    log(`  ${'TOTAL'.padEnd(12)} expected ${VOL.toLocaleString().padStart(9)}  after ${totalCorrect.toLocaleString().padStart(9)}`);
+    log(`  layers verified: ${SIDE - badLayers}/${SIDE} fully correct` + (badLayers ? `  (worst: y=${worstLayer.y} ${worstLayer.t} ${worstLayer.n}/${LAYER})` : ''));
+    const pass = allMatch && totalCorrect === VOL && badLayers === 0;
+    log(`\n  VERDICT: ${pass
+        ? 'PASS — every layer restored to its exact type; distribution identical before and after.'
+        : 'FAIL — distribution diverged (see mismatches / bad layers above).'}`);
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y1} ${Z1} air`);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(pass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -188,17 +188,25 @@ public final class ClickHouseRecordStore implements RecordStore {
     // everything streamRollbackEffects never reads vs ROLLBACK_COLUMNS:
     // expires_at, origin_*, all source_*, server, target, plus the
     // container_type/amount and entity killer/damage columns that the
-    // effect constructors ignore. Cutting the SELECT this far trims both
-    // the wire response and the per-row decode — there is no Origin,
-    // Source, or record wrapper to allocate, only the effect's own fields.
-    private static final List<String> LEAN_ROLLBACK_COLUMNS = List.of(
+    // effect constructors ignore.
+    //
+    // Direction-specific (read-churn cut): force-overwrite (#69) never reads
+    // the expected (other) side of a block edit, so a rollback fetches only
+    // the before_* block columns and a restore only the after_* ones. That
+    // halves the per-row LowCardinality string materialization (the dominant
+    // eden filler) for a million-row read — without it the client decodes
+    // both before_blockdata AND after_blockdata per row for nothing. Common
+    // (cursor / dispatch / location / container / entity) columns are shared.
+    private static final List<String> LEAN_COMMON_COLUMNS = List.of(
             "id", "event", "occurred",
             "location_world_id", "location_world_name",
             "location_x", "location_y", "location_z",
-            "before_material", "before_blockdata", "before_extras",
-            "after_material", "after_blockdata", "after_extras",
             "slot", "before_item", "after_item",
             "entity_type", "entity_id", "entity_nbt");
+    private static final List<String> LEAN_ROLLBACK_BLOCK = List.of(
+            "before_material", "before_blockdata", "before_extras");
+    private static final List<String> LEAN_RESTORE_BLOCK = List.of(
+            "after_material", "after_blockdata", "after_extras");
 
     private final PredicateToSql predicateToSql = new PredicateToSql();
     private final Client client;
@@ -209,7 +217,8 @@ public final class ClickHouseRecordStore implements RecordStore {
     private final String summarySelect;
     private final String fullSelect;
     private final String rollbackSelect;
-    private final String leanRollbackSelect;
+    private final String rollbackReadSelect;
+    private final String restoreReadSelect;
 
     public ClickHouseRecordStore(String host, int port, String database, String table,
                                  String user, String password, boolean ssl) {
@@ -219,7 +228,8 @@ public final class ClickHouseRecordStore implements RecordStore {
         this.summarySelect = String.join(", ", concat(COMMON_COLUMNS, SUMMARY_EXTRAS));
         this.fullSelect = String.join(", ", concat(COMMON_COLUMNS, SUMMARY_EXTRAS, HEAVY_COLUMNS));
         this.rollbackSelect = String.join(", ", ROLLBACK_COLUMNS);
-        this.leanRollbackSelect = String.join(", ", LEAN_ROLLBACK_COLUMNS);
+        this.rollbackReadSelect = String.join(", ", concat(LEAN_COMMON_COLUMNS, LEAN_ROLLBACK_BLOCK));
+        this.restoreReadSelect = String.join(", ", concat(LEAN_COMMON_COLUMNS, LEAN_RESTORE_BLOCK));
 
         this.client = new Client.Builder()
                 .addEndpoint((ssl ? "https" : "http") + "://" + host + ":" + port)
@@ -602,14 +612,15 @@ public final class ClickHouseRecordStore implements RecordStore {
                                                   int windowLimit, boolean rollback,
                                                   RollbackEffectSink sink) {
         // Allocation-lean rollback read (#67): same keyset-streamed scan as
-        // streamRollback, but the trimmed LEAN_ROLLBACK_COLUMNS SELECT and
-        // decodeEffect build only the RollbackEffect the engine applies —
-        // no EventRecord, Origin, Source, server/target, or expires_at is
-        // ever materialized. On a 2M-block rollback that removes the bulk
-        // of the per-row object graph (the firehose that, surviving one
-        // young GC under MaxTenuringThreshold=1, promoted to old gen and
-        // forced the Mixed-GC freeze).
-        String sql = buildRollbackSql(leanRollbackSelect, request, cursor, windowLimit);
+        // streamRollback, but the trimmed SELECT + emitEffect build only the
+        // RollbackEffect the engine applies — no EventRecord, Origin, Source,
+        // server/target, or expires_at is ever materialized. The SELECT is
+        // direction-specific: force-overwrite ignores the expected side, so a
+        // rollback reads only before_* block columns, a restore only after_*
+        // — halving the per-row LowCardinality string churn that, left
+        // unchecked, fills eden and triggers a young GC mid-rollback.
+        String sql = buildRollbackSql(rollback ? rollbackReadSelect : restoreReadSelect,
+                request, cursor, windowLimit);
         Instant lastOccurred = null;
         UUID lastId = null;
         int rowCount = 0;
@@ -712,42 +723,37 @@ public final class ClickHouseRecordStore implements RecordStore {
             // Resolve which stored state we write (replacement) vs. expect
             // currently present (expectedCurrent). rollback writes the
             // before-state expecting the after-state; restore is the inverse.
+            // Replacement side only — the SELECT omits the expected side and
+            // force-overwrite (#69) never reads it. rollback writes the
+            // before-state; restore writes the after-state.
             String replMaterial;
             String replData;
             String replExtras;
-            String expData;
             if (rollback) {
                 replMaterial = row.getString("before_material");
                 replData = row.getString("before_blockdata");
                 replExtras = row.getString("before_extras");
-                expData = row.getString("after_blockdata");
             } else {
                 replMaterial = row.getString("after_material");
                 replData = row.getString("after_blockdata");
                 replExtras = row.getString("after_extras");
-                expData = row.getString("before_blockdata");
             }
             boolean simple = replData != null && (replExtras == null || replExtras.isEmpty());
             if (simple) {
+                // expectedData is unused under force-overwrite; pass null.
                 sink.block(row.getUUID("location_world_id"),
                         row.getInteger("location_x"),
                         row.getInteger("location_y"),
                         row.getInteger("location_z"),
-                        replData, expData, occurred, id);
+                        replData, null, occurred, id);
                 return;
             }
             // Tile-entity payload (or malformed block-data): object path.
+            // expectedCurrent is null — force-overwrite ignores it.
             BlockLocation location = readLocation(row);
             BlockSnapshot replacement = BsonBlobs.decodeBlockSnapshotFromColumns(
                     replMaterial, replData, replExtras);
-            BlockSnapshot expected = rollback
-                    ? BsonBlobs.decodeBlockSnapshotFromColumns(
-                            row.getString("after_material"), row.getString("after_blockdata"),
-                            row.getString("after_extras"))
-                    : BsonBlobs.decodeBlockSnapshotFromColumns(
-                            row.getString("before_material"), row.getString("before_blockdata"),
-                            row.getString("before_extras"));
-            sink.complex(new RollbackEffect.BlockReplace(location, expected, replacement), occurred, id);
+            sink.complex(new RollbackEffect.BlockReplace(location, null, replacement), occurred, id);
             return;
         }
         if (clazz == ContainerDepositRecord.class || clazz == ContainerWithdrawRecord.class) {

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -443,9 +443,12 @@ class ClickHouseRecordStoreIT {
 
         assertThat(blocks).hasSize(5);
         assertThat(skips[0]).isZero();
-        // rollback writes the before-state (stone), expects the after (air).
+        // rollback writes the before-state (stone). The expected side is
+        // never read under force-overwrite (#69) — the direction-specific
+        // SELECT omits after_* entirely on a rollback — so expectedData is
+        // null. (This is the read-churn cut: ~half the per-row string decode.)
         assertThat(blockData).containsOnly("minecraft:stone");
-        assertThat(expectedData).containsOnly("minecraft:air");
+        assertThat(expectedData).containsOnly((String) null);
         // The sign block fell back to a built BlockReplace effect.
         assertThat(complex).hasSize(1);
         assertThat(complex.get(0))


### PR DESCRIPTION
Closes #83.

## Problem
After #67 (lean decode + columnar apply) and #69 (force-overwrite), a *warmed* 2M rollback still fired **one ~9 ms pure-young GC** (often zero, never a Mixed pause). The ClickHouse read materialized enough per-row objects to fill eden once during the ~3 s scan, so a single young collection landed inside the op — sub-tick and imperceptible, but not *reliably* zero.

## Root cause
Force-overwrite (#69) never reads the expected side of a block edit, yet the lean SELECT still fetched **both** `before_*` and `after_*` block columns, and `emitEffect` materialized both `before_blockdata` and `after_blockdata` (LowCardinality strings) per row. Double the dominant per-row string churn, for nothing.

## Fix
The lean rollback read is now **direction-specific**: a rollback reads only the `before_*` block columns, a restore only `after_*` (cursor / location / container / entity columns shared). `emitEffect` reads only the replacement side and passes `null` for the now-unused expected. This halves per-row LowCardinality string materialization on a block read — dropping eden fill below the young-GC threshold so no collection fires during the rollback.

## Result (6 GB bench heap, stock Aikar flags)
- **5 / 5 consecutive warmed 2M rollbacks: zero GC pauses** (2,000,376 applied each, ~3.1–3.3 s). Previously 0–1 × ~9 ms.
- **Fidelity intact**: heterogeneous 8-type cube restored **126 / 126 layers exactly**, per-type counts identical before/after ([regression/bot/_distribution-proof.js](regression/bot/_distribution-proof.js)).
- `./gradlew check` green (incl. ClickHouse IT; the lean block decode's `expectedData` is now `null`, asserted).

Also commits `_distribution-proof.js` (per-layer fidelity verifier) alongside the existing `_rollback-proof.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)