### PR TITLE
feat: container rollback salvage — /sg inventory recovery GUI (#76)

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -11,7 +11,7 @@ All default to `op`.
 | `spyglass.use` | help, events, page |
 | `spyglass.search` | search |
 | `spyglass.search.ip` | reveals join IPs in results and unlocks the `ip:` key (without it IPs render as `(ip hidden)`) |
-| `spyglass.rollback` | rollback, restore, undo, rbqueue |
+| `spyglass.rollback` | rollback, restore, undo, rbqueue, inventory |
 | `spyglass.tool` | inspection wand |
 | `spyglass.tele` | teleport (used by clickable result rows) |
 | `spyglass.worldedit` | allows the `-we` flag |
@@ -31,6 +31,7 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `/spyglass undo` | `u` |
 | `/spyglass rbqueue [list\|stop\|cancel <id>\|resume <id>]` | `queue`, `rbq` |
 | `/spyglass tool` | `t`, `inspect` |
+| `/spyglass inventory` | `inv`, `salvage` |
 | `/spyglass tele <world> <x> <y> <z>` | - |
 
 ## Query keys
@@ -74,7 +75,15 @@ Root: `/spyglass`. Short alias: `/sg`.
 
 Rollback and restore **force-overwrite**: each matched block is set back to its recorded state regardless of what is there now (matching the original Omniscience and CoreProtect). This is what you want for grief recovery — if water, lava, fire, or falling blocks drifted into a griefed area after the edit, the rollback still restores the original blocks over them. It also means a rollback re-run is idempotent (re-applies to the same state) and a `/spyglass undo` cleanly reverses it.
 
-The trade-off: a rollback does not skip a cell just because someone changed it afterward, so a rollback scoped to one player can overwrite a *legitimate* later edit by another player in those exact cells. Scope the rollback (by player, region `r:`, and time `t:`) to the grief you mean to revert; review with `/spyglass lookup` first if unsure.
+The trade-off: a rollback does not skip a cell just because someone changed it afterward, so a rollback scoped to one player can overwrite a *legitimate* later edit by another player in those exact cells. Scope the rollback (by player, region `r:`, and time `t:`) to the grief you mean to revert; review with `/spyglass lookup` first if unsure. Items in a container the rollback overwrites are recoverable — see below.
+
+## Container salvage
+
+When a force-overwrite rollback destroys a container that had items in it — a chest someone filled after the grief, restored back to stone — those items are **not lost**. The rollback captures the destroyed inventory first and files it under `/spyglass inventory`.
+
+`/spyglass inventory` (alias `inv`) opens a GUI of chest icons, one per destroyed inventory (newest first, labelled with the world, coordinates, and operator). Click an icon to open that snapshot and **take items out** — it is extract-only; you cannot put items in. Each withdrawal is logged as a `salvage-withdraw` event (find them with `/sg search a:salvage-withdraw`), and a snapshot disappears once emptied. From the console or RCON the command prints a text listing instead of a GUI.
+
+Only containers the rollback *actually* destroys are salvaged — a chest in the rolled region that the rollback leaves untouched is never captured, so items are never duplicated. Salvage snapshots are kept for 30 days.
 
 ## Explosion grief
 

--- a/regression/bot/_salvage-proof.js
+++ b/regression/bot/_salvage-proof.js
@@ -1,0 +1,188 @@
+// End-to-end proof for container salvage (#76).
+//
+// Scenario: a stone region is griefed (bot //set air, LOGGED). Then a VICTIM
+// chest full of diamonds is placed inside the griefed region, and a SURVIVOR
+// chest full of emeralds is placed in the SAME CHUNK but above the grief (a
+// cell the rollback will not touch). The rollback restores stone over the
+// region — destroying the victim chest but not the survivor.
+//
+// Verifies, all server-side:
+//   1. CAPTURE   — the victim's diamonds land in the salvage store (ClickHouse).
+//   2. PRECISION — exactly ONE salvage row; the survivor's emeralds are NOT
+//                  salvaged (capture-then-verify discards survivors → no dupe).
+//   3. WORLD     — victim cell restored to stone; survivor chest intact.
+//   4. LISTING   — /sg inventory (console text) shows the diamonds.
+//   5. EXTRACT   — a player opens the GUI, takes the diamonds (into their
+//                  inventory), the snapshot empties, and a salvage-withdraw
+//                  event is logged.
+import mineflayer from 'mineflayer';
+import vec3 from 'vec3';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const CH = 'http://localhost:8123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+// Fresh region, away from the other proofs (24000 / 26000).
+const X0 = 28000, Z0 = 28000, GY0 = 72, GY1 = 76;   // grief box (stone -> air)
+const X1 = X0 + 9, Z1 = Z0 + 9;
+const VX = X0 + 5, VY = 73, VZ = Z0 + 5;             // victim chest (inside grief)
+const SX = X0 + 2, SY = 80, SZ = Z0 + 2;             // survivor chest (same chunk, above)
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+async function chQuery(sql) {
+    const r = await fetch(`${CH}/?query=${encodeURIComponent(sql)}`);
+    return (await r.text()).trim();
+}
+function waitChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+
+const BOT = 'salv' + Date.now().toString(36).slice(-4);
+const results = [];
+const check = (name, ok, detail) => { results.push({ name, ok }); log(`  ${ok ? 'PASS' : 'FAIL'} — ${name}${detail ? ' :: ' + detail : ''}`); };
+
+(async () => {
+    log(`Salvage proof. grief (${X0},${GY0},${Z0})..(${X1},${GY1},${Z1}); victim @${VX},${VY},${VZ}; survivor @${SX},${SY},${SZ}; bot=${BOT}`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(1500);
+
+    log('Stage 0: stone baseline over the grief box (RCON, unlogged)…');
+    await rcon(`fill ${X0} ${GY0} ${Z0} ${X1} ${GY1} ${Z1} stone`);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${VX} ${SY + 3} ${VZ}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1500);
+
+    log('Stage 1: bot //set air over the grief box (LOGGED)…');
+    bot.chat('//sel cuboid'); await sleep(150);
+    bot.chat(`//pos1 ${X0},${GY0},${Z0}`); await sleep(150);
+    bot.chat(`//pos2 ${X1},${GY1},${Z1}`); await sleep(150);
+    const weDone = waitChat(bot, /(blocks? have been changed|operation completed|affected)/i, 60000);
+    bot.chat('//set air');
+    await weDone;
+    await sleep(6000); // let the recorder drain to ClickHouse
+
+    log('Stage 2: place VICTIM (diamonds, in grief) + SURVIVOR (emeralds, above)…');
+    await rcon(`setblock ${VX} ${VY} ${VZ} chest`);
+    await rcon(`data merge block ${VX} ${VY} ${VZ} {Items:[{Slot:0b,id:"minecraft:diamond",count:64},{Slot:1b,id:"minecraft:diamond",count:32}]}`);
+    await rcon(`setblock ${SX} ${SY} ${SZ} chest`);
+    await rcon(`data merge block ${SX} ${SY} ${SZ} {Items:[{Slot:0b,id:"minecraft:emerald",count:64}]}`);
+    await sleep(1000);
+
+    log('Stage 3: /sg rollback p:' + BOT + ' -g (restores stone, destroys victim chest)…');
+    let summary = null;
+    const h = m => { if (/(reversals|No results|rolled back|applied)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    const t0 = Date.now();
+    while (summary == null && Date.now() - t0 < 60000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    log(`  rollback: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none/timeout)'}`);
+    await sleep(6000); // let salvage persist + recorder drain
+
+    log('── Verifying ──');
+    // 1. CAPTURE + 2. PRECISION (ClickHouse salvage table)
+    const rowCount = await chQuery(`SELECT count() FROM spyglass.spyglass_salvage FINAL WHERE deleted = 0`);
+    check('CAPTURE: exactly one salvage row exists', rowCount === '1', `rows=${rowCount} (expect 1: victim only)`);
+    const types = await chQuery(`SELECT container_type FROM spyglass.spyglass_salvage FINAL WHERE deleted = 0`);
+    check('CAPTURE: salvaged a CHEST', /CHEST/i.test(types), `container_type=${types}`);
+
+    // 3. WORLD: victim restored to stone, survivor intact
+    const vBlock = bot.blockAt(vec3(VX, VY, VZ))?.name;
+    const sBlock = bot.blockAt(vec3(SX, SY, SZ))?.name;
+    check('WORLD: victim cell restored to stone', vBlock === 'stone', `victim block=${vBlock}`);
+    check('WORLD: survivor chest intact', sBlock === 'chest', `survivor block=${sBlock}`);
+
+    // 4. LISTING: /sg inventory text shows diamonds, not emeralds
+    const listing = await rcon('sg inventory');
+    const clean = listing.replace(/§./g, '');
+    check('LISTING: /sg inventory shows DIAMOND', /DIAMOND/i.test(clean), clean.replace(/\s+/g, ' ').slice(0, 160));
+    check('PRECISION: survivor EMERALD not salvaged', !/EMERALD/i.test(clean), 'emeralds absent from salvage');
+
+    // 5. EXTRACT: player opens the GUI and takes the diamonds
+    log('Stage 4: extract via the GUI…');
+    let extracted = false;
+    try {
+        const idxOpen = new Promise(r => bot.once('windowOpen', r));
+        bot.chat('/sg inventory');
+        const idx = await Promise.race([idxOpen, sleep(8000).then(() => null)]);
+        if (idx) {
+            await sleep(800);
+            bot.clickWindow(0, 0, 0);                 // click the chest icon
+            const snapOpen = new Promise(r => bot.once('windowOpen', r));
+            const snap = await Promise.race([snapOpen, sleep(8000).then(() => null)]);
+            if (snap) {
+                await sleep(800);
+                try { bot.clickWindow(0, 0, 0); } catch { } // take slot 0
+                await sleep(400);
+                try { bot.clickWindow(1, 0, 0); } catch { } // take slot 1
+                await sleep(1200);
+            }
+        }
+        try { bot.closeWindow(bot.currentWindow); } catch { }
+        await sleep(1500);
+        const diamondsHeld = bot.inventory.items().filter(i => /diamond/.test(i.name)).reduce((s, i) => s + i.count, 0);
+        extracted = diamondsHeld > 0;
+        check('EXTRACT: diamonds moved into player inventory', extracted, `held=${diamondsHeld}`);
+    } catch (e) {
+        check('EXTRACT: diamonds moved into player inventory', false, 'gui error: ' + (e?.message || e));
+    }
+    await sleep(4000); // let withdraw + store update persist
+
+    const afterCount = await chQuery(`SELECT count() FROM spyglass.spyglass_salvage FINAL WHERE deleted = 0`);
+    check('EXTRACT: salvage snapshot emptied/removed after taking all', afterCount === '0', `rows=${afterCount} (expect 0)`);
+    const withdraws = await chQuery(`SELECT count() FROM spyglass.event_records WHERE event = 'salvage-withdraw'`);
+    check('EXTRACT: salvage-withdraw event logged', Number(withdraws) >= 1, `count=${withdraws}`);
+
+    // Summary
+    const passed = results.filter(r => r.ok).length;
+    log(`\n──────── SALVAGE SUITE: ${passed}/${results.length} checks passed ────────`);
+    for (const r of results) log(`  ${r.ok ? '✓' : '✗'} ${r.name}`);
+    const allPass = results.every(r => r.ok);
+    log(`\n  VERDICT: ${allPass ? 'PASS — container salvage works end-to-end.' : 'FAIL — see checks above.'}`);
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`fill ${X0} ${GY0} ${Z0} ${X1} ${SY} ${Z1} air`);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(allPass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -55,6 +55,10 @@ public final class EventCatalog {
         m.put("named", EntityNameRecord.class);
         m.put("entity-deposit", ContainerDepositRecord.class);
         m.put("entity-withdraw", ContainerWithdrawRecord.class);
+        // Emitted when an operator takes an item out of a rollback-salvage
+        // snapshot via /sg inventory (#76). Reuses the withdraw record shape,
+        // so both storage backends already persist it.
+        m.put("salvage-withdraw", ContainerWithdrawRecord.class);
         m.put("bookshelf-insert", ContainerDepositRecord.class);
         m.put("bookshelf-remove", ContainerWithdrawRecord.class);
         m.put("pot-insert", ContainerDepositRecord.class);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -102,6 +102,13 @@ import net.medievalrp.spyglass.plugin.storage.IndexManager;
 import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
 import net.medievalrp.spyglass.plugin.storage.SynthesizingRecordStore;
+import net.medievalrp.spyglass.plugin.salvage.ClickHouseSalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.MongoSalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.SalvageCapturer;
+import net.medievalrp.spyglass.plugin.salvage.SalvageGui;
+import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.SalvageWithdrawLogger;
+import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.tool.ClickHouseToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.MongoToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.ToolStateStore;
@@ -127,6 +134,7 @@ public final class SpyglassPlugin extends JavaPlugin {
     private java.util.concurrent.ExecutorService worldWriteExecutor;
     private UndoStack undoStack;
     private ToolStateStore toolStateStore;
+    private SalvageStore salvageStore;
     private Executor queryExecutor;
     private SpyglassConfig config;
     private WorldEditSubscriber worldEditSubscriber;
@@ -153,6 +161,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                             mongoStore.database(), mongoStore.codecRegistry());
                     toolStateStore = new MongoToolStateStore(
                             mongoStore.database(), getLogger());
+                    salvageStore = new MongoSalvageStore(
+                            mongoStore.database(), mongoStore.codecRegistry(), 30L);
                 }
                 case CLICKHOUSE -> {
                     SpyglassConfig.ClickHouse ch = config.database().clickhouse();
@@ -164,6 +174,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                             chStore.client(), ch.database());
                     toolStateStore = new ClickHouseToolStateStore(
                             chStore.client(), ch.database());
+                    salvageStore = new ClickHouseSalvageStore(
+                            chStore.client(), ch.database(), 30L);
                 }
             }
             if (config.storage().rolledAuditSynthesized()) {
@@ -384,6 +396,16 @@ public final class SpyglassPlugin extends JavaPlugin {
         // chunk during the async write phase — chunks pinned loaded
         // until each chunk's main-thread post-processing completes.
         engine.setChunkTicketHolder(this);
+        // Container salvage (#76): capture inventories a rollback would destroy
+        // so they can be recovered via /sg inventory. Wired only when the
+        // backend provides a salvage store (Mongo for now); the persist runs on
+        // the virtual-thread query executor, never the main thread.
+        if (salvageStore != null) {
+            engine.setSalvageHook(new SalvageCapturer(salvageStore, queryExecutor, getLogger()));
+            getLogger().info("Spyglass: container salvage capture enabled.");
+        } else {
+            getLogger().info("Spyglass: container salvage capture disabled for this backend.");
+        }
         ServiceSupport serviceSupport = ServiceSupport.bukkit(this);
 
         QueryStringParser parser = new QueryStringParser(apiImpl, config);
@@ -427,6 +449,30 @@ public final class SpyglassPlugin extends JavaPlugin {
         TeleportService teleportService = new TeleportService();
         SpyglassSuggestions suggestions = new SpyglassSuggestions(apiImpl);
 
+        // Container salvage GUI + command (#76). The withdraw logger records a
+        // salvage-withdraw event (reusing ContainerWithdrawRecord) so every
+        // recovery is auditable; the GUI persists off-main on the query pool.
+        SalvageWithdrawLogger salvageWithdrawLogger = (player, snap, taken, amount) -> {
+            net.medievalrp.spyglass.api.util.BlockLocation salvageLoc =
+                    new net.medievalrp.spyglass.api.util.BlockLocation(
+                            snap.worldId(), snap.worldName(), snap.x(), snap.y(), snap.z());
+            net.medievalrp.spyglass.api.event.RecordContext salvageCtx =
+                    support.playerContext(player, salvageLoc);
+            net.medievalrp.spyglass.api.event.StoredItem salvageStored =
+                    net.medievalrp.spyglass.plugin.util.ItemSerialization.storedItem(0, taken);
+            recorder.record(net.medievalrp.spyglass.api.event.ContainerWithdrawRecord.of(
+                    salvageCtx, "salvage-withdraw", taken.getType().name(),
+                    snap.containerType(), 0, amount, salvageStored, null));
+        };
+        SalvageGui salvageGui = salvageStore == null ? null
+                : new SalvageGui(salvageStore, queryExecutor, salvageWithdrawLogger,
+                        config.limits().searchResult(), getLogger());
+        if (salvageGui != null) {
+            getServer().getPluginManager().registerEvents(salvageGui, this);
+        }
+        SalvageService salvageService = new SalvageService(
+                salvageStore, salvageGui, config.limits().searchResult());
+
         SpyglassCommands commands = new SpyglassCommands(
                 this,
                 apiImpl,
@@ -438,6 +484,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 pageCache,
                 toolService,
                 teleportService,
+                salvageService,
                 suggestions);
         commands.register();
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -7,6 +7,7 @@ import net.medievalrp.spyglass.plugin.command.service.HelpService;
 import net.medievalrp.spyglass.plugin.command.service.RbqueueService;
 import net.medievalrp.spyglass.plugin.command.service.RollbackMode;
 import net.medievalrp.spyglass.plugin.command.service.RollbackService;
+import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.SearchService;
 import net.medievalrp.spyglass.plugin.command.service.TeleportService;
 import net.medievalrp.spyglass.plugin.command.service.ToolService;
@@ -37,6 +38,7 @@ public final class SpyglassCommands {
     private final PageCache pageCache;
     private final ToolService tool;
     private final TeleportService teleport;
+    private final SalvageService salvage;
     private final SpyglassSuggestions suggestions;
 
     public SpyglassCommands(JavaPlugin plugin,
@@ -49,6 +51,7 @@ public final class SpyglassCommands {
                         PageCache pageCache,
                         ToolService tool,
                         TeleportService teleport,
+                        SalvageService salvage,
                         SpyglassSuggestions suggestions) {
         this.plugin = plugin;
         this.api = api;
@@ -60,6 +63,7 @@ public final class SpyglassCommands {
         this.pageCache = pageCache;
         this.tool = tool;
         this.teleport = teleport;
+        this.salvage = salvage;
         this.suggestions = suggestions;
     }
 
@@ -76,6 +80,7 @@ public final class SpyglassCommands {
     private static final List<String> TOOL_ALIASES = List.of("tool", "t", "inspect");
     private static final List<String> EVENTS_ALIASES = List.of("events", "e");
     private static final List<String> HELP_ALIASES = List.of("help", "h", "?");
+    private static final List<String> INVENTORY_ALIASES = List.of("inventory", "inv", "salvage");
 
     public CommandManager<CommandSender> register() {
         LegacyPaperCommandManager<CommandSender> manager = LegacyPaperCommandManager.createNative(
@@ -147,6 +152,12 @@ public final class SpyglassCommands {
                 manager.command(manager.commandBuilder(root).literal(name)
                         .permission("spyglass.tool")
                         .handler(ctx -> tool.toggle(ctx.sender())));
+            }
+
+            for (String name : INVENTORY_ALIASES) {
+                manager.command(manager.commandBuilder(root).literal(name)
+                        .permission("spyglass.rollback")
+                        .handler(ctx -> salvage.execute(ctx.sender())));
             }
 
             // /spyglass tele <world> <x> <y> <z> — wired to search-result click

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -284,6 +284,9 @@ public final class RollbackService {
                                      boolean replayOp) {
         CommandSender sender = job.sender;
         AtomicBoolean cancelFlag = job.cancelFlag;
+        // Attribute any containers this rollback salvages to the operator and
+        // reset the capturer's per-run dedup state (#76).
+        engine.salvageBegin(sender == null ? "console" : sender.getName());
         // Encoded once per job: checkpoint() re-writes the whole marker
         // after every applied window and must carry the same resolved
         // plan markStart wrote (#49). Null for replays — see runJob.

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SalvageService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SalvageService.java
@@ -1,0 +1,54 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.command.render.Feedback;
+import net.medievalrp.spyglass.plugin.salvage.SalvageGui;
+import net.medievalrp.spyglass.plugin.salvage.SalvageSnapshot;
+import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Backs {@code /sg inventory}. A player gets the chest-icon GUI; the console /
+ * RCON (no GUI possible) gets a text listing — which also makes the feature
+ * scriptable for the regression harness.
+ */
+public final class SalvageService {
+
+    private final SalvageStore store;
+    private final SalvageGui gui;
+    private final int listLimit;
+
+    public SalvageService(SalvageStore store, SalvageGui gui, int listLimit) {
+        this.store = store;
+        this.gui = gui;
+        this.listLimit = listLimit;
+    }
+
+    public void execute(CommandSender sender) {
+        if (store == null || gui == null) {
+            sender.sendMessage(Feedback.error("Container salvage is not enabled on this backend."));
+            return;
+        }
+        if (sender instanceof Player player) {
+            gui.openIndex(player);
+            return;
+        }
+        List<SalvageSnapshot> snaps = store.list(listLimit);
+        if (snaps.isEmpty()) {
+            sender.sendMessage(Feedback.bonus("No salvaged inventories."));
+            return;
+        }
+        sender.sendMessage(Feedback.success("Salvaged inventories: " + snaps.size()));
+        for (SalvageSnapshot snap : snaps) {
+            String items = snap.items().stream()
+                    .map(StoredItem::material)
+                    .collect(Collectors.joining(", "));
+            sender.sendMessage(Feedback.bonus("#" + snap.id().toString().substring(0, 8)
+                    + " " + snap.worldName() + " " + snap.x() + "," + snap.y() + "," + snap.z()
+                    + " " + snap.containerType() + " [" + items + "] by " + snap.operatorName()));
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -90,6 +90,25 @@ public final class RollbackEngine {
     // from the main thread stay consistent. Null = sync fallback.
     private volatile Executor worldWriteExecutor;
 
+    // Salvage hook (#76): captures container inventories a rollback would
+    // destroy, so they can be recovered via /sg inventory. Null when salvage
+    // is disabled or in unit tests — the engine treats null as a no-op.
+    private volatile SalvageHook salvageHook;
+
+    public void setSalvageHook(SalvageHook hook) {
+        this.salvageHook = hook;
+    }
+
+    // Marks the start of one rollback so salvaged containers are attributed to
+    // the operator and the capturer's per-run dedup is reset. No-op without a
+    // hook, so unit tests and salvage-disabled backends are unaffected.
+    public void salvageBegin(String operatorName) {
+        SalvageHook hook = salvageHook;
+        if (hook != null) {
+            hook.begin(operatorName);
+        }
+    }
+
     // How many chunks' palette writes the apply path dispatches
     // concurrently per batch — matched to the worldWriteExecutor pool
     // size so every thread stays busy without queueing. 1 keeps the
@@ -508,6 +527,9 @@ public final class RollbackEngine {
                 // writeBlock only re-resolves the section on Y crossings.
                 ChunkDirectWriter.ChunkContext chunkCtx =
                         ChunkDirectWriter.prepareChunk(world, cx, cz);
+                if (salvageHook != null) {
+                    salvageHook.onChunkResolved(world, cx, cz);
+                }
 
                 for (int j = i; j < chunkEnd; j++) {
                     int targetIndex = blockReplaceIndices.get(j);
@@ -536,6 +558,9 @@ public final class RollbackEngine {
                 } catch (RuntimeException ignored) {
                     // Best-effort: a failed resend only delays the client's view
                     // of the restored chunk until its next natural update.
+                }
+                if (salvageHook != null) {
+                    salvageHook.onChunkWritten(world, cx, cz);
                 }
             }
 
@@ -644,6 +669,9 @@ public final class RollbackEngine {
             }
             ChunkDirectWriter.ChunkContext ctx =
                     ChunkDirectWriter.prepareChunk(world, cx, cz);
+            if (salvageHook != null) {
+                salvageHook.onChunkResolved(world, cx, cz);
+            }
             batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
             cursor = chunkEnd;
         }
@@ -795,6 +823,9 @@ public final class RollbackEngine {
             } catch (RuntimeException ignored) {
                 // Best-effort: a failed resend only delays the client's view
                 // of the restored chunk until its next natural update.
+            }
+            if (salvageHook != null) {
+                salvageHook.onChunkWritten(world, work.cx, work.cz);
             }
         } finally {
             if (work.ticketAdded && chunkTicketHolder != null) {
@@ -963,6 +994,9 @@ public final class RollbackEngine {
                 }
             }
             ChunkDirectWriter.ChunkContext ctx = ChunkDirectWriter.prepareChunk(world, cx, cz);
+            if (salvageHook != null) {
+                salvageHook.onChunkResolved(world, cx, cz);
+            }
             batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
             cursor = rangeEnd;
         }
@@ -985,6 +1019,9 @@ public final class RollbackEngine {
                 } catch (RuntimeException ignored) {
                     // Best-effort: a failed resend only delays the client's view
                     // of the restored chunk until its next natural update.
+                }
+                if (salvageHook != null) {
+                    salvageHook.onChunkWritten(world, cc.cx, cc.cz);
                 }
                 if (cc.ticketAdded && ticketHolder != null) {
                     try {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/SalvageHook.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/SalvageHook.java
@@ -1,0 +1,35 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import org.bukkit.World;
+
+/**
+ * Lets the {@link RollbackEngine} hand off container inventories that a
+ * rollback is about to destroy, so they can be salvaged instead of lost. The
+ * engine knows nothing about storage or Bukkit inventories — it just signals
+ * each chunk's lifecycle and the implementation does the capture.
+ *
+ * <p>All methods run on the main server thread. The hook is {@code null} in
+ * unit tests and when salvage is disabled — the engine treats that as a no-op,
+ * so this never affects the headless engine tests.
+ *
+ * <p>Capture-then-verify: {@link #onChunkResolved} snapshots a chunk's live
+ * containers <em>before</em> its blocks are overwritten; {@link #onChunkWritten}
+ * runs <em>after</em> and keeps only the ones the rollback actually destroyed
+ * (discarding survivors), so nothing that still exists in the world is ever
+ * salvaged — no item duplication.
+ */
+public interface SalvageHook {
+
+    /** Mark the start of one rollback/restore so captures are attributed. */
+    void begin(String operatorName);
+
+    /** Before a chunk's blocks are overwritten: snapshot its live containers. */
+    void onChunkResolved(World world, int chunkX, int chunkZ);
+
+    /** After a chunk's blocks are written: persist the containers that were
+     *  actually destroyed; discard the ones that survived unchanged. */
+    void onChunkWritten(World world, int chunkX, int chunkZ);
+
+    /** End of the operation — drop any per-run state. */
+    void end();
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/ClickHouseSalvageStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/ClickHouseSalvageStore.java
@@ -1,0 +1,185 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.command.CommandResponse;
+import com.clickhouse.client.api.query.GenericRecord;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.BsonBlobs;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * ClickHouse-backed {@link SalvageStore}. A {@code ReplacingMergeTree(updated_at)}
+ * keyed on {@code id}: a re-insert with a newer {@code updated_at} supersedes the
+ * row (so an extraction's {@link #replaceItems} wins), and {@link #delete} writes
+ * a {@code deleted=1} tombstone that {@code FINAL WHERE deleted = 0} reads hide.
+ * Items are a {@code |}-joined list of {@link BsonBlobs#encodeStoredItem} blobs.
+ * Modeled on {@code ClickHouseUndoStack}; self-creates its table.
+ */
+@ApiStatus.Internal
+public final class ClickHouseSalvageStore implements SalvageStore {
+
+    private static final DateTimeFormatter CH_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final UUID ZERO_UUID = new UUID(0L, 0L);
+
+    private final Client client;
+    private final String table;
+
+    public ClickHouseSalvageStore(Client client, String database, long ttlDays) {
+        this.client = client;
+        this.table = "`" + database + "`.`spyglass_salvage`";
+        ensureTable(ttlDays);
+    }
+
+    private void ensureTable(long ttlDays) {
+        String ttl = ttlDays > 0
+                ? "TTL toDateTime(captured_at) + INTERVAL " + ttlDays + " DAY\n"
+                : "";
+        execute("CREATE TABLE IF NOT EXISTS " + table + " (\n"
+                + "  id UUID,\n"
+                + "  rollback_op_id UUID,\n"
+                + "  world_id UUID,\n"
+                + "  world_name String,\n"
+                + "  x Int32,\n  y Int32,\n  z Int32,\n"
+                + "  container_type String,\n"
+                + "  operator_name String,\n"
+                + "  captured_at DateTime64(3),\n"
+                + "  items String,\n"
+                + "  deleted UInt8,\n"
+                + "  updated_at DateTime64(3)\n"
+                + ") ENGINE = ReplacingMergeTree(updated_at)\n"
+                + "ORDER BY id\n"
+                + ttl);
+    }
+
+    @Override
+    public void save(SalvageSnapshot snapshot) {
+        insert(snapshot, false);
+    }
+
+    @Override
+    public List<SalvageSnapshot> list(int limit) {
+        List<SalvageSnapshot> out = new ArrayList<>();
+        for (GenericRecord row : client.queryAll(selectColumns()
+                + " FROM " + table + " FINAL WHERE deleted = 0 "
+                + "ORDER BY captured_at DESC LIMIT " + Math.max(1, limit))) {
+            out.add(fromRow(row));
+        }
+        return out;
+    }
+
+    @Override
+    public Optional<SalvageSnapshot> get(UUID id) {
+        List<GenericRecord> rows = client.queryAll(selectColumns()
+                + " FROM " + table + " FINAL WHERE deleted = 0 AND id = toUUID('" + id + "') LIMIT 1");
+        return rows.isEmpty() ? Optional.empty() : Optional.of(fromRow(rows.get(0)));
+    }
+
+    @Override
+    public void replaceItems(UUID id, List<StoredItem> remaining) {
+        get(id).ifPresent(current -> insert(current.withItems(remaining), false));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        String now = chTimestamp(Instant.now());
+        execute("INSERT INTO " + table + " " + columns() + " VALUES ("
+                + "toUUID('" + id + "'), toUUID('" + ZERO_UUID + "'), toUUID('" + ZERO_UUID + "'), "
+                + "'', 0, 0, 0, '', '', " + now + ", '', 1, " + now + ")");
+    }
+
+    private void insert(SalvageSnapshot s, boolean deleted) {
+        execute("INSERT INTO " + table + " " + columns() + " VALUES ("
+                + "toUUID('" + s.id() + "'), "
+                + "toUUID('" + (s.rollbackOpId() == null ? ZERO_UUID : s.rollbackOpId()) + "'), "
+                + "toUUID('" + s.worldId() + "'), " + escape(s.worldName()) + ", "
+                + s.x() + ", " + s.y() + ", " + s.z() + ", "
+                + escape(s.containerType()) + ", " + escape(s.operatorName()) + ", "
+                + chTimestamp(s.capturedAt()) + ", " + escape(encodeItems(s.items())) + ", "
+                + (deleted ? 1 : 0) + ", " + chTimestamp(Instant.now()) + ")");
+    }
+
+    private SalvageSnapshot fromRow(GenericRecord r) {
+        return new SalvageSnapshot(
+                r.getUUID("id"),
+                r.getUUID("rollback_op_id"),
+                r.getUUID("world_id"),
+                r.getString("world_name"),
+                (int) r.getLong("x"), (int) r.getLong("y"), (int) r.getLong("z"),
+                r.getString("container_type"),
+                r.getString("operator_name"),
+                r.getInstant("captured_at"),
+                decodeItems(r.getString("items")));
+    }
+
+    private static String selectColumns() {
+        return "SELECT id, rollback_op_id, world_id, world_name, x, y, z, "
+                + "container_type, operator_name, captured_at, items";
+    }
+
+    private static String columns() {
+        return "(id, rollback_op_id, world_id, world_name, x, y, z, container_type, "
+                + "operator_name, captured_at, items, deleted, updated_at)";
+    }
+
+    // Items as a '|'-joined list of base64 blobs. The base64 alphabet never
+    // contains '|', so the split is unambiguous.
+    static String encodeItems(List<StoredItem> items) {
+        StringBuilder sb = new StringBuilder();
+        for (StoredItem item : items) {
+            String enc = BsonBlobs.encodeStoredItem(item);
+            if (enc != null) {
+                if (sb.length() > 0) {
+                    sb.append('|');
+                }
+                sb.append(enc);
+            }
+        }
+        return sb.toString();
+    }
+
+    static List<StoredItem> decodeItems(String blob) {
+        List<StoredItem> items = new ArrayList<>();
+        if (blob == null || blob.isEmpty()) {
+            return items;
+        }
+        for (String part : blob.split("\\|")) {
+            if (!part.isEmpty()) {
+                StoredItem item = BsonBlobs.decodeStoredItem(part);
+                if (item != null) {
+                    items.add(item);
+                }
+            }
+        }
+        return items;
+    }
+
+    private void execute(String sql) {
+        try (CommandResponse ignored = client.execute(sql).get(30, TimeUnit.SECONDS)) {
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Salvage command interrupted", ie);
+        } catch (Exception ex) {
+            throw new RuntimeException("Salvage command failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    private static String chTimestamp(Instant instant) {
+        return "'" + CH_TIMESTAMP.format(instant.atOffset(ZoneOffset.UTC)) + "'";
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "''";
+        }
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/MongoSalvageStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/MongoSalvageStore.java
@@ -1,0 +1,76 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Mongo-backed {@link SalvageStore}. One small collection of
+ * {@link SalvageSnapshot} documents, decoded with the shared Spyglass codec
+ * registry (the same one that already knows {@code StoredItem}). Modeled on
+ * {@code MongoUndoStack}.
+ */
+@ApiStatus.Internal
+public final class MongoSalvageStore implements SalvageStore {
+
+    private final MongoCollection<SalvageSnapshot> collection;
+
+    public MongoSalvageStore(MongoDatabase database, CodecRegistry codecRegistry, long ttlDays) {
+        MongoDatabase db = database.withCodecRegistry(codecRegistry);
+        this.collection = db.getCollection("SpyglassSalvage", SalvageSnapshot.class);
+        // Single ascending index on capturedAt: serves the newest-first list
+        // (Mongo scans it in reverse) and, with expireAfter, prunes old
+        // salvage so the store self-cleans. ttlDays <= 0 disables expiry.
+        if (ttlDays > 0) {
+            this.collection.createIndex(Indexes.ascending("capturedAt"),
+                    new IndexOptions().expireAfter(ttlDays, TimeUnit.DAYS));
+        } else {
+            this.collection.createIndex(Indexes.ascending("capturedAt"));
+        }
+    }
+
+    @Override
+    public void save(SalvageSnapshot snapshot) {
+        collection.insertOne(snapshot);
+    }
+
+    @Override
+    public List<SalvageSnapshot> list(int limit) {
+        List<SalvageSnapshot> out = new ArrayList<>();
+        collection.find()
+                .sort(Sorts.descending("capturedAt"))
+                .limit(Math.max(1, limit))
+                .into(out);
+        return out;
+    }
+
+    @Override
+    public Optional<SalvageSnapshot> get(UUID id) {
+        return Optional.ofNullable(collection.find(Filters.eq("_id", id)).first());
+    }
+
+    @Override
+    public void replaceItems(UUID id, List<StoredItem> remaining) {
+        SalvageSnapshot current = collection.find(Filters.eq("_id", id)).first();
+        if (current == null) {
+            return;
+        }
+        collection.replaceOne(Filters.eq("_id", id), current.withItems(remaining));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        collection.deleteOne(Filters.eq("_id", id));
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
@@ -1,0 +1,187 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.rollback.SalvageHook;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Container;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Captures container inventories a rollback destroys (see {@link SalvageHook}).
+ *
+ * <p>On {@link #onChunkResolved} it clones the live contents of every non-empty
+ * container in the chunk (the chunk's block-entity map lists them directly — no
+ * per-block scan; terrain chunks have none and cost nothing). On
+ * {@link #onChunkWritten} it re-reads each captured cell: if the container is
+ * gone or its contents changed, the rollback destroyed it and the clone is
+ * persisted; if it survived unchanged, the clone is dropped. So only genuinely
+ * destroyed inventories reach the store, and nothing still present in the world
+ * is ever salvaged.
+ *
+ * <p>All hook methods run on the main thread; only the final {@link SalvageStore#save}
+ * is dispatched off-main. One rollback runs at a time (the job queue serializes
+ * them), so the per-run {@code pending} state needs no cross-run synchronization.
+ */
+public final class SalvageCapturer implements SalvageHook {
+
+    private final SalvageStore store;
+    private final Executor persistExecutor;
+    private final Logger logger;
+
+    private final Map<String, List<Captured>> pending = new HashMap<>();
+    // Cells already salvaged this rollback — guards against a chunk being
+    // resolved twice (its simple cells via the columnar path, its complex cells
+    // via the object path) double-persisting the same destroyed container.
+    private final Set<String> salvagedCells = new HashSet<>();
+    private volatile String operator = "console";
+
+    public SalvageCapturer(SalvageStore store, Executor persistExecutor, Logger logger) {
+        this.store = store;
+        this.persistExecutor = persistExecutor;
+        this.logger = logger;
+    }
+
+    private record Captured(int x, int y, int z, String type, List<StoredItem> items) {
+    }
+
+    @Override
+    public void begin(String operatorName) {
+        this.operator = operatorName == null ? "console" : operatorName;
+        this.pending.clear();
+        this.salvagedCells.clear();
+    }
+
+    @Override
+    public void end() {
+        this.pending.clear();
+        this.salvagedCells.clear();
+        this.operator = "console";
+    }
+
+    @Override
+    public void onChunkResolved(World world, int chunkX, int chunkZ) {
+        if (!world.isChunkLoaded(chunkX, chunkZ)) {
+            return;
+        }
+        Chunk chunk = world.getChunkAt(chunkX, chunkZ);
+        List<Captured> captured = null;
+        // useSnapshot=false: read the live tile entities (we're on the main
+        // thread, before any write to this chunk). Most chunks have none.
+        for (BlockState state : chunk.getTileEntities(false)) {
+            if (state instanceof Container container) {
+                List<StoredItem> items = capture(container.getInventory());
+                if (!items.isEmpty()) {
+                    if (captured == null) {
+                        captured = new ArrayList<>();
+                    }
+                    captured.add(new Captured(state.getX(), state.getY(), state.getZ(),
+                            state.getType().name(), items));
+                }
+            }
+        }
+        if (captured != null) {
+            pending.put(key(world, chunkX, chunkZ), captured);
+            logger.fine("salvage: captured " + captured.size()
+                    + " non-empty container(s) in chunk " + chunkX + "," + chunkZ);
+        }
+    }
+
+    @Override
+    public void onChunkWritten(World world, int chunkX, int chunkZ) {
+        List<Captured> captured = pending.remove(key(world, chunkX, chunkZ));
+        if (captured == null) {
+            return;
+        }
+        final String op = operator;
+        List<SalvageSnapshot> toSave = new ArrayList<>();
+        for (Captured cap : captured) {
+            Block block = world.getBlockAt(cap.x(), cap.y(), cap.z());
+            boolean destroyed;
+            // Check the block TYPE first — read from the chunk section the
+            // rollback overwrote. A direct NMS section write leaves the old block
+            // entity lingering in the chunk map, so getState() can still return a
+            // stale Container even though the block is now (e.g.) stone; the
+            // material is authoritative.
+            if (!block.getType().name().equals(cap.type())) {
+                destroyed = true;
+            } else if (block.getState() instanceof Container container) {
+                // Same container type still here — destroyed only if its contents
+                // changed (e.g. the rollback restored a different recorded inv).
+                destroyed = !sameItems(capture(container.getInventory()), cap.items());
+            } else {
+                destroyed = true;
+            }
+            if (destroyed && salvagedCells.add(
+                    world.getUID() + ":" + cap.x() + ":" + cap.y() + ":" + cap.z())) {
+                toSave.add(new SalvageSnapshot(UUID.randomUUID(), null,
+                        world.getUID(), world.getName(),
+                        cap.x(), cap.y(), cap.z(), cap.type(), op,
+                        Instant.now(), cap.items()));
+            }
+        }
+        if (!toSave.isEmpty()) {
+            logger.fine("salvage: persisting " + toSave.size()
+                    + " destroyed container(s) from chunk " + chunkX + "," + chunkZ);
+            persistExecutor.execute(() -> {
+                for (SalvageSnapshot snapshot : toSave) {
+                    try {
+                        store.save(snapshot);
+                    } catch (RuntimeException ex) {
+                        logger.warning("Spyglass salvage save failed at " + snapshot.x()
+                                + "," + snapshot.y() + "," + snapshot.z() + ": " + ex.getMessage());
+                    }
+                }
+            });
+        }
+    }
+
+    private static List<StoredItem> capture(Inventory inventory) {
+        List<StoredItem> items = new ArrayList<>();
+        int size = inventory.getSize();
+        for (int slot = 0; slot < size; slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (stack != null && stack.getType() != Material.AIR) {
+                items.add(ItemSerialization.storedItem(slot, stack));
+            }
+        }
+        return items;
+    }
+
+    // Equal iff the same slot->blob set. Order-independent; cheap for the
+    // handful of captured containers.
+    private static boolean sameItems(List<StoredItem> a, List<StoredItem> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        Set<String> keys = new HashSet<>();
+        for (StoredItem item : a) {
+            keys.add(item.slot() + ":" + item.data());
+        }
+        for (StoredItem item : b) {
+            if (!keys.contains(item.slot() + ":" + item.data())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String key(World world, int chunkX, int chunkZ) {
+        return world.getUID() + ":" + chunkX + ":" + chunkZ;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageGui.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageGui.java
@@ -1,0 +1,202 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * The {@code /sg inventory} GUI: a grid of chest icons (one per destroyed
+ * inventory) that opens into the salvaged items, <b>extract-only</b>. Built on
+ * the raw Bukkit inventory API — no extra dependency. Every click is cancelled
+ * by default and item movement is performed manually for takes only, which
+ * blocks shift-insert, number-key swaps, drags, double-click collect, and
+ * hopper pulls in one stroke.
+ */
+public final class SalvageGui implements Listener {
+
+    private static final int MAX_SLOTS = 54;
+    private static final DateTimeFormatter TIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
+
+    private final SalvageStore store;
+    private final Executor storeExecutor;
+    private final SalvageWithdrawLogger withdrawLogger;
+    private final int listLimit;
+    private final Logger logger;
+
+    public SalvageGui(SalvageStore store, Executor storeExecutor,
+                      SalvageWithdrawLogger withdrawLogger, int listLimit, Logger logger) {
+        this.store = store;
+        this.storeExecutor = storeExecutor;
+        this.withdrawLogger = withdrawLogger;
+        this.listLimit = listLimit;
+        this.logger = logger;
+    }
+
+    /** The chest-icon grid of every salvaged inventory, newest first. */
+    public void openIndex(Player player) {
+        List<SalvageSnapshot> snaps = store.list(listLimit);
+        if (snaps.isEmpty()) {
+            player.sendMessage(Component.text("No salvaged inventories.", NamedTextColor.GRAY));
+            return;
+        }
+        int size = clampSize(snaps.size());
+        SalvageHolder holder = SalvageHolder.index(snaps);
+        Inventory inv = Bukkit.createInventory(holder, size,
+                Component.text("Rollback Salvage", NamedTextColor.GOLD));
+        holder.setInventory(inv);
+        for (int i = 0; i < snaps.size() && i < size; i++) {
+            inv.setItem(i, indexIcon(snaps.get(i)));
+        }
+        player.openInventory(inv);
+    }
+
+    /** One snapshot's salvaged items, take-only. */
+    public void openSnapshot(Player player, SalvageSnapshot snap) {
+        List<StoredItem> items = snap.items();
+        int size = clampSize(Math.max(1, items.size()));
+        SalvageHolder holder = SalvageHolder.snapshot(snap);
+        Inventory inv = Bukkit.createInventory(holder, size,
+                Component.text("Salvage " + shortId(snap.id()), NamedTextColor.GOLD));
+        holder.setInventory(inv);
+        for (int i = 0; i < items.size() && i < size; i++) {
+            ItemStack stack = ItemSerialization.decode(items.get(i).data());
+            if (stack != null) {
+                inv.setItem(i, stack);
+            }
+        }
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getView().getTopInventory().getHolder() instanceof SalvageHolder holder)) {
+            return;
+        }
+        // Extract-only: deny every default movement; takes are done manually.
+        event.setCancelled(true);
+        Inventory top = event.getView().getTopInventory();
+        if (event.getClickedInventory() != top || !(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getSlot();
+        if (holder.kind() == SalvageHolder.Kind.INDEX) {
+            List<SalvageSnapshot> snaps = holder.snapshots();
+            if (slot >= 0 && slot < snaps.size()) {
+                openSnapshot(player, snaps.get(slot));
+            }
+            return;
+        }
+        take(player, holder, top, slot);
+    }
+
+    @EventHandler
+    public void onDrag(InventoryDragEvent event) {
+        if (event.getView().getTopInventory().getHolder() instanceof SalvageHolder) {
+            event.setCancelled(true);
+        }
+    }
+
+    private void take(Player player, SalvageHolder holder, Inventory top, int slot) {
+        ItemStack item = top.getItem(slot);
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        Map<Integer, ItemStack> overflow = player.getInventory().addItem(item.clone());
+        ItemStack remaining = overflow.isEmpty() ? null : overflow.values().iterator().next();
+        int taken = item.getAmount() - (remaining == null ? 0 : remaining.getAmount());
+        if (taken <= 0) {
+            player.sendMessage(Component.text("Your inventory is full.", NamedTextColor.RED));
+            return;
+        }
+        top.setItem(slot, remaining);
+        if (withdrawLogger != null && holder.snapshot() != null) {
+            ItemStack takenStack = item.clone();
+            takenStack.setAmount(taken);
+            try {
+                withdrawLogger.log(player, holder.snapshot(), takenStack, taken);
+            } catch (RuntimeException ex) {
+                logger.warning("Spyglass salvage withdraw log failed: " + ex.getMessage());
+            }
+        }
+        persist(holder, top);
+    }
+
+    // The GUI is the source of truth once open: recompute the snapshot's
+    // remaining items from its current contents and write that back off-main.
+    private void persist(SalvageHolder holder, Inventory top) {
+        SalvageSnapshot snap = holder.snapshot();
+        if (snap == null) {
+            return;
+        }
+        List<StoredItem> remaining = new ArrayList<>();
+        for (int i = 0; i < top.getSize(); i++) {
+            ItemStack stack = top.getItem(i);
+            if (stack != null && stack.getType() != Material.AIR) {
+                remaining.add(ItemSerialization.storedItem(i, stack));
+            }
+        }
+        UUID id = snap.id();
+        storeExecutor.execute(() -> {
+            try {
+                if (remaining.isEmpty()) {
+                    store.delete(id);
+                } else {
+                    store.replaceItems(id, remaining);
+                }
+            } catch (RuntimeException ex) {
+                logger.warning("Spyglass salvage persist failed: " + ex.getMessage());
+            }
+        });
+    }
+
+    private ItemStack indexIcon(SalvageSnapshot snap) {
+        Material material = Material.matchMaterial(snap.containerType());
+        if (material == null || !material.isItem()) {
+            material = Material.CHEST;
+        }
+        ItemStack icon = new ItemStack(material);
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.displayName(Component.text("Salvage " + shortId(snap.id()), NamedTextColor.YELLOW));
+            List<Component> lore = new ArrayList<>();
+            lore.add(Component.text(snap.worldName() + " " + snap.x() + ", " + snap.y() + ", " + snap.z(),
+                    NamedTextColor.GRAY));
+            lore.add(Component.text(snap.items().size() + " stack(s)", NamedTextColor.GRAY));
+            lore.add(Component.text("by " + snap.operatorName(), NamedTextColor.DARK_GRAY));
+            lore.add(Component.text(TIME.format(snap.capturedAt()), NamedTextColor.DARK_GRAY));
+            lore.add(Component.text("Click to open", NamedTextColor.GREEN));
+            meta.lore(lore);
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private static int clampSize(int itemCount) {
+        int rows = (Math.min(itemCount, MAX_SLOTS) + 8) / 9;
+        return Math.max(1, Math.min(6, rows)) * 9;
+    }
+
+    private static String shortId(UUID id) {
+        return "#" + id.toString().substring(0, 8);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageHolder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageHolder.java
@@ -1,0 +1,57 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.util.List;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Marks a Bukkit inventory as one of the salvage GUIs so the click listener can
+ * recognise it (and tell the index grid from an open snapshot). Carries the
+ * context each view needs: the index grid holds the snapshots it lists (slot →
+ * snapshot); an open snapshot holds its id so extractions persist back to it.
+ */
+public final class SalvageHolder implements InventoryHolder {
+
+    public enum Kind { INDEX, SNAPSHOT }
+
+    private final Kind kind;
+    private final SalvageSnapshot snapshot;
+    private final List<SalvageSnapshot> snapshots;
+    private Inventory inventory;
+
+    private SalvageHolder(Kind kind, SalvageSnapshot snapshot, List<SalvageSnapshot> snapshots) {
+        this.kind = kind;
+        this.snapshot = snapshot;
+        this.snapshots = snapshots;
+    }
+
+    static SalvageHolder index(List<SalvageSnapshot> snapshots) {
+        return new SalvageHolder(Kind.INDEX, null, snapshots);
+    }
+
+    static SalvageHolder snapshot(SalvageSnapshot snapshot) {
+        return new SalvageHolder(Kind.SNAPSHOT, snapshot, List.of());
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    /** The snapshot this view shows (SNAPSHOT kind only; null for INDEX). */
+    public SalvageSnapshot snapshot() {
+        return snapshot;
+    }
+
+    public List<SalvageSnapshot> snapshots() {
+        return snapshots;
+    }
+
+    void setInventory(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageSnapshot.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageSnapshot.java
@@ -1,0 +1,41 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+/**
+ * One container inventory captured because a rollback was about to destroy it
+ * (overwrite the block, or clear/replace its contents). Persisted to the
+ * {@link SalvageStore} and surfaced through {@code /sg inventory} so an operator
+ * can recover the items rather than losing them to a force-overwrite rollback.
+ *
+ * <p>{@code items} are the live contents at capture time, serialized with the
+ * same {@code StoredItem} blob used everywhere else (base64
+ * {@code ItemStack.serializeAsBytes()}), so they reconstruct faithfully.
+ */
+public record SalvageSnapshot(
+        @BsonProperty("_id") UUID id,
+        UUID rollbackOpId,
+        UUID worldId,
+        String worldName,
+        int x,
+        int y,
+        int z,
+        String containerType,
+        String operatorName,
+        Instant capturedAt,
+        List<StoredItem> items) {
+
+    public SalvageSnapshot {
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+
+    /** A copy with a different item list — used after an operator extracts. */
+    public SalvageSnapshot withItems(List<StoredItem> remaining) {
+        return new SalvageSnapshot(id, rollbackOpId, worldId, worldName,
+                x, y, z, containerType, operatorName, capturedAt, remaining);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageStore.java
@@ -1,0 +1,36 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Durable store for container inventories a rollback destroyed. A dedicated
+ * store (not the event log) because the rows are mutable — an operator extracts
+ * items out of a snapshot over time — and carry full item blobs that have no
+ * business in the searchable record stream. Dual-backend by the same pattern as
+ * {@code UndoStack} / {@code ToolStateStore}.
+ */
+@ApiStatus.Internal
+public interface SalvageStore {
+
+    /** Persist a captured inventory. Called off the main thread. */
+    void save(SalvageSnapshot snapshot);
+
+    /** Most-recent snapshots first, capped. Backs the {@code /sg inventory} GUI. */
+    List<SalvageSnapshot> list(int limit);
+
+    Optional<SalvageSnapshot> get(UUID id);
+
+    /** Replace a snapshot's items after an extraction (the slots still present). */
+    void replaceItems(UUID id, List<StoredItem> remaining);
+
+    /** Remove an emptied snapshot. */
+    void delete(UUID id);
+
+    /** Best-effort release of any backend resources. */
+    default void close() {
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageWithdrawLogger.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageWithdrawLogger.java
@@ -1,0 +1,15 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Records an operator taking an item out of a salvage snapshot, so the
+ * recovery is auditable ({@code a:salvage-withdraw}). Supplied by the plugin
+ * (which owns the recorder); the GUI stays free of recording details.
+ */
+@FunctionalInterface
+public interface SalvageWithdrawLogger {
+
+    void log(Player operator, SalvageSnapshot snapshot, ItemStack taken, int amount);
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -240,4 +240,7 @@ events {
   # This is what the per-block entries above are synthesized from —
   # leave enabled.
   rollback-op = { enabled = true, past-tense = "ran" }
+  # Emitted when an operator extracts an item from a rollback-salvage
+  # snapshot via /sg inventory (#76).
+  salvage-withdraw = { enabled = true, past-tense = "took" }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/ClickHouseSalvageStoreTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/ClickHouseSalvageStoreTest.java
@@ -1,0 +1,40 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The ClickHouse salvage store serializes a container's items into one
+ * {@code |}-joined string column. These pin that round-trip — the custom bit
+ * that the headless tests can reach without a live ClickHouse.
+ */
+class ClickHouseSalvageStoreTest {
+
+    @Test
+    void itemsRoundTripThroughTheBlobColumn() {
+        List<StoredItem> items = List.of(
+                new StoredItem(0, "DIAMOND", "ZGF0YS1kaWFtb25k", "Shiny", List.of("lore line"), List.of("ench")),
+                new StoredItem(5, "EMERALD", "ZGF0YS1lbWVyYWxk"));
+
+        String blob = ClickHouseSalvageStore.encodeItems(items);
+        assertThat(blob).contains("|"); // two blobs joined
+
+        List<StoredItem> back = ClickHouseSalvageStore.decodeItems(blob);
+        assertThat(back).hasSize(2);
+        assertThat(back.get(0).slot()).isEqualTo(0);
+        assertThat(back.get(0).material()).isEqualTo("DIAMOND");
+        assertThat(back.get(0).data()).isEqualTo("ZGF0YS1kaWFtb25k");
+        assertThat(back.get(1).slot()).isEqualTo(5);
+        assertThat(back.get(1).material()).isEqualTo("EMERALD");
+    }
+
+    @Test
+    void emptyAndNullDecodeToEmpty() {
+        assertThat(ClickHouseSalvageStore.encodeItems(List.of())).isEmpty();
+        assertThat(ClickHouseSalvageStore.decodeItems("")).isEmpty();
+        assertThat(ClickHouseSalvageStore.decodeItems(null)).isEmpty();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageSnapshotTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageSnapshotTest.java
@@ -1,0 +1,39 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.junit.jupiter.api.Test;
+
+class SalvageSnapshotTest {
+
+    @Test
+    void withItemsKeepsMetadataAndSwapsItems() {
+        UUID id = UUID.randomUUID();
+        SalvageSnapshot snap = new SalvageSnapshot(id, null, UUID.randomUUID(), "world",
+                1, 2, 3, "CHEST", "alice", Instant.EPOCH,
+                List.of(new StoredItem(0, "DIAMOND", "d")));
+
+        SalvageSnapshot updated = snap.withItems(List.of());
+
+        assertThat(updated.id()).isEqualTo(id);
+        assertThat(updated.x()).isEqualTo(1);
+        assertThat(updated.y()).isEqualTo(2);
+        assertThat(updated.z()).isEqualTo(3);
+        assertThat(updated.containerType()).isEqualTo("CHEST");
+        assertThat(updated.operatorName()).isEqualTo("alice");
+        assertThat(updated.items()).isEmpty();
+        // the original is untouched (records are immutable)
+        assertThat(snap.items()).hasSize(1);
+    }
+
+    @Test
+    void nullItemsBecomeEmpty() {
+        SalvageSnapshot snap = new SalvageSnapshot(UUID.randomUUID(), null, UUID.randomUUID(),
+                "world", 0, 0, 0, "BARREL", "op", Instant.EPOCH, null);
+        assertThat(snap.items()).isEmpty();
+    }
+}


### PR DESCRIPTION
A force-overwrite rollback that destroys a container no longer loses its
contents. The rollback captures the destroyed inventory and files it under
/sg inventory, where an operator recovers the items.

Capture (capture-then-verify, dupe-proof, no per-cell cost):
- RollbackEngine signals each chunk's lifecycle to a SalvageHook (null in
  tests / on backends without a salvage store, so a no-op). SalvageCapturer
  clones the live containers in each resolved chunk (the chunk's block-entity
  map lists them directly; terrain chunks have none and cost nothing), then
  after the writes land keeps only the ones the rollback actually destroyed
  and discards survivors. So nothing still in the world is salvaged — no item
  duplication — and the per-cell hot path is untouched. A per-cell dedup
  guards the simple+complex two-pass case.
- Destruction is detected by block TYPE (read from the overwritten section),
  not getState(): a direct NMS section write leaves the old block entity
  lingering, so getState() can still report a stale container.

Storage: a dedicated dual-backend SalvageStore like UndoStack —
MongoSalvageStore (record codec) and ClickHouseSalvageStore
(ReplacingMergeTree, items as a |-joined blob), 30-day TTL.

GUI: /sg inventory (alias inv) — a chest-icon grid (raw Bukkit inventory, no
new dependency) opening into each snapshot, extract-only (every click
cancelled; takes performed manually). Console/RCON gets a text listing.
Extractions move items to the player, shrink/delete the snapshot, and log a
salvage-withdraw event (reuses ContainerWithdrawRecord, so both backends
already persist it). Operator attribution wired through RollbackService.

Verified end-to-end in game (regression/bot/_salvage-proof.js, 9/9): capture,
precision (a survivor chest in the same chunk is NOT salvaged), world
restored, listing, GUI extraction into the player inventory, snapshot
emptied, salvage-withdraw logged. Normal rollback unaffected
(_rollback-proof.js still PASS, 262144 blocks ~0.7s). Unit tests for the CH
item serialization + the snapshot record; ./gradlew check green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
