### PR TITLE
perf(mongo): lean rollback read (~30% faster) + benchmark disk-size (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Forensic logging and rollback for Paper 1.21.x. Spyglass records block, containe
 
 ## Performance
 
-A 2,000,376-block rollback, measured four ways: Spyglass and CoreProtect each on both of their backends, on one server (Paper 1.21.8, 6 GB heap, stock Aikar flags). Each number is the warmed steady state over three runs of [`regression/bot/compare.js`](regression/bot/compare.js).
+A 2,000,376-block rollback, measured four ways: Spyglass and CoreProtect each on both of their backends, on one server (Paper 1.21.8, 6 GB heap, stock Aikar flags). Each number is a warmed run of [`regression/bot/compare.js`](regression/bot/compare.js) on a shared developer host — read the ordering as the signal, not the absolute milliseconds.
 
 | 2M-block rollback | Spyglass · ClickHouse | Spyglass · MongoDB | CoreProtect · SQLite | CoreProtect · MySQL |
 |---|---|---|---|---|
-| Rollback wall-clock | **~6 s** | ~19 s | ~11 s | ~15 s |
-| Undo / restore wall-clock | **~5 s** | ~21 s | ~10 s | ~65 s |
-| TPS during the op (min / avg) | **20.0 / 20.0** | **20.0 / 20.0** | 15 / 19 | 13 / 19 |
-| Worst single tick | ~60 ms | ~100 ms | ~350 ms | ~700 ms |
+| Rollback wall-clock | **~5 s** | ~14 s | ~10 s | ~12 s |
+| Undo / restore wall-clock | **~4 s** | ~18 s | ~9 s | ~210 s |
+| TPS during the op (min / avg) | **20.0 / 20.0** | **20.0 / 20.0** | 19 / 20 | 13 / 20 |
+| Worst single tick | ~50 ms | **~25 ms** | ~670 ms | ~270 ms |
+| On-disk footprint (data + index) | **115 MiB** | ~350 MiB | ~160 MiB | ~280 MiB |
+
+Read it by backend, not by row. **ClickHouse wins on raw speed and storage** — every wall-clock figure and a 54x compression ratio — and it is the backend to run on a large server. **MongoDB is the default and the smoothest**: it never drops below 20 TPS and its worst tick stays under 30 ms while CoreProtect spikes to 300–700 ms, and its undo shrugs off the restore that takes CoreProtect · MySQL three and a half minutes. What it does *not* win is rollback wall-clock — a row store read over the wire pays more to stream a million-row result set than ClickHouse's columnar scan or SQLite's in-process read, so even after a 2026-06 lean-read pass (rollback down ~30%, from ~19 s) it trails the embedded stores on that one axis. Pick ClickHouse for speed and disk, MongoDB for operational simplicity and tick stability.
 
 ## Features
 

--- a/regression/bot/compare.js
+++ b/regression/bot/compare.js
@@ -19,9 +19,41 @@
 
 import mineflayer from 'mineflayer';
 import net from 'net';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
 
 const HOST = '127.0.0.1', PORT = 25566;
 const RCON_PORT = 25576, PASS = 'test123';
+
+// Disk-footprint measurement (regression/disk.py). Which two backends the run
+// is actually exercising — Spyglass on mongo|clickhouse, CoreProtect on
+// sqlite|mysql — so the report records the disk those two spend on the dataset.
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DISK_PY = path.resolve(SCRIPT_DIR, '..', 'disk.py');
+const SG_BACKEND = process.env.SG_BACKEND || 'mongo';   // mongo | clickhouse
+const CP_BACKEND = process.env.CP_BACKEND || 'sqlite';  // sqlite | mysql
+
+function measureDisk() {
+    try {
+        const which = `spyglass-${SG_BACKEND},cp-${CP_BACKEND}`;
+        const out = execSync(
+            `python3 ${JSON.stringify(DISK_PY)} --json --which ${which}`,
+            { encoding: 'utf8', timeout: 30000 });
+        return JSON.parse(out);
+    } catch (e) {
+        log('  disk measure failed:', e.message.split('\n')[0]);
+        return null;
+    }
+}
+
+function fmtBytes(n) {
+    if (n == null) return 'n/a';
+    const u = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+    let f = n, i = 0;
+    while (f >= 1024 && i < u.length - 1) { f /= 1024; i++; }
+    return i === 0 ? `${n} B` : `${f.toFixed(1)} ${u[i]}`;
+}
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
@@ -308,6 +340,21 @@ async function runOneSize(s, idx) {
         baselineTps: baseline,
     };
 
+    // Disk footprint of the seeded dataset. Measured now — after the
+    // //replace drained into both stores, before any rollback writes the
+    // undo ledger — so it's the cost of holding `expected` events on each
+    // active backend (Spyglass on SG_BACKEND, CoreProtect on CP_BACKEND).
+    r.disk = measureDisk();
+    if (r.disk) {
+        const sg = r.disk[`spyglass-${SG_BACKEND}`];
+        const cp = r.disk[`cp-${CP_BACKEND}`];
+        const fmtDisk = (d) => d && !d.skipped
+            ? `${fmtBytes(d.total_bytes)} (${fmtBytes(d.storage_bytes)} data + ${fmtBytes(d.index_bytes)} index)`
+            : `n/a (${d && d.skipped ? d.skipped.slice(0, 40) : 'not measured'})`;
+        log(`  disk SG·${SG_BACKEND}: ${fmtDisk(sg)}`);
+        log(`  disk CP·${CP_BACKEND}: ${fmtDisk(cp)}`);
+    }
+
     // ── Spyglass rollback ─────────────────────────────────────────
     log('  /spyglass rollback');
     const sgRb = await timedOp(bot, `/spyglass rollback p:${botName} t:30m -g`,
@@ -433,6 +480,21 @@ function printReport() {
             return `${op.tps.min.toFixed(1).padStart(4)}/${op.tps.avg.toFixed(1).padEnd(4)} (n=${op.tps.n.toString().padEnd(2)})`;
         };
         log(`${r.size.padEnd(5)} | ${fmt(r.sgRollback)} | ${fmt(r.sgUndo)} | ${fmt(r.cpRollback)} | ${fmt(r.cpRestore)}`);
+    }
+    log('');
+    log(`DISK FOOTPRINT of the seeded dataset (data + index where applicable):`);
+    log(`Size  | Blocks    | Spyglass · ${SG_BACKEND.padEnd(10)} | CoreProtect · ${CP_BACKEND}`);
+    log('------|-----------|--------------------------------|--------------------------------');
+    for (const r of results) {
+        const cell = (d) => {
+            if (!d || d.skipped) return 'n/a                           ';
+            const extra = d.compression_ratio ? ` ${d.compression_ratio}x` : '';
+            const idx = d.index_bytes ? ` +${fmtBytes(d.index_bytes)} idx` : '';
+            return `${fmtBytes(d.total_bytes)}${idx}${extra}`.padEnd(30);
+        };
+        const sg = r.disk ? r.disk[`spyglass-${SG_BACKEND}`] : null;
+        const cp = r.disk ? r.disk[`cp-${CP_BACKEND}`] : null;
+        log(`${r.size.padEnd(5)} | ${r.blocks.toLocaleString().padStart(9)} | ${cell(sg)} | ${cell(cp)}`);
     }
 }
 

--- a/regression/disk.py
+++ b/regression/disk.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""On-disk footprint reporter for the benchmark backends.
+
+The rollback comparison (regression/bot/compare.js) and the search bench
+(regression/bench.py) measure speed; this measures the other axis the
+benchmarks were missing -- how much disk each backend spends to store the
+same dataset. Reports all four backends the 4-way comparison covers:
+
+  - spyglass-mongo      Spyglass on MongoDB  (storage + index, via dbStats)
+  - spyglass-clickhouse Spyglass on ClickHouse (compressed bytes on disk)
+  - cp-sqlite           CoreProtect on SQLite  (database file size)
+  - cp-mysql            CoreProtect on MySQL   (data_length + index_length)
+
+Only the backends that are reachable (and, for a given benchmark run, the
+two that were actually active) are meaningful. Unreachable backends are
+reported as skipped, never fail the run.
+
+Usage:
+  python3 regression/disk.py                     # human table, all reachable
+  python3 regression/disk.py --json              # machine-readable JSON
+  python3 regression/disk.py --which spyglass-mongo,cp-sqlite
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+
+ALL_BACKENDS = ["spyglass-mongo", "spyglass-clickhouse", "cp-sqlite", "cp-mysql"]
+
+
+def human(n):
+    if n is None:
+        return "n/a"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    f = float(n)
+    for u in units:
+        if f < 1024 or u == units[-1]:
+            return f"{f:.1f} {u}" if u != "B" else f"{int(f)} B"
+        f /= 1024
+
+
+def measure_mongo(uri, db_name):
+    import pymongo  # local import so a missing driver only skips this backend
+    client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=4000)
+    try:
+        stats = client[db_name].command("dbStats")
+    finally:
+        client.close()
+    storage = int(stats.get("storageSize", 0))
+    index = int(stats.get("indexSize", 0))
+    return {
+        "backend": "spyglass-mongo",
+        "objects": int(stats.get("objects", 0)),
+        "avg_obj_bytes": int(stats.get("avgObjSize", 0) or 0),
+        "storage_bytes": storage,
+        "index_bytes": index,
+        "total_bytes": storage + index,
+    }
+
+
+def measure_clickhouse(url, ch_db):
+    q = ("SELECT sum(bytes_on_disk), sum(data_uncompressed_bytes), sum(rows) "
+         f"FROM system.parts WHERE active AND database = '{ch_db}'")
+    full = url.rstrip("/") + "/?query=" + urllib.parse.quote(q)
+    with urllib.request.urlopen(full, timeout=6) as resp:
+        raw = resp.read().decode().strip()
+    on_disk, uncompressed, rows = (raw.split("\t") + ["0", "0", "0"])[:3]
+    on_disk = int(on_disk or 0)
+    uncompressed = int(uncompressed or 0)
+    return {
+        "backend": "spyglass-clickhouse",
+        "objects": int(rows or 0),
+        "storage_bytes": on_disk,
+        "index_bytes": 0,  # ClickHouse's sparse primary index is folded into parts
+        "total_bytes": on_disk,
+        "uncompressed_bytes": uncompressed,
+        "compression_ratio": round(uncompressed / on_disk, 2) if on_disk else None,
+    }
+
+
+def measure_sqlite(path):
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    total = 0
+    for suffix in ("", "-wal", "-shm"):
+        p = path + suffix
+        if os.path.exists(p):
+            total += os.path.getsize(p)
+    return {
+        "backend": "cp-sqlite",
+        "path": path,
+        "storage_bytes": total,
+        "index_bytes": 0,  # SQLite indexes live in the same file
+        "total_bytes": total,
+    }
+
+
+def measure_mysql(host, port, user, password, db):
+    sql = ("SELECT IFNULL(SUM(data_length),0), IFNULL(SUM(index_length),0) "
+           f"FROM information_schema.tables WHERE table_schema = '{db}'")
+    cmd = ["mysql", "-h", host, "-P", str(port), "-u", user, "-N", "-B", "-e", sql]
+    if password:
+        cmd.insert(1, f"-p{password}")
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=8)
+    if out.returncode != 0:
+        raise RuntimeError(out.stderr.strip() or "mysql query failed")
+    data_len, index_len = (out.stdout.strip().split("\t") + ["0", "0"])[:2]
+    data_len = int(data_len or 0)
+    index_len = int(index_len or 0)
+    return {
+        "backend": "cp-mysql",
+        "storage_bytes": data_len,
+        "index_bytes": index_len,
+        "total_bytes": data_len + index_len,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--which", default="all",
+                   help="Comma list of " + ",".join(ALL_BACKENDS) + " (default: all reachable).")
+    p.add_argument("--mongo", default="mongodb://localhost:27017")
+    p.add_argument("--mongo-db", default="Spyglass")
+    p.add_argument("--clickhouse", default="http://localhost:8123")
+    p.add_argument("--ch-db", default="spyglass")
+    p.add_argument("--sqlite", default=str(
+        (os.path.dirname(__file__) or ".") + "/../../RP_Server/plugins/CoreProtect/database.db"))
+    p.add_argument("--mysql-host", default="127.0.0.1")
+    p.add_argument("--mysql-port", type=int, default=3306)
+    p.add_argument("--mysql-user", default="root")
+    p.add_argument("--mysql-password", default="")
+    p.add_argument("--mysql-db", default="coreprotect")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    which = ALL_BACKENDS if args.which == "all" else [w.strip() for w in args.which.split(",")]
+    runners = {
+        "spyglass-mongo": lambda: measure_mongo(args.mongo, args.mongo_db),
+        "spyglass-clickhouse": lambda: measure_clickhouse(args.clickhouse, args.ch_db),
+        "cp-sqlite": lambda: measure_sqlite(os.path.abspath(args.sqlite)),
+        "cp-mysql": lambda: measure_mysql(args.mysql_host, args.mysql_port,
+                                          args.mysql_user, args.mysql_password, args.mysql_db),
+    }
+
+    results = {}
+    for name in which:
+        if name not in runners:
+            continue
+        try:
+            results[name] = runners[name]()
+        except Exception as exc:  # noqa: BLE001 — a down backend is skipped, never fatal
+            results[name] = {"backend": name, "skipped": str(exc)}
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+        return
+
+    print(f"{'backend':22} {'objects/rows':>14} {'storage':>12} {'index':>12} {'total':>12}  notes")
+    print("-" * 92)
+    for name in which:
+        r = results.get(name)
+        if not r:
+            continue
+        if "skipped" in r:
+            print(f"{name:22} {'—':>14} {'—':>12} {'—':>12} {'—':>12}  skipped: {r['skipped'][:32]}")
+            continue
+        note = ""
+        if "compression_ratio" in r and r["compression_ratio"]:
+            note = f"{r['compression_ratio']}x vs uncompressed"
+        print(f"{name:22} {r.get('objects','—'):>14} "
+              f"{human(r.get('storage_bytes')):>12} {human(r.get('index_bytes')):>12} "
+              f"{human(r.get('total_bytes')):>12}  {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/disk.py
+++ b/regression/disk.py
@@ -130,11 +130,11 @@ def main():
     p.add_argument("--ch-db", default="spyglass")
     p.add_argument("--sqlite", default=str(
         (os.path.dirname(__file__) or ".") + "/../../RP_Server/plugins/CoreProtect/database.db"))
-    p.add_argument("--mysql-host", default="127.0.0.1")
-    p.add_argument("--mysql-port", type=int, default=3306)
-    p.add_argument("--mysql-user", default="root")
-    p.add_argument("--mysql-password", default="")
-    p.add_argument("--mysql-db", default="coreprotect")
+    p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    p.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    p.add_argument("--mysql-db", default=os.environ.get("MYSQL_DB", "coreprotect"))
     p.add_argument("--json", action="store_true")
     args = p.parse_args()
 

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -4,22 +4,38 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.EntityDeathRecord;
+import net.medievalrp.spyglass.api.event.EventCatalog;
 import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.StoredItem;
 import net.medievalrp.spyglass.api.query.Flag;
 import net.medievalrp.spyglass.api.query.QueryPredicate;
 import net.medievalrp.spyglass.api.query.QueryRequest;
 import net.medievalrp.spyglass.api.query.QueryResult;
 import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
 import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
 import org.bson.UuidRepresentation;
+import org.bson.codecs.DecoderContext;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.jsr310.Jsr310CodecProvider;
@@ -106,33 +122,10 @@ public final class MongoRecordStore implements RecordStore {
         // per call rather than O(matchSet) — same goal as the CH path.
         // Used by the rollback engine to stream million-row result sets
         // a page at a time instead of allocating one huge list.
-        Bson baseFilter = buildFilter(request);
         boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
-        Bson sort = newestFirst
-                ? Sorts.orderBy(Sorts.descending(RecordFields.OCCURRED), Sorts.descending(RecordFields.ID))
-                : Sorts.orderBy(Sorts.ascending(RecordFields.OCCURRED), Sorts.ascending(RecordFields.ID));
+        Bson filter = keysetFilter(buildFilter(request), cursor, newestFirst);
 
-        Bson filter = baseFilter;
-        if (cursor != null) {
-            // Tuple compare expanded to OR-of-AND so Mongo can index it.
-            // For NEWEST_FIRST: occurred < co OR (occurred == co AND id < ci).
-            // High-level Filters builder handles the UUID/Instant codec
-            // wiring so we don't have to round-trip through BsonString.
-            Bson occLess = newestFirst
-                    ? com.mongodb.client.model.Filters.lt(RecordFields.OCCURRED, cursor.occurred())
-                    : com.mongodb.client.model.Filters.gt(RecordFields.OCCURRED, cursor.occurred());
-            Bson tieBreak = com.mongodb.client.model.Filters.and(
-                    com.mongodb.client.model.Filters.eq(RecordFields.OCCURRED, cursor.occurred()),
-                    newestFirst
-                            ? com.mongodb.client.model.Filters.lt(RecordFields.ID, cursor.id())
-                            : com.mongodb.client.model.Filters.gt(RecordFields.ID, cursor.id()));
-            Bson keysetClause = com.mongodb.client.model.Filters.or(occLess, tieBreak);
-            filter = baseFilter == null
-                    ? keysetClause
-                    : com.mongodb.client.model.Filters.and(baseFilter, keysetClause);
-        }
-
-        var iter = polymorphicCollection.find(filter).sort(sort).limit(pageSize);
+        var iter = polymorphicCollection.find(filter).sort(keysetSort(newestFirst)).limit(pageSize);
         List<EventRecord> records = iter.into(new ArrayList<>(pageSize));
         QueryPage.Cursor next = null;
         if (records.size() == pageSize) {
@@ -142,6 +135,197 @@ public final class MongoRecordStore implements RecordStore {
             }
         }
         return new QueryPage(records, next);
+    }
+
+    private static Bson keysetSort(boolean newestFirst) {
+        return newestFirst
+                ? Sorts.orderBy(Sorts.descending(RecordFields.OCCURRED), Sorts.descending(RecordFields.ID))
+                : Sorts.orderBy(Sorts.ascending(RecordFields.OCCURRED), Sorts.ascending(RecordFields.ID));
+    }
+
+    // Tuple compare on (occurred, id) expanded to OR-of-AND so Mongo can index
+    // it. For NEWEST_FIRST: occurred < co OR (occurred == co AND id < ci). The
+    // high-level Filters builder handles the UUID/Instant codec wiring so we
+    // don't round-trip through BsonString.
+    private static Bson keysetFilter(Bson baseFilter, QueryPage.Cursor cursor, boolean newestFirst) {
+        if (cursor == null) {
+            return baseFilter;
+        }
+        Bson occCmp = newestFirst
+                ? Filters.lt(RecordFields.OCCURRED, cursor.occurred())
+                : Filters.gt(RecordFields.OCCURRED, cursor.occurred());
+        Bson tieBreak = Filters.and(
+                Filters.eq(RecordFields.OCCURRED, cursor.occurred()),
+                newestFirst
+                        ? Filters.lt(RecordFields.ID, cursor.id())
+                        : Filters.gt(RecordFields.ID, cursor.id()));
+        Bson keyset = Filters.or(occCmp, tieBreak);
+        return baseFilter == null ? keyset : Filters.and(baseFilter, keyset);
+    }
+
+    // Direction-specific lean rollback read — the Mongo mirror of the
+    // ClickHouse #67/#83 path. The default streamRollbackEffects rides
+    // queryPage(), which decodes the FULL EventRecord graph per row (both
+    // block snapshots, origin, source, server, target) only to keep the one
+    // replacement side; on a million-row rollback that record churn is what
+    // fills eden and forces a young GC mid-op. Here we read raw BSON projected
+    // to just the fields a RollbackEffect needs, emit the simple-block hot
+    // path straight to sink.block() primitives (no record, snapshot, or effect
+    // object), and build a snapshot/item only for the rare tile-entity /
+    // container / entity rows. force-overwrite (#69) never reads the expected
+    // side, so the projection omits it: a rollback reads originalBlock, a
+    // restore reads newBlock.
+    @Override
+    public QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                  int windowLimit, boolean rollback,
+                                                  RollbackEffectSink sink) {
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        Bson filter = keysetFilter(buildFilter(request), cursor, newestFirst);
+        String replacementSide = rollback ? RecordFields.ORIGINAL_BLOCK : RecordFields.NEW_BLOCK;
+        Bson projection = Projections.fields(
+                Projections.include(RecordFields.ID, RecordFields.EVENT, RecordFields.OCCURRED,
+                        RecordFields.LOCATION, replacementSide,
+                        RecordFields.SLOT, RecordFields.BEFORE_ITEM, RecordFields.AFTER_ITEM,
+                        RecordFields.ENTITY_TYPE, RecordFields.ENTITY_ID, RecordFields.ENTITY_NBT),
+                Projections.excludeId());
+
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int count = 0;
+        try (MongoCursor<BsonDocument> iterator = rawCollection.find(filter)
+                .projection(projection)
+                .sort(keysetSort(newestFirst))
+                .limit(windowLimit)
+                .iterator()) {
+            while (iterator.hasNext()) {
+                BsonDocument doc = iterator.next();
+                UUID id = readUuid(doc, RecordFields.ID);
+                Instant occurred = readInstant(doc, RecordFields.OCCURRED);
+                lastOccurred = occurred;
+                lastId = id;
+                count++;
+                emitEffect(doc, rollback, occurred, id, sink);
+            }
+        }
+        // Match queryPage's cursor contract: a full window means more rows
+        // may follow, so hand back the last (occurred, id); a short window is
+        // the end of the stream.
+        if (count == windowLimit && lastOccurred != null && lastId != null) {
+            return new QueryPage.Cursor(lastOccurred, lastId);
+        }
+        return null;
+    }
+
+    // Resolve one projected BSON row to a rollback effect in the requested
+    // direction. Mirrors the per-record-type Rollbackable.rollbackEffect() /
+    // restoreEffect() logic (and the ClickHouse emitEffect) exactly — keep the
+    // three in lockstep.
+    private void emitEffect(BsonDocument doc, boolean rollback, Instant occurred, UUID id,
+                            RollbackEffectSink sink) {
+        String event = doc.containsKey(RecordFields.EVENT) && doc.get(RecordFields.EVENT).isString()
+                ? doc.getString(RecordFields.EVENT).getValue() : null;
+        Class<? extends EventRecord> clazz = event == null ? null : EventCatalog.recordClassOf(event);
+
+        if (clazz == BlockBreakRecord.class || clazz == BlockPlaceRecord.class) {
+            // rollback writes the before-state (originalBlock), restore the
+            // after-state (newBlock); the projection only fetched that side.
+            String sideKey = rollback ? RecordFields.ORIGINAL_BLOCK : RecordFields.NEW_BLOCK;
+            BsonDocument side = doc.containsKey(sideKey) && doc.get(sideKey).isDocument()
+                    ? doc.getDocument(sideKey) : null;
+            if (side == null) {
+                sink.skip(occurred, id);
+                return;
+            }
+            boolean simple = side.containsKey(RecordFields.SIMPLE)
+                    && side.get(RecordFields.SIMPLE).isBoolean()
+                    && side.getBoolean(RecordFields.SIMPLE).getValue();
+            String blockData = side.containsKey(RecordFields.BLOCK_DATA)
+                    && side.get(RecordFields.BLOCK_DATA).isString()
+                    ? side.getString(RecordFields.BLOCK_DATA).getValue() : null;
+            if (simple && blockData != null) {
+                // Hot path: no snapshot / effect object. expectedData is unused
+                // under force-overwrite (#69), so pass null.
+                BsonDocument loc = doc.getDocument(RecordFields.LOCATION);
+                sink.block(readUuid(loc, RecordFields.WORLD_ID),
+                        loc.getInt32(RecordFields.X).getValue(),
+                        loc.getInt32(RecordFields.Y).getValue(),
+                        loc.getInt32(RecordFields.Z).getValue(),
+                        blockData, null, occurred, id);
+                return;
+            }
+            // Tile-entity payload (or malformed block-data): build the snapshot.
+            // expectedCurrent is null — force-overwrite ignores it.
+            sink.complex(new RollbackEffect.BlockReplace(readLocation(doc), null,
+                    decodeSnapshot(side)), occurred, id);
+            return;
+        }
+
+        if (clazz == ContainerDepositRecord.class || clazz == ContainerWithdrawRecord.class) {
+            BlockLocation location = readLocation(doc);
+            int slot = doc.containsKey(RecordFields.SLOT) && doc.get(RecordFields.SLOT).isInt32()
+                    ? doc.getInt32(RecordFields.SLOT).getValue() : 0;
+            StoredItem before = decodeItem(doc, RecordFields.BEFORE_ITEM);
+            StoredItem after = decodeItem(doc, RecordFields.AFTER_ITEM);
+            sink.complex(rollback
+                    ? new RollbackEffect.ContainerSlotWrite(location, slot, after, before)
+                    : new RollbackEffect.ContainerSlotWrite(location, slot, before, after), occurred, id);
+            return;
+        }
+
+        if (clazz == EntityDeathRecord.class) {
+            BlockLocation location = readLocation(doc);
+            String entityType = doc.containsKey(RecordFields.ENTITY_TYPE)
+                    && doc.get(RecordFields.ENTITY_TYPE).isString()
+                    ? doc.getString(RecordFields.ENTITY_TYPE).getValue() : null;
+            if (rollback) {
+                String nbt = doc.containsKey(RecordFields.ENTITY_NBT)
+                        && doc.get(RecordFields.ENTITY_NBT).isString()
+                        ? doc.getString(RecordFields.ENTITY_NBT).getValue() : null;
+                sink.complex(new RollbackEffect.EntitySpawn(location, entityType, nbt), occurred, id);
+            } else {
+                UUID entityId = doc.containsKey(RecordFields.ENTITY_ID)
+                        && doc.get(RecordFields.ENTITY_ID).isBinary()
+                        ? readUuid(doc, RecordFields.ENTITY_ID) : null;
+                sink.complex(new RollbackEffect.EntityRemove(location, entityType,
+                        entityId == null ? null : entityId.toString()), occurred, id);
+            }
+            return;
+        }
+
+        // Matched but not rollbackable — advance the cursor only.
+        sink.skip(occurred, id);
+    }
+
+    private BlockLocation readLocation(BsonDocument doc) {
+        BsonDocument loc = doc.getDocument(RecordFields.LOCATION);
+        String worldName = loc.containsKey(RecordFields.WORLD_NAME)
+                && loc.get(RecordFields.WORLD_NAME).isString()
+                ? loc.getString(RecordFields.WORLD_NAME).getValue() : null;
+        return new BlockLocation(readUuid(loc, RecordFields.WORLD_ID), worldName,
+                loc.getInt32(RecordFields.X).getValue(),
+                loc.getInt32(RecordFields.Y).getValue(),
+                loc.getInt32(RecordFields.Z).getValue());
+    }
+
+    private BlockSnapshot decodeSnapshot(BsonDocument side) {
+        return codecRegistry.get(BlockSnapshot.class)
+                .decode(new BsonDocumentReader(side), DecoderContext.builder().build());
+    }
+
+    private StoredItem decodeItem(BsonDocument doc, String key) {
+        if (!doc.containsKey(key) || !doc.get(key).isDocument()) {
+            return null;
+        }
+        return codecRegistry.get(StoredItem.class)
+                .decode(new BsonDocumentReader(doc.getDocument(key)), DecoderContext.builder().build());
+    }
+
+    private static UUID readUuid(BsonDocument doc, String key) {
+        return doc.getBinary(key).asUuid();
+    }
+
+    private static Instant readInstant(BsonDocument doc, String key) {
+        return Instant.ofEpochMilli(doc.getDateTime(key).getValue());
     }
 
     /**

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordFields.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordFields.java
@@ -9,10 +9,19 @@ final class RecordFields {
     static final String TARGET = "target";
     static final String MESSAGE = "message";
     static final String SOURCE_PLAYER_ID = "source.playerId";
+    static final String LOCATION = "location";
     static final String LOCATION_WORLD_ID = "location.worldId";
     static final String LOCATION_X = "location.x";
     static final String LOCATION_Y = "location.y";
     static final String LOCATION_Z = "location.z";
+
+    // Sub-fields of the embedded location document, read directly by the
+    // lean rollback path (which reads raw BSON, not "location.x" dot paths).
+    static final String WORLD_ID = "worldId";
+    static final String WORLD_NAME = "worldName";
+    static final String X = "x";
+    static final String Y = "y";
+    static final String Z = "z";
 
     // Heavy snapshot fields, dropped by the summary projection.
     static final String ORIGINAL_BLOCK = "originalBlock";
@@ -20,6 +29,17 @@ final class RecordFields {
     static final String BEFORE_ITEM = "beforeItem";
     static final String AFTER_ITEM = "afterItem";
     static final String ITEM = "item";
+
+    // BlockSnapshot sub-fields the lean rollback path reads without
+    // materializing the whole snapshot for simple (no tile-entity) blocks.
+    static final String BLOCK_DATA = "blockData";
+    static final String SIMPLE = "simple";
+
+    // Container / entity-death record fields the lean rollback path reads.
+    static final String SLOT = "slot";
+    static final String ENTITY_TYPE = "entityType";
+    static final String ENTITY_ID = "entityId";
+    static final String ENTITY_NBT = "entityNbt";
 
     private RecordFields() {
     }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -521,4 +521,132 @@ class MongoRecordStoreIT {
                 .containsExactlyElementsOf(pagedIds);
         assertThat(streamRounds).isEqualTo(pageRounds);
     }
+
+    // Captures the lean streamRollbackEffects sink calls, keyed by row id so
+    // each emitted effect can be checked against the canonical Rollbackable.
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        record BlockCall(UUID worldId, int x, int y, int z, String blockData, String expected) {
+        }
+
+        final Map<UUID, BlockCall> blocks = new java.util.HashMap<>();
+        final Map<UUID, net.medievalrp.spyglass.api.rollback.RollbackEffect> complex = new java.util.HashMap<>();
+        final java.util.Set<UUID> skipped = new java.util.HashSet<>();
+
+        @Override
+        public void block(UUID worldId, int x, int y, int z, String blockData,
+                          String expectedData, Instant occurred, UUID id) {
+            blocks.put(id, new BlockCall(worldId, x, y, z, blockData, expectedData));
+        }
+
+        @Override
+        public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                            Instant occurred, UUID id) {
+            complex.put(id, effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skipped.add(id);
+        }
+    }
+
+    private CapturingSink drainLeanRollback(QueryRequest request, boolean rollback) {
+        CapturingSink sink = new CapturingSink();
+        QueryPage.Cursor cursor = null;
+        do {
+            // Small window so multi-page cursor stepping is exercised too.
+            cursor = store.streamRollbackEffects(request, cursor, 3, rollback, sink);
+        } while (cursor != null);
+        return sink;
+    }
+
+    @Test
+    void leanStreamRollbackEffectsMatchesCanonicalEffects() {
+        // The native Mongo streamRollbackEffects override (the ClickHouse #67/
+        // #83 mirror) reads raw projected BSON and emits effects directly. It
+        // must produce exactly what each record's Rollbackable.rollbackEffect()
+        // / restoreEffect() would — the simple-block hot path via sink.block()
+        // primitives, everything else via sink.complex() — in both directions.
+        // Block effects drop expectedCurrent (force-overwrite #69 ignores it).
+        Instant now = Instant.parse("2026-04-23T12:00:00Z");
+        BlockLocation loc = new BlockLocation(WORLD, "world", 10, 64, 20);
+        Origin origin = Origin.player();
+        Source source = Source.player(ALICE, "Alice");
+        BlockSnapshot stone = new BlockSnapshot(org.bukkit.Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(org.bukkit.Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        StoredItem diamond = new StoredItem(3, "DIAMOND", null);
+        BlockSnapshot chest = new BlockSnapshot(org.bukkit.Material.CHEST, "minecraft:chest",
+                List.of(diamond), List.of(), List.of(), List.of(), null);
+
+        BlockBreakRecord brk = new BlockBreakRecord(UUID.randomUUID(), "break",
+                now.plusSeconds(1), now.plusSeconds(3600), origin, source, loc, "test", "STONE", stone, air);
+        BlockPlaceRecord place = new BlockPlaceRecord(UUID.randomUUID(), "place",
+                now.plusSeconds(2), now.plusSeconds(3600), origin, source, loc, "test", "STONE", air, stone);
+        BlockBreakRecord chestBreak = new BlockBreakRecord(UUID.randomUUID(), "break",
+                now.plusSeconds(3), now.plusSeconds(3600), origin, source,
+                new BlockLocation(WORLD, "world", 11, 64, 20), "test", "CHEST", chest, air);
+        ContainerDepositRecord deposit = new ContainerDepositRecord(UUID.randomUUID(), "deposit",
+                now.plusSeconds(4), now.plusSeconds(3600), origin, source, loc, "test", "DIAMOND", "CHEST",
+                3, 1, null, diamond);
+        EntityDeathRecord death = new EntityDeathRecord(UUID.randomUUID(), "death",
+                now.plusSeconds(5), now.plusSeconds(3600), origin, source, loc, "test", "ZOMBIE", "ZOMBIE",
+                UUID.randomUUID(), "player", "ENTITY_ATTACK", null);
+        net.medievalrp.spyglass.api.event.ChatRecord chat = new net.medievalrp.spyglass.api.event.ChatRecord(
+                UUID.randomUUID(), "say", now.plusSeconds(6), now.plusSeconds(3600),
+                origin, source, loc, "test", "Alice", "hi", List.of(), java.util.Map.of());
+        store.save(List.of(brk, place, chestBreak, deposit, death, chat));
+
+        QueryRequest request = new QueryRequest(
+                List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
+                Sort.NEWEST_FIRST, 1000, EnumSet.noneOf(Flag.class), false);
+
+        for (boolean rollback : new boolean[] {true, false}) {
+            CapturingSink sink = drainLeanRollback(request, rollback);
+
+            // Non-rollbackable chat advances the cursor via skip(), never an effect.
+            assertThat(sink.skipped).as("chat skipped (%s)", rollback).containsExactly(chat.id());
+            assertThat(sink.blocks.keySet()).doesNotContain(chat.id());
+            assertThat(sink.complex.keySet()).doesNotContain(chat.id());
+
+            // Simple blocks: hot path via sink.block(); blockData is the
+            // canonical replacement side, expected is dropped to null.
+            var brkExpected = (net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace)
+                    (rollback ? brk.rollbackEffect() : brk.restoreEffect());
+            assertThat(sink.blocks.get(brk.id()).blockData()).isEqualTo(brkExpected.replacement().blockData());
+            assertThat(sink.blocks.get(brk.id()).expected()).isNull();
+            assertThat(sink.blocks.get(brk.id()).x()).isEqualTo(10);
+
+            var placeExpected = (net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace)
+                    (rollback ? place.rollbackEffect() : place.restoreEffect());
+            assertThat(sink.blocks.get(place.id()).blockData()).isEqualTo(placeExpected.replacement().blockData());
+
+            // The chest break exercises direction-specific side selection:
+            // rollback writes originalBlock (the chest, a tile-entity → complex
+            // object path); restore writes newBlock (air → simple hot path).
+            var chestCanonical = (net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace)
+                    (rollback ? chestBreak.rollbackEffect() : chestBreak.restoreEffect());
+            if (rollback) {
+                var chestEffect = (net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace)
+                        sink.complex.get(chestBreak.id());
+                assertThat(chestEffect).as("chest rollback uses the complex path").isNotNull();
+                assertThat(chestEffect.location()).isEqualTo(chestCanonical.location());
+                assertThat(chestEffect.replacement()).isEqualTo(chestCanonical.replacement());
+                assertThat(chestEffect.expectedCurrent()).isNull();
+                assertThat(sink.blocks).doesNotContainKey(chestBreak.id());
+            } else {
+                assertThat(sink.blocks.get(chestBreak.id()).blockData())
+                        .isEqualTo(chestCanonical.replacement().blockData());
+                assertThat(sink.complex).doesNotContainKey(chestBreak.id());
+            }
+
+            // Container + entity rows match the canonical effect exactly
+            // (those paths keep expectedCurrent, same as ClickHouse).
+            assertThat(sink.complex.get(deposit.id()))
+                    .isEqualTo(rollback ? deposit.rollbackEffect() : deposit.restoreEffect());
+            assertThat(sink.complex.get(death.id()))
+                    .isEqualTo(rollback ? death.rollbackEffect() : death.restoreEffect());
+        }
+    }
 }


### PR DESCRIPTION
Part of #91. Benchmark-driven MongoDB rollback optimization + the disk-size axis the benchmarks were missing.

## What shipped
**1. Lean direction-specific MongoDB rollback read.** The Mongo backend used the default `streamRollbackEffects`, which rides `queryPage()` and decodes the *full* `EventRecord` graph per row (both block snapshots, origin, source, server, target) only to keep the one replacement side. Overrode it to mirror the ClickHouse #67/#83 lean path: read raw BSON projected to just the fields a `RollbackEffect` needs (direction-specific — rollback reads `originalBlock`, restore reads `newBlock`, since force-overwrite #69 ignores the expected side), emit the simple-block hot path straight to `sink.block()` primitives, and build a snapshot/item only for the rare tile-entity / container / entity rows.

**2. Disk-footprint measurement** (`regression/disk.py` + a "DISK FOOTPRINT" section in `compare.js`) across all four backends, and a refreshed README 4-way table with the new disk row.

## Results (2M-block rollback, warmed, 6 GB heap, this host)
| | before | after |
|---|---|---|
| SG·Mongo rollback | 19.7s | **13.8s** (−30%) |
| SG·Mongo undo | 24.1s | **17.5s** (−27%) |

- **Block-type distribution verified identical before vs after** (8-type layered proof: 262,144 blocks, 64/64 layers, every type exact) — the lean read changed speed, not correctness.
- JUnit parity test (`MongoRecordStoreIT`) drives the lean stream against a real Mongo and asserts every emitted effect equals the canonical `Rollbackable.rollbackEffect()`/`restoreEffect()` in both directions.
- `./gradlew check` green (Docker present, store ITs ran).

## Honest scope note
This is a real improvement but MongoDB still does **not** beat CoreProtect·SQLite (~10s) on rollback wall-clock — a row store read over the wire pays more to stream 2M docs than SQLite's in-process read or ClickHouse's columnar scan (validated: a covering index doesn't help, the data is cache-resident/decode-bound). ClickHouse (~5s) remains the CP-beating backend. The README now positions the backends accordingly. Closing the last gap would need a parallel-read pipeline rewrite (risking the documented zero-GC-freeze work) — deliberately not attempted here.