### PR TITLE
feat: move vanilla WorldEdit edit-logging off the main thread (#87)

### DIFF
--- a/regression/bot/_worldedit-offmain-proof.js
+++ b/regression/bot/_worldedit-offmain-proof.js
@@ -1,0 +1,83 @@
+// End-to-end proof for #87: WorldEdit edit-logging moved off the main thread.
+// A //set over stone + a filled chest must still log break/place records
+// (origin=worldedit) and roll back faithfully — including the chest's items,
+// which are captured on the main thread and must survive the off-main build.
+import mineflayer from 'mineflayer';
+import vec3 from 'vec3';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = (...a) => console.log('[' + new Date().toISOString().slice(11, 19) + ']', ...a);
+const BOT = 'wep' + Math.floor(1000 + Math.random() * 8999); // unique → CH rows never collide
+
+function pkt(i, t, b) { const u = Buffer.from(b); const l = 10 + u.length; const o = Buffer.alloc(4 + l); o.writeInt32LE(l, 0); o.writeInt32LE(i, 4); o.writeInt32LE(t, 8); u.copy(o, 12); return o; }
+function rcon(cmd) { return new Promise((res, rej) => { const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 60000 }); let st = 0, bs = []; s.on('error', rej); s.on('timeout', () => { s.destroy(); rej('t/o'); }); s.on('connect', () => s.write(pkt(1, 3, PASS))); s.on('data', c => { bs.push(c); const a = Buffer.concat(bs); if (a.length < 4) return; const l = a.readInt32LE(0); if (a.length < l + 4) return; if (st === 0) { st = 1; bs = []; s.write(pkt(1, 2, cmd)); } else { s.end(); res(a.slice(12, 12 + l - 10).toString().replace(/§./g, '')); } }); }); }
+function waitChat(bot, re, t) { return new Promise(r => { const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); r(m); } }; bot.on('messagestr', h); setTimeout(() => { bot.removeListener('messagestr', h); r(null); }, t); }); }
+async function ch(q) { return (await (await fetch(`http://localhost:8123/?query=${encodeURIComponent(q)}`)).text()).trim(); }
+
+let pass = 0, fail = 0;
+const check = (name, ok, detail) => { if (ok) { pass++; log(`  ✅ ${name}`); } else { fail++; log(`  ❌ ${name} — ${detail}`); } };
+
+// Small region so the test is fast; the off-main behaviour is identical at any
+// size (scale is proven separately by the profiler run).
+const S = 6, X = 16000, Y = 75, Z = 16000;
+const x1 = X + S - 1, y1 = Y + S - 1, z1 = Z + S - 1;
+const CX = X + 3, CY = Y + 3, CZ = Z + 3;       // chest cell inside the region
+const VOL = S * S * S;                          // 216 cells
+
+(async () => {
+  log(`=== #87 WorldEdit off-main logging proof (bot=${BOT}) ===`);
+  await rcon(`forceload add ${X} ${Z} ${x1} ${z1}`); await sleep(600);
+
+  log('setup: fill stone + a chest of 17 diamonds…');
+  await rcon(`fill ${X} ${Y} ${Z} ${x1} ${y1} ${z1} stone`); await sleep(400);
+  await rcon(`setblock ${CX} ${CY} ${CZ} chest`); await sleep(200);
+  await rcon(`data merge block ${CX} ${CY} ${CZ} {Items:[{Slot:0b,id:"minecraft:diamond",count:17}]}`); await sleep(300);
+  const pre = await rcon(`data get block ${CX} ${CY} ${CZ} Items`);
+  check('setup chest holds 17 diamonds', /diamond/.test(pre) && /17/.test(pre), pre.slice(0, 80));
+
+  const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+  await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+  await rcon(`op ${BOT}`); await rcon(`gamemode creative ${BOT}`); await rcon(`tp ${BOT} ${CX} ${y1 + 3} ${CZ}`); await sleep(2500);
+  try { await bot.waitForChunksToLoad(); } catch { }
+  await sleep(1500);
+
+  log('//set glass over the region (break + place, off-main build)…');
+  bot.chat('//sel cuboid'); await sleep(300);
+  bot.chat(`//pos1 ${X},${Y},${Z}`); await sleep(300);
+  bot.chat(`//pos2 ${x1},${y1},${z1}`); await sleep(300);
+  const setDone = waitChat(bot, /have been changed|operation completed/i, 60000);
+  bot.chat('//set glass');
+  await setDone;
+
+  log('draining to ClickHouse…');
+  await sleep(8000);
+  const breaks = parseInt(await ch(`SELECT count() FROM spyglass.event_records WHERE origin_kind='worldedit' AND source_player_name='${BOT}' AND event='break'`)) || 0;
+  const places = parseInt(await ch(`SELECT count() FROM spyglass.event_records WHERE origin_kind='worldedit' AND source_player_name='${BOT}' AND event='place'`)) || 0;
+  const glassPlaces = parseInt(await ch(`SELECT count() FROM spyglass.event_records WHERE origin_kind='worldedit' AND source_player_name='${BOT}' AND event='place' AND target='GLASS'`)) || 0;
+  const chestBreaks = parseInt(await ch(`SELECT count() FROM spyglass.event_records WHERE origin_kind='worldedit' AND source_player_name='${BOT}' AND event='break' AND target='CHEST'`)) || 0;
+  check(`break records logged off-main (${breaks}/${VOL})`, breaks === VOL, `got ${breaks}`);
+  check(`place records logged off-main (${places}/${VOL})`, places === VOL, `got ${places}`);
+  check(`edit applied — all places are glass (${glassPlaces}/${VOL})`, glassPlaces === VOL, `got ${glassPlaces}`);
+  check(`destroyed chest captured (target=CHEST: ${chestBreaks})`, chestBreaks === 1, `got ${chestBreaks}`);
+
+  log(`rollback: /sg rollback p:${BOT} t:10m -g`);
+  await rcon(`sg rollback p:${BOT} t:10m -g`);
+  for (let i = 0; i < 60; i++) { const q = await rcon('sg rbqueue list'); if (/Recent/.test(q) && !/Running:/.test(q)) break; await sleep(1000); }
+  await sleep(1500);
+
+  const cornerName = bot.blockAt(vec3(X, Y, Z))?.name;
+  const chestName = bot.blockAt(vec3(CX, CY, CZ))?.name;
+  check('region restored to stone', cornerName === 'stone', cornerName);
+  check('chest block restored', chestName === 'chest', chestName);
+  const post = await rcon(`data get block ${CX} ${CY} ${CZ} Items`);
+  check('chest items restored (17 diamonds survived off-main capture+rollback)',
+    /diamond/.test(post) && /17/.test(post), post.slice(0, 100));
+
+  bot.quit();
+  await rcon(`fill ${X} ${Y} ${Z} ${x1} ${y1} ${z1} air`);
+  await rcon(`forceload remove ${X} ${Z} ${x1} ${z1}`);
+  log(`\n=== RESULT: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { log('FATAL', e?.message || e); process.exit(2); });

--- a/regression/bot/we-profile.js
+++ b/regression/bot/we-profile.js
@@ -1,0 +1,45 @@
+// Profile the main thread during a bulk WorldEdit //set, to attribute how much
+// tick time Spyglass's WE-edit logging costs. Compares old (synchronous) vs new
+// (off-main) jars: grep the Sundial report for WorldEditSubscriber frames.
+// Usage: node we-profile.js <tag>   (tag distinguishes runs, e.g. old / new)
+import mineflayer from 'mineflayer';
+import net from 'net';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const TAG = process.argv[2] || 'run';
+function pkt(i, t, b) { const u = Buffer.from(b); const l = 10 + u.length; const o = Buffer.alloc(4 + l); o.writeInt32LE(l, 0); o.writeInt32LE(i, 4); o.writeInt32LE(t, 8); u.copy(o, 12); return o; }
+function rcon(cmd) { return new Promise((res, rej) => { const s = net.createConnection({ host: "127.0.0.1", port: 25576, timeout: 60000 }); let st = 0, bs = []; s.on("error", rej); s.on("timeout", () => { s.destroy(); rej("t/o"); }); s.on("connect", () => s.write(pkt(1, 3, "test123"))); s.on("data", c => { bs.push(c); const a = Buffer.concat(bs); if (a.length < 4) return; const l = a.readInt32LE(0); if (a.length < l + 4) return; if (st === 0) { st = 1; bs = []; s.write(pkt(1, 2, cmd)); } else { s.end(); res(a.slice(12, 12 + l - 10).toString().replace(/§./g, "")); } }); }); }
+function waitChat(bot, re, t) { return new Promise(r => { const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); r(m); } }; bot.on('messagestr', h); setTimeout(() => { bot.removeListener('messagestr', h); r(null); }, t); }); }
+
+const X = 18000, Y = 70, Z = 18000, S = 100; // 100^3 = 1,000,000 blocks
+
+(async () => {
+  console.log(`=== WE main-thread profile [${TAG}] : //set air over ${S}^3 = ${(S**3).toLocaleString()} blocks ===`);
+  await rcon(`forceload add ${X} ${Z} ${X + S - 1} ${Z + S - 1}`); await sleep(800);
+  console.log('fill stone…');
+  for (let y = Y; y < Y + S; y += 3) await rcon(`fill ${X} ${y} ${Z} ${X + S - 1} ${Math.min(y + 2, Y + S - 1)} ${Z + S - 1} stone`);
+  await sleep(1500);
+
+  const bot = mineflayer.createBot({ host: "127.0.0.1", port: 25566, username: "weprof", version: "1.21.4" });
+  await new Promise((r, j) => { bot.once("spawn", r); bot.once("error", j); });
+  await rcon("op weprof"); await rcon("gamemode creative weprof"); await rcon(`tp weprof ${X} ${Y + S + 5} ${Z}`); await sleep(2500);
+  bot.chat("//sel cuboid"); await sleep(300); bot.chat(`//pos1 ${X},${Y},${Z}`); await sleep(300); bot.chat(`//pos2 ${X + S - 1},${Y + S - 1},${Z + S - 1}`); await sleep(400);
+
+  console.log('sundial start main…');
+  await rcon('sundial start main 30');
+  await sleep(500);
+  const done = waitChat(bot, /operation completed|blocks have been changed/i, 120000);
+  const t0 = Date.now();
+  bot.chat('//set air');
+  await done;
+  const setMs = Date.now() - t0;
+  console.log(`//set air done in ${setMs}ms`);
+  await sleep(800);
+  await rcon('sundial stop');
+  await sleep(2500);
+
+  bot.quit();
+  await rcon(`fill ${X} ${Y} ${Z} ${X + S - 1} ${Y + S - 1} ${Z + S - 1} air`);
+  await rcon(`forceload remove ${X} ${Z} ${X + S - 1} ${Z + S - 1}`);
+  console.log(`set-wallclock-ms=${setMs}`);
+  process.exit(0);
+})().catch(e => { console.log("ERR", e?.message || e); process.exit(1); });

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -490,7 +490,7 @@ public final class SpyglassPlugin extends JavaPlugin {
 
         if (isWorldEditInstalled()) {
             try {
-                worldEditSubscriber = new WorldEditSubscriber(recorder, support, getLogger());
+                worldEditSubscriber = new WorldEditSubscriber(recorder, support, queryExecutor, this, getLogger());
                 worldEditSubscriber.register();
             } catch (Throwable thrown) {
                 getLogger().warning("Spyglass: WorldEdit integration failed to initialize: " + thrown);
@@ -503,7 +503,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         // subscriber is handed in and the listener only acts on a
         // future disable.
         worldEditLifecycle = new WorldEditLifecycleListener(
-                recorder, support, getLogger(), worldEditSubscriber);
+                recorder, support, queryExecutor, this, getLogger(), worldEditSubscriber);
         getServer().getPluginManager().registerEvents(worldEditLifecycle, this);
 
         getLogger().info("Spyglass enabled; events=" + enabledEvents);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditLifecycleListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditLifecycleListener.java
@@ -1,5 +1,6 @@
 package net.medievalrp.spyglass.plugin.worldedit;
 
+import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
@@ -26,13 +27,18 @@ public final class WorldEditLifecycleListener implements Listener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor asyncExecutor;
+    private final org.bukkit.plugin.Plugin plugin;
     private final Logger logger;
     private WorldEditSubscriber subscriber;
 
-    public WorldEditLifecycleListener(Recorder recorder, RecordingSupport support, Logger logger,
-                                      @Nullable WorldEditSubscriber existing) {
+    public WorldEditLifecycleListener(Recorder recorder, RecordingSupport support,
+                                      Executor asyncExecutor, org.bukkit.plugin.Plugin plugin,
+                                      Logger logger, @Nullable WorldEditSubscriber existing) {
         this.recorder = recorder;
         this.support = support;
+        this.asyncExecutor = asyncExecutor;
+        this.plugin = plugin;
         this.logger = logger;
         this.subscriber = existing;
     }
@@ -46,7 +52,7 @@ public final class WorldEditLifecycleListener implements Listener {
             return;
         }
         try {
-            subscriber = new WorldEditSubscriber(recorder, support, logger);
+            subscriber = new WorldEditSubscriber(recorder, support, asyncExecutor, plugin, logger);
             subscriber.register();
             logger.info("Spyglass: WorldEdit integration enabled after hot-load ("
                     + event.getPlugin().getName() + ").");

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditRecords.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditRecords.java
@@ -1,0 +1,53 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import java.time.Instant;
+import java.util.List;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Turns a resolved before/after pair for one WorldEdit-edited cell into the
+ * break / place records it should emit. Pulled out of {@link WorldEditSubscriber}
+ * so the gating — which never runs on the main thread — is unit-testable without
+ * a live WorldEdit platform (the {@code BaseBlock} -> {@link BlockSnapshot}
+ * conversion that needs one stays in the subscriber).
+ *
+ * <p>The rules mirror the long-standing listener behavior: a non-air before is a
+ * break, a non-air after is a place, and a block changing from one solid to
+ * another emits both. Air-to-air (a no-op overwrite) emits nothing.
+ */
+@ApiStatus.Internal
+final class WorldEditRecords {
+
+    private WorldEditRecords() {
+    }
+
+    /**
+     * Append the break and/or place records for one cell to {@code out}.
+     *
+     * @param before snapshot of the block before the edit (air if none)
+     * @param after  snapshot of the block the edit set (air if cleared)
+     */
+    static void appendCell(List<EventRecord> out, RecordingSupport support, Origin origin,
+                           Source source, String serverName, BlockLocation location,
+                           Instant occurred, BlockSnapshot before, BlockSnapshot after) {
+        Instant expires = support.expiresAt(occurred);
+        if (!before.isAir()) {
+            out.add(new BlockBreakRecord(support.newId(), "break", occurred, expires,
+                    origin, source, location, serverName,
+                    before.material().name(), before, after));
+        }
+        if (!after.isAir()) {
+            out.add(new BlockPlaceRecord(support.newId(), "place", occurred, expires,
+                    origin, source, location, serverName,
+                    after.material().name(), before, after));
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
@@ -7,45 +7,76 @@ import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extent.AbstractDelegateExtent;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executor;
 import java.util.logging.Logger;
-import net.medievalrp.spyglass.api.event.BlockBreakRecord;
-import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
-import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
+import net.medievalrp.spyglass.plugin.util.FallingBlockCascade;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.IllegalPluginAccessException;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Subscribes to WorldEdit's EditSessionEvent and wraps the extent chain with a
- * logger. Every setBlock on the wrapped extent produces a break + place record
- * tagged with Origin.worldEdit() before delegating.
+ * logger. Every setBlock on the wrapped extent yields a break + place record
+ * tagged with Origin.worldEdit().
  *
- * <p>This path handles vanilla WorldEdit. FastAsyncWorldEdit's fast-placement
- * mode bypasses the extent chain and is wired separately (deferred).
+ * <p><b>Off-main design.</b> Vanilla WorldEdit runs the whole edit on the main
+ * thread, so the one thing we cannot move is reading the <em>before</em> block —
+ * we have to read it on the thread that is about to overwrite it. Everything
+ * else does: {@link LoggingExtent#setBlock} captures only WorldEdit's own
+ * immutable block objects ({@code getFullBlock} for the before, the {@code block}
+ * parameter for the after — no second world read) into a per-session buffer, and
+ * the heavy work (block-data string building, {@link BlockSnapshot} allocation,
+ * record construction, {@code recorder.recordAll}) runs off-main when the edit
+ * flushes ({@link LoggingExtent#commitBefore}) or when the buffer fills. This is
+ * the same shape as the FAWE path ({@link FaweBatchLogger}), which already builds
+ * records off the main thread from WorldEdit's chunk data.
+ *
+ * <p>Tile entities (containers, signs, banners, …) are the exception: their live
+ * inventory/text is only safe to read on the main thread, so those — detected by
+ * a non-null block-entity NBT — are captured in full via {@link
+ * BlockSnapshots#capture} inline. They are rare in a bulk edit's block volume.
+ *
+ * <p>FastAsyncWorldEdit's fast-placement mode bypasses the extent chain and is
+ * wired separately ({@link FaweHook}).
  */
 @ApiStatus.Internal
 public final class WorldEditSubscriber {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor asyncExecutor;
+    private final Plugin plugin;
     private final Logger logger;
 
-    public WorldEditSubscriber(Recorder recorder, RecordingSupport support, Logger logger) {
+    public WorldEditSubscriber(Recorder recorder, RecordingSupport support,
+                               Executor asyncExecutor, Plugin plugin, Logger logger) {
         this.recorder = recorder;
         this.support = support;
+        this.asyncExecutor = asyncExecutor;
+        this.plugin = plugin;
         this.logger = logger;
     }
 
@@ -91,66 +122,196 @@ public final class WorldEditSubscriber {
         return Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit") != null;
     }
 
+    /** One buffered cell: the immutable inputs a record needs, captured on the
+     *  main thread and converted into records off it. For each side exactly one
+     *  of the {@code rich*} snapshot (tile entity, captured in full on main) or
+     *  the {@code *We} block (plain block, converted off-main) is non-null. */
+    private record Pending(int x, int y, int z, Instant occurred,
+                           BlockSnapshot richBefore, BaseBlock beforeWe,
+                           BlockSnapshot richAfter, BaseBlock afterWe) {
+    }
+
     private final class LoggingExtent extends AbstractDelegateExtent {
+
+        /** Hand the buffer off-main once it reaches this many cells, so a
+         *  multi-million-block edit neither holds every cell in memory nor
+         *  waits for the whole op to finish before any record is built. */
+        private static final int DRAIN_THRESHOLD = 50_000;
+
         private final Player player;
         private final World world;
-        // Per-EditSession dedup for the falling-block cascade emit.
-        // Without this, if WE breaks every cell of an N-tall sand
-        // column in the same op, each break re-walks the column above
-        // and re-logs every still-standing sand cell — O(N²) audit
-        // events for a single //set 0 over a sand silo.
-        private final java.util.Set<Long> cascadedAbove = new java.util.HashSet<>();
+        private final UUID playerId;
+        private final String playerName;
+        private final UUID worldId;
+        private final String worldName;
+
+        // Per-EditSession dedup for the falling-block cascade emit. Without
+        // this, if WE breaks every cell of an N-tall sand column in the same
+        // op, each break re-walks the column above and re-logs every
+        // still-standing sand cell — O(N²) audit events for a single //set 0
+        // over a sand silo.
+        private final Set<Long> cascadedAbove = new HashSet<>();
+        private List<Pending> buffer = new ArrayList<>();
+        // A next-tick drain is queued. Coalesces a whole edit's worth of
+        // setBlock calls (vanilla WE runs them synchronously within the tick)
+        // into a single off-main build, without depending on WorldEdit calling
+        // commit() on this particular extent.
+        private boolean drainScheduled = false;
 
         LoggingExtent(Extent extent, Player player, World world) {
             super(extent);
             this.player = player;
             this.world = world;
+            this.playerId = player.getUniqueId();
+            this.playerName = player.getName();
+            this.worldId = world.getUID();
+            this.worldName = world.getName();
         }
 
         @Override
         public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block)
                 throws com.sk89q.worldedit.WorldEditException {
-            Location bukkitLocation = new Location(world, position.x(), position.y(), position.z());
-            BlockSnapshot original = BlockSnapshots.capture(bukkitLocation.getBlock().getState());
-            boolean originalIsAir = original.isAir();
-            BlockLocation location = BlockLocations.fromLocation(bukkitLocation);
+            int x = position.x();
+            int y = position.y();
+            int z = position.z();
+
+            // The before-state: WorldEdit's own immutable read, NBT included.
+            // Cheaper than a Bukkit getState() and — being immutable — safe to
+            // convert into a snapshot off the main thread.
+            BaseBlock weBefore = super.getFullBlock(position);
+            boolean beforeTile = isTileEntity(weBefore);
+            // Tile entities carry inventory / sign text / banner patterns that
+            // are only safe to read on the main thread; capture them in full now.
+            // The before is what a rollback restores, so it must stay faithful.
+            BlockSnapshot richBefore = beforeTile
+                    ? BlockSnapshots.capture(world.getBlockAt(x, y, z).getState()) : null;
+            // The after-state is exactly what we are setting — for plain blocks
+            // no second world read is needed (the block parameter is the after).
+            BaseBlock weAfter = block.toBaseBlock();
+            boolean afterTile = isTileEntity(weAfter);
             Instant occurred = support.now();
-            Origin origin = Origin.worldEdit();
-            Source source = Source.player(player.getUniqueId(), player.getName());
 
             boolean result = super.setBlock(position, block);
 
-            BlockSnapshot after = BlockSnapshots.capture(bukkitLocation.getBlock().getState());
-            boolean newIsAir = after.isAir();
+            // Only a placed tile entity needs a post-write read — to keep the
+            // after faithful for /sg restore (redo). Plain blocks (the bulk of
+            // any edit) never hit this; their after is built off-main from the
+            // parameter.
+            BlockSnapshot richAfter = afterTile
+                    ? BlockSnapshots.capture(world.getBlockAt(x, y, z).getState()) : null;
 
-            if (!originalIsAir) {
-                recorder.record(new BlockBreakRecord(
-                        support.newId(), "break", occurred, support.expiresAt(occurred),
-                        origin, source, location, support.serverName(),
-                        original.material().name(), original, after));
-                // Cascade: if this break knocks out the support of a
-                // gravity-affected column above (sand, gravel, anvil,
-                // concrete powder, ...), the column will drop as
-                // falling-block entities on the next tick — by which
-                // point the original cells are air and there's no
-                // listener that ties those falls back to this player.
-                // Pre-emptively log the column's breaks tagged with the
-                // same player + WE origin so a rollback of this op
-                // pulls the cascade in. Cheap when the block above
-                // isn't gravity-affected (one Material lookup, returns).
-                if (newIsAir) {
-                    net.medievalrp.spyglass.plugin.util.FallingBlockCascade.emitCascadeAbove(
-                            recorder, support, player, world,
-                            position.x(), position.y(), position.z(), cascadedAbove);
-                }
+            buffer.add(new Pending(x, y, z, occurred,
+                    richBefore, beforeTile ? null : weBefore,
+                    richAfter, afterTile ? null : weAfter));
+            if (buffer.size() >= DRAIN_THRESHOLD) {
+                drain();
+            } else {
+                scheduleDrain();
             }
-            if (!newIsAir) {
-                recorder.record(new BlockPlaceRecord(
-                        support.newId(), "place", occurred, support.expiresAt(occurred),
-                        origin, source, location, support.serverName(),
-                        after.material().name(), original, after));
+
+            // Falling-block cascade stays on the main thread: it walks the live
+            // column above a break-to-air, which is rare relative to the bulk
+            // per-block path and inherently a main-thread world read.
+            boolean beforeAir = !beforeTile && weBefore.getBlockType().getMaterial().isAir();
+            boolean afterAir = !afterTile && weAfter.getBlockType().getMaterial().isAir();
+            if (!beforeAir && afterAir) {
+                FallingBlockCascade.emitCascadeAbove(recorder, support, player, world,
+                        x, y, z, cascadedAbove);
             }
             return result;
+        }
+
+        @Override
+        protected Operation commitBefore() {
+            // Belt-and-suspenders: drain if WorldEdit happens to commit this
+            // extent. The scheduled next-tick drain is the primary trigger,
+            // since not every WE version routes commit() through here.
+            drain();
+            return super.commitBefore();
+        }
+
+        /** Queue a one-tick-later drain (idempotent within a tick). Runs on the
+         *  main thread, so all of this edit's buffered cells are present before
+         *  it fires. */
+        private void scheduleDrain() {
+            if (drainScheduled) {
+                return;
+            }
+            drainScheduled = true;
+            try {
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    drainScheduled = false;
+                    drain();
+                });
+            } catch (IllegalPluginAccessException disabling) {
+                // Plugin disabling — scheduler refuses new tasks. Drain now.
+                drainScheduled = false;
+                drain();
+            }
+        }
+
+        /** Hand the current buffer to the async executor and start a fresh one.
+         *  If the executor has been shut down (server stopping), build inline so
+         *  no records are dropped. */
+        private void drain() {
+            if (buffer.isEmpty()) {
+                return;
+            }
+            List<Pending> batch = buffer;
+            buffer = new ArrayList<>();
+            try {
+                asyncExecutor.execute(() -> build(batch));
+            } catch (RuntimeException rejected) {
+                build(batch);
+            }
+        }
+
+        /** Off-main: convert WorldEdit's captured block data into break / place
+         *  records and queue them. Touches only immutable inputs plus
+         *  thread-safe helpers ({@code BukkitAdapter.adapt}, {@code support.*},
+         *  {@code recorder.recordAll}). */
+        private void build(List<Pending> batch) {
+            try {
+                Origin origin = Origin.worldEdit();
+                Source source = Source.player(playerId, playerName);
+                String serverName = support.serverName();
+                List<EventRecord> out = new ArrayList<>(batch.size() * 2);
+                for (Pending p : batch) {
+                    BlockSnapshot before = p.richBefore() != null ? p.richBefore() : snapshot(p.beforeWe());
+                    BlockSnapshot after = p.richAfter() != null ? p.richAfter() : snapshot(p.afterWe());
+                    BlockLocation location = new BlockLocation(worldId, worldName, p.x(), p.y(), p.z());
+                    WorldEditRecords.appendCell(out, support, origin, source, serverName,
+                            location, p.occurred(), before, after);
+                }
+                if (!out.isEmpty()) {
+                    recorder.recordAll(out);
+                }
+            } catch (RuntimeException ex) {
+                // Never let an off-main build die silently — a swallowed
+                // exception here would drop a whole edit's audit trail.
+                logger.warning("Spyglass: WorldEdit off-main record build failed ("
+                        + batch.size() + " cells): " + ex);
+            }
+        }
+
+        /** A block WorldEdit reports as carrying block-entity NBT (or whose
+         *  material is a container) — chest, sign, banner, jukebox, decorated
+         *  pot, … — whose extra data BlockSnapshots.capture only reads safely on
+         *  the main thread. */
+        private static boolean isTileEntity(BaseBlock block) {
+            return block.getNbtReference() != null
+                    || block.getBlockType().getMaterial().hasContainer();
+        }
+
+        /** WorldEdit block -> Spyglass snapshot (material + block-data string).
+         *  No inventory / sign data: tile entities take the {@code rich*}
+         *  path instead. Pure data conversion, safe off the main thread. */
+        private BlockSnapshot snapshot(BaseBlock we) {
+            if (we == null || we.getBlockType().getMaterial().isAir()) {
+                return BlockSnapshots.air();
+            }
+            BlockData data = BukkitAdapter.adapt(we.toImmutableState());
+            return BlockSnapshots.of(data.getMaterial(), data.getAsString());
         }
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditRecordsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditRecordsTest.java
@@ -1,0 +1,98 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The break / place gating that the off-main WorldEdit build runs for every
+ * edited cell. Exercised directly (no live WorldEdit platform) since the gating
+ * is exactly the bit that must not regress when the heavy work moved off the
+ * main thread.
+ */
+class WorldEditRecordsTest {
+
+    private static final RecordingSupport SUPPORT = new RecordingSupport(Duration.parse("30d"), "srv");
+    private static final UUID WORLD = UUID.randomUUID();
+    private static final UUID PLAYER = UUID.randomUUID();
+    private static final BlockLocation LOC = new BlockLocation(WORLD, "world", 10, 64, -20);
+    private static final BlockSnapshot STONE = BlockSnapshots.of(Material.STONE, "minecraft:stone");
+    private static final BlockSnapshot DIRT = BlockSnapshots.of(Material.DIRT, "minecraft:dirt");
+    private static final BlockSnapshot AIR = BlockSnapshots.air();
+
+    private List<EventRecord> append(BlockSnapshot before, BlockSnapshot after, Instant occurred) {
+        List<EventRecord> out = new ArrayList<>();
+        WorldEditRecords.appendCell(out, SUPPORT, Origin.worldEdit(),
+                Source.player(PLAYER, "Joe"), "srv", LOC, occurred, before, after);
+        return out;
+    }
+
+    @Test
+    void solidToSolidEmitsBreakThenPlace() {
+        Instant now = Instant.parse("2026-06-19T12:00:00Z");
+        List<EventRecord> out = append(STONE, DIRT, now);
+
+        assertThat(out).hasSize(2);
+        assertThat(out.get(0)).isInstanceOf(BlockBreakRecord.class);
+        assertThat(out.get(1)).isInstanceOf(BlockPlaceRecord.class);
+
+        BlockBreakRecord brk = (BlockBreakRecord) out.get(0);
+        assertThat(brk.event()).isEqualTo("break");
+        assertThat(brk.origin()).isEqualTo(Origin.worldEdit());
+        assertThat(brk.source().playerName()).isEqualTo("Joe");
+        assertThat(brk.location()).isEqualTo(LOC);
+        assertThat(brk.server()).isEqualTo("srv");
+        assertThat(brk.occurred()).isEqualTo(now);
+        assertThat(brk.expiresAt()).isEqualTo(SUPPORT.expiresAt(now));
+        assertThat(brk.target()).isEqualTo("STONE");
+        assertThat(brk.originalBlock()).isEqualTo(STONE);
+        assertThat(brk.newBlock()).isEqualTo(DIRT);
+
+        BlockPlaceRecord place = (BlockPlaceRecord) out.get(1);
+        assertThat(place.event()).isEqualTo("place");
+        assertThat(place.target()).isEqualTo("DIRT");
+        assertThat(place.originalBlock()).isEqualTo(STONE);
+        assertThat(place.newBlock()).isEqualTo(DIRT);
+    }
+
+    @Test
+    void clearingToAirEmitsOnlyBreak() {
+        // //set air over a solid block: a break, no place.
+        List<EventRecord> out = append(STONE, AIR, Instant.now());
+
+        assertThat(out).hasSize(1);
+        assertThat(out.get(0)).isInstanceOf(BlockBreakRecord.class);
+        assertThat(((BlockBreakRecord) out.get(0)).newBlock().isAir()).isTrue();
+    }
+
+    @Test
+    void placingOverAirEmitsOnlyPlace() {
+        // //set stone over air: a place, no break.
+        List<EventRecord> out = append(AIR, STONE, Instant.now());
+
+        assertThat(out).hasSize(1);
+        assertThat(out.get(0)).isInstanceOf(BlockPlaceRecord.class);
+        assertThat(((BlockPlaceRecord) out.get(0)).originalBlock().isAir()).isTrue();
+    }
+
+    @Test
+    void airToAirEmitsNothing() {
+        // A no-op overwrite (air set to air) records neither side.
+        assertThat(append(AIR, AIR, Instant.now())).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #87.

## What
Vanilla WorldEdit runs the whole edit on the main thread, and Spyglass's `LoggingExtent` was doing **two** heavyweight Bukkit `getState()` reads per block (before + a redundant after), two `BlockSnapshots.capture` block-data string-builds, and record allocation — all synchronous on main. Profiling a bulk `//set` showed this at a meaningful slice of tick time.

Now `setBlock` captures only WorldEdit's **own immutable** block data — `getFullBlock` for the before, the `setBlock` parameter for the after (no second world read) — into a per-EditSession buffer, and the record-building + `recorder.recordAll` runs **off the main thread** on a next-tick drain. Same architecture the FAWE path already uses.

Tile entities (chest / sign / banner / jukebox / decorated pot) are still captured in full on the main thread — their live inventory/text is the only faithful source and isn't safe to read off-main. They're rare in an edit's block volume.

## Why the drain is scheduler-based
`commit()` is `final`; the natural hook is `commitBefore()`, but in-game testing showed WE 7.4.3 doesn't route commit through this extent, so a buffer-only-drained-at-commit approach logged **zero** records. The primary trigger is now a coalesced next-tick `BukkitScheduler` drain (version-independent), with a 50k size-cap drain for huge edits and `commitBefore` + inline-on-rejection as fallbacks. `build()` is wrapped so an off-main exception is logged, never swallowed.

## Evidence
- **`./gradlew check`** green (jacoco floors hold; Docker up so store ITs ran).
- **Unit:** `WorldEditRecordsTest` covers the break/place gating (solid→solid, clear-to-air, place-over-air, air→air).
- **In-game (live ClickHouse server, vanilla WE):** `_worldedit-offmain-proof.js` — **8/8**. A `//set glass` over 215 stone + a chest of 17 diamonds logs 216 break + 216 place records (origin=worldedit), captures the destroyed chest, and a rollback restores the region, the chest, **and its 17 diamonds** — proving the main-thread tile capture round-trips through the off-main build.
- **Off-main profile (warmed-server Sundial, 1M `//set`):** Spyglass main-thread time **11.8% → 5.0%**, with `CraftBlockData.getAsString` / block-data parsing dropping out of the main-thread hot methods. Remaining 5% is the one WE-native read per block (irreducible for vanilla WE).
- **No data loss:** shutdown drained 5.26M queued records, 0 dropped.

## Notes
- Falling-block cascade kept on the main thread for this change (gated to break-to-air, rare); a clean follow-up if profiling ever flags it.
- No API/command/config surface change — internal ingest-path perf only.