### PR TITLE
perf(mongo): id-covered rollback keyset index — beats both CoreProtect backends (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ A 2,000,376-block rollback, measured four ways: Spyglass and CoreProtect each on
 
 | 2M-block rollback | Spyglass · ClickHouse | Spyglass · MongoDB | CoreProtect · SQLite | CoreProtect · MySQL |
 |---|---|---|---|---|
-| Rollback wall-clock | **~5 s** | ~14 s | ~10 s | ~12 s |
-| Undo / restore wall-clock | **~4 s** | ~18 s | ~9 s | ~210 s |
-| TPS during the op (min / avg) | **20.0 / 20.0** | **20.0 / 20.0** | 19 / 20 | 13 / 20 |
-| Worst single tick | ~50 ms | **~25 ms** | ~670 ms | ~270 ms |
-| On-disk footprint (data + index) | **~11 MiB** | ~245 MiB | ~160 MiB | ~180 MiB |
+| Rollback wall-clock | **~5 s** | ~7 s | ~11 s | ~12 s |
+| Undo / restore wall-clock | **~4 s** | ~6 s | ~9 s | ~210 s |
+| TPS during the op (min / avg) | **20.0 / 20.0** | **20.0 / 20.0** | 14 / 19 | 13 / 20 |
+| Worst single tick | **~50 ms** | ~100 ms | ~670 ms | ~270 ms |
+| On-disk footprint (data + index) | **~11 MiB** | ~330 MiB | ~160 MiB | ~180 MiB |
 
-Read it by backend, not by row. **ClickHouse wins on raw speed and storage** (every wall-clock figure and a 54x compression ratio), and it is the backend to run on a large server. **MongoDB is the default and the smoothest**: it never drops below 20 TPS and its worst tick stays under 30 ms while CoreProtect spikes to 300-700 ms, and its undo shrugs off the restore that takes CoreProtect · MySQL three and a half minutes. What it does *not* win is rollback wall-clock. A row store read over the wire pays more to stream a million-row result set than ClickHouse's columnar scan or SQLite's in-process read, so even after a 2026-06 lean-read pass (rollback down ~30%, from ~19 s) it trails the embedded stores on that one axis. Pick ClickHouse for speed and disk, MongoDB for operational simplicity and tick stability.
+Read it by backend, not by row. **ClickHouse wins outright on speed and storage** (the fastest wall-clock figures, a worst tick near 50 ms, and a 54x compression ratio), and it is the backend for the largest servers. **MongoDB is the default, and after a 2026-06 pass it now out-runs both CoreProtect backends.** The rollback read was paying for a blocking in-memory sort on every page; ending each rollback index with the same id the reader pages by made the scan index-ordered and removed it, which roughly halved the read and dropped a 2M rollback from ~14 s to ~7 s. MongoDB holds 20.0 TPS throughout where CoreProtect dips into the teens, keeps its worst tick near 100 ms against CoreProtect's 300-700 ms, and its undo shrugs off the restore that takes CoreProtect · MySQL three and a half minutes. The one place it does not win is disk: those covering indexes push it to ~330 MiB, more than the embedded stores and far more than ClickHouse, a deliberate trade of space for read speed. Pick ClickHouse for the lowest latency and smallest disk, MongoDB when you want a document store with rollback speed now in hand.
 
 ## Features
 
@@ -44,7 +44,7 @@ Spyglass and CoreProtect both log the world and roll it back. Where they part wa
 | Preview a rollback before applying |  | ✓ |
 | Rollback runs off the main thread | ✓ |  |
 | TPS during a 2M rollback | **20.0, flat** | dips to ~13 |
-| Worst single tick | **~60 ms** | up to ~900 ms |
+| Worst single tick | **~100 ms** | up to ~900 ms |
 | Automatic data pruning | ✓ |  |
 | Storage engines | MongoDB, ClickHouse | SQLite, MySQL |
 | Minecraft versions | 1.21.x | 1.7+ |

--- a/regression/bot/_multi-edit-proof.js
+++ b/regression/bot/_multi-edit-proof.js
@@ -1,0 +1,130 @@
+// Multi-edit ordering proof for the parallel-read rollback.
+//
+// The distribution proof edits each cell ONCE, so it can't catch an apply
+// that processes events out of global time order. This one edits every cell
+// THREE times, seconds apart, so the three edits land in different
+// occurred-time partitions of the parallel reader. A correct rollback applies
+// them newest-first across partitions, so the oldest edit's revert wins and
+// every cell returns to its pre-first-edit base. A mis-ordered apply leaves
+// cells stuck at an intermediate type.
+//
+// Usage: node _multi-edit-proof.js [SIDE]
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+
+const SIDE = parseInt(process.argv[2] || '48', 10);
+const X0 = 28000, Y0 = 80, Z0 = 28000;
+const X1 = X0 + SIDE - 1, Z1 = Z0 + SIDE - 1; // single Y-layer
+const VOL = SIDE * SIDE;
+const BASE = 'bedrock';                 // pre-first-edit state every cell must return to
+const ROUNDS = ['stone', 'dirt', 'glass']; // three logged overwrites, oldest→newest
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+const countOf = s => { const m = s && s.match(/(\d[\d,]*)\s+block/i); return m ? parseInt(m[1].replace(/,/g, ''), 10) : 0; };
+function waitChat(bot, re, timeout) {
+    return new Promise(resolve => {
+        const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); resolve(m); } };
+        bot.on('messagestr', h);
+        setTimeout(() => { bot.removeListener('messagestr', h); resolve(null); }, timeout);
+    });
+}
+
+const BOT = 'rbm' + Date.now().toString(36).slice(-4);
+
+(async () => {
+    log(`Region ${SIDE}x${SIDE} = ${VOL.toLocaleString()} cells @ (${X0},${Y0},${Z0}); base=${BASE}, rounds=[${ROUNDS}]`);
+    await rcon(`forceload add ${X0} ${Z0} ${X1} ${Z1}`);
+    await sleep(1500);
+    // Base layer, UNLOGGED (RCON). Every cell must return here after rollback.
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y0} ${Z1} ${BASE}`);
+
+    const bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    await rcon(`op ${BOT}`);
+    await rcon(`gamemode creative ${BOT}`);
+    await rcon(`tp ${BOT} ${X0 + SIDE / 2} ${Y0 + 4} ${Z0 + SIDE / 2}`);
+    await sleep(2500);
+    try { await bot.waitForChunksToLoad(); } catch { }
+    await sleep(1500);
+    bot.chat('//sel cuboid'); await sleep(200);
+    bot.chat(`//pos1 ${X0},${Y0},${Z0}`); await sleep(200);
+    bot.chat(`//pos2 ${X1},${Y0},${Z1}`); await sleep(200);
+
+    // Three logged overwrites, ~3s apart so each lands in a distinct
+    // occurred-time partition of the parallel reader.
+    for (const type of ROUNDS) {
+        const done = waitChat(bot, /(blocks? have been changed|operation completed|affected)/i, 120000);
+        bot.chat(`//set ${type}`);
+        await done;
+        log(`  //set ${type} done`);
+        await sleep(3000);
+    }
+    await sleep(6000); // let the recorder drain all three rounds
+
+    log(`Rollback /sg rollback p:${BOT} t:1h -g …`);
+    let summary = null;
+    const h = m => { if (/(reversals|No results|rolled back)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    const t0 = Date.now();
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    while (summary == null && Date.now() - t0 < 180000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    log(`  rollback: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(timeout)'}  (${Date.now() - t0}ms)`);
+    await sleep(5000);
+
+    // Verify: every cell back to BASE. Count base cells (destructive: base->diamond),
+    // and count any survivors of each round type that should be gone.
+    const baseCount = countOf(await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y0} ${Z1} diamond_block replace ${BASE}`));
+    const leftovers = {};
+    for (const type of ROUNDS) {
+        leftovers[type] = countOf(await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y0} ${Z1} air replace ${type}`));
+    }
+    log('\n──────── MULTI-EDIT ROLLBACK RESULT ────────');
+    log(`  ${BASE.padEnd(10)} restored ${baseCount.toLocaleString().padStart(8)} / ${VOL.toLocaleString()}`);
+    let stuck = 0;
+    for (const type of ROUNDS) {
+        if (leftovers[type] > 0) { log(`  STUCK at ${type}: ${leftovers[type].toLocaleString()} cells (ordering bug)`); stuck += leftovers[type]; }
+    }
+    const pass = baseCount === VOL && stuck === 0;
+    log(`\n  VERDICT: ${pass
+        ? 'PASS — every multi-edited cell returned to its pre-first-edit base; global order preserved across partitions.'
+        : 'FAIL — cells did not return to base (' + baseCount + '/' + VOL + ', ' + stuck + ' stuck) — apply order is wrong.'}`);
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`fill ${X0} ${Y0} ${Z0} ${X1} ${Y0} ${Z1} air`);
+    await rcon(`forceload remove ${X0} ${Z0} ${X1} ${Z1}`);
+    process.exit(pass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); process.exit(2); });

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/IndexManager.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/IndexManager.java
@@ -3,25 +3,72 @@ package net.medievalrp.spyglass.plugin.storage;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.bson.BsonDocument;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class IndexManager {
 
+    // The pre-id rollback indexes, superseded by the (… , occurred desc,
+    // id desc) shape below. Each new index is a strict superset of its
+    // legacy form (same prefix, one extra trailing field), so once the new
+    // one exists the old is pure write-amplification — every record insert
+    // would maintain both. createIndex can't replace them in place (adding
+    // id changes the generated name, so it's a new index, not an update), so
+    // an upgrade-in-place deployment is left carrying both until we drop the
+    // legacy names here. Exact-name drops only ever touch indexes this class
+    // created; _id_, the new rollback indexes, and any operator-made index
+    // are untouched.
+    private static final List<String> SUPERSEDED_INDEXES = List.of(
+            "source.playerId_1_occurred_-1",
+            "event_1_occurred_-1",
+            "location.worldId_1_location.x_1_location.z_1_location.y_1_occurred_-1");
+
     public void ensureRecordIndexes(MongoCollection<BsonDocument> collection) {
+        // Each rollback index ends with (occurred desc, id desc) — the exact
+        // key the keyset reader (queryPage / streamRollbackEffects) sorts by.
+        // Without the trailing id, the (occurred, id) sort is only partly
+        // index-ordered, so Mongo adds a blocking in-memory SORT stage per
+        // 500k-row page (plan: SORT->FETCH->IXSCAN). Including id makes the
+        // read a pure streamed scan (LIMIT->FETCH->IXSCAN, no SORT), which on
+        // a 2M rollback is the difference between ~12s and ~4s of read with
+        // no extra heap — the keyset was designed for this index shape. The
+        // index covers both directions (NEWEST_FIRST forward, OLDEST_FIRST via
+        // a backward scan).
         collection.createIndex(Indexes.compoundIndex(
                 Indexes.ascending(RecordFields.SOURCE_PLAYER_ID),
-                Indexes.descending(RecordFields.OCCURRED)));
+                Indexes.descending(RecordFields.OCCURRED),
+                Indexes.descending(RecordFields.ID)));
         collection.createIndex(Indexes.compoundIndex(
                 Indexes.ascending(RecordFields.EVENT),
-                Indexes.descending(RecordFields.OCCURRED)));
+                Indexes.descending(RecordFields.OCCURRED),
+                Indexes.descending(RecordFields.ID)));
         collection.createIndex(Indexes.compoundIndex(
                 Indexes.ascending(RecordFields.LOCATION_WORLD_ID),
                 Indexes.ascending(RecordFields.LOCATION_X),
                 Indexes.ascending(RecordFields.LOCATION_Z),
                 Indexes.ascending(RecordFields.LOCATION_Y),
-                Indexes.descending(RecordFields.OCCURRED)));
-        collection.createIndex(Indexes.ascending(RecordFields.EXPIRES_AT), new IndexOptions().expireAfter(0L, java.util.concurrent.TimeUnit.SECONDS));
+                Indexes.descending(RecordFields.OCCURRED),
+                Indexes.descending(RecordFields.ID)));
+        collection.createIndex(Indexes.ascending(RecordFields.EXPIRES_AT),
+                new IndexOptions().expireAfter(0L, TimeUnit.SECONDS));
+
+        dropSupersededIndexes(collection);
+    }
+
+    private void dropSupersededIndexes(MongoCollection<BsonDocument> collection) {
+        Set<String> present = new HashSet<>();
+        for (BsonDocument index : collection.listIndexes(BsonDocument.class)) {
+            present.add(index.getString("name").getValue());
+        }
+        for (String legacy : SUPERSEDED_INDEXES) {
+            if (present.contains(legacy)) {
+                collection.dropIndex(legacy);
+            }
+        }
     }
 }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -139,12 +139,43 @@ class MongoRecordStoreIT {
                 .map(document -> document.getString("name"))
                 .toList();
 
+        // Rollback indexes end with id (-1) so the keyset (occurred, id) sort
+        // is fully index-covered — no blocking SORT stage per page.
         assertThat(indexNames).contains(
                 "_id_",
-                "source.playerId_1_occurred_-1",
-                "event_1_occurred_-1",
-                "location.worldId_1_location.x_1_location.z_1_location.y_1_occurred_-1",
+                "source.playerId_1_occurred_-1_id_-1",
+                "event_1_occurred_-1_id_-1",
+                "location.worldId_1_location.x_1_location.z_1_location.y_1_occurred_-1_id_-1",
                 "expiresAt_1");
+    }
+
+    @Test
+    void supersededLegacyRollbackIndexIsDropped() {
+        com.mongodb.client.MongoCollection<org.bson.BsonDocument> collection = rawClient
+                .getDatabase("IT").getCollection("EventRecords", org.bson.BsonDocument.class);
+        // Recreate the pre-id legacy rollback index, as a Mongo deployment
+        // upgraded in place from before the id-covered keyset shape would have.
+        collection.createIndex(com.mongodb.client.model.Indexes.compoundIndex(
+                com.mongodb.client.model.Indexes.ascending("event"),
+                com.mongodb.client.model.Indexes.descending("occurred")));
+        assertThat(legacyIndexNames(collection)).contains("event_1_occurred_-1");
+
+        new IndexManager().ensureRecordIndexes(collection);
+
+        // The legacy index is gone (no double write-amplification) and the
+        // id-covered superset that replaced it is present.
+        assertThat(legacyIndexNames(collection))
+                .doesNotContain("event_1_occurred_-1")
+                .contains("event_1_occurred_-1_id_-1");
+    }
+
+    private static List<String> legacyIndexNames(
+            com.mongodb.client.MongoCollection<org.bson.BsonDocument> collection) {
+        return collection.listIndexes(org.bson.BsonDocument.class)
+                .into(new java.util.ArrayList<>())
+                .stream()
+                .map(document -> document.getString("name").getValue())
+                .toList();
     }
 
     @Test


### PR DESCRIPTION
## What

Appends `(id desc)` to the three MongoDB rollback compound indexes so the keyset reader's `(occurred desc, id desc)` sort is fully index-ordered. Previously Mongo planned a **blocking in-memory SORT per 500k-row page** (`SORT->FETCH->IXSCAN`); now the read is a pure streamed scan (`LIMIT->FETCH->IXSCAN`, no SORT).

This is the change that makes the MongoDB backend **beat both CoreProtect backends** on a 2M-block rollback, where it previously trailed them.

## Results (warmed 2M rollback, shared dev host, `compare.js`)

| | rollback | undo/restore | TPS | worst tick |
|---|---|---|---|---|
| **SG·Mongo (this PR)** | **6.7 s** | **6.1 s** | 20.0/20.0 | ~100 ms |
| SG·Mongo (before) | 13.8 s | 17.5 s | 20.0/20.0 | ~25 ms |
| CP·SQLite | 11.2 s | 9.1 s | 13.6/18.8 | 305/683 ms |
| CP·MySQL | ~12 s | ~210 s | 13/20 | ~270 ms |

The read phase dropped ~12 s → ~5 s with **no extra heap** — single lean reader, zero-GC-freeze structure intact. Honest cost: worst tick rose ~25 → ~100 ms (still far under CoreProtect) and the covering indexes grow the footprint to ~330 MiB (clean 2M: 136 data + 196 index).

## Index migration

Adding `id` changes each index's generated name, so `createIndex` makes a **new** index rather than updating the old. The new index is a strict superset of its legacy form, so an upgrade-in-place deployment would otherwise carry both and double insert-time write-amplification. The three superseded legacy index names are dropped on startup (exact-name, plugin-owned only — `_id_`, the new indexes, and operator-made indexes are untouched).

## Verification

- `./gradlew check` green (jacoco floors hold).
- `MongoRecordStoreIT` against real Mongo (Testcontainers): index names, lean-read parity (both directions), and `supersededLegacyRollbackIndexIsDropped`.
- In-world correctness: single-edit distribution proof (64/64 layers) and the new multi-edit ordering proof (cells edited 3× all return to base) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)