### PR TITLE
perf(pipeline): skip RecordCommittedEvent dispatch when unlistened (#96)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -92,6 +92,7 @@ import net.medievalrp.spyglass.plugin.listener.player.JoinListener;
 import net.medievalrp.spyglass.plugin.listener.player.QuitListener;
 import net.medievalrp.spyglass.plugin.listener.player.TeleportListener;
 import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
+import net.medievalrp.spyglass.plugin.pipeline.RecordCommittedPublisher;
 import net.medievalrp.spyglass.plugin.rollback.ClickHouseUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.MongoUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
@@ -213,9 +214,13 @@ public final class SpyglassPlugin extends JavaPlugin {
         // Publish RecordCommittedEvent to Bukkit listeners on every
         // intake. Done via a hook (rather than a direct Bukkit call
         // inside AsyncRecorder) so the recorder stays unit-testable
-        // headless.
-        recorder.onCommitted(record ->
-                Bukkit.getPluginManager().callEvent(new RecordCommittedEvent(record)));
+        // headless. The publisher skips the allocation + dispatch
+        // entirely when nothing is listening — the hook runs on the
+        // recording (main) thread, so an unconsumed dispatch is pure
+        // per-record waste on the ingest hot path of every event type.
+        recorder.onCommitted(new RecordCommittedPublisher(
+                () -> RecordCommittedEvent.getHandlerList().getRegisteredListeners().length,
+                record -> Bukkit.getPluginManager().callEvent(new RecordCommittedEvent(record))));
 
         // Replay any WAL files left from a prior crash before the
         // listeners come online, so recovered records land in the DB

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/RecordCommittedPublisher.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/RecordCommittedPublisher.java
@@ -1,0 +1,52 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import java.util.function.Consumer;
+import java.util.function.IntSupplier;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Committed-hook target that publishes {@code RecordCommittedEvent} to
+ * Bukkit, but only when something is actually listening for it.
+ *
+ * <p>The committed hook runs synchronously on the recording thread — the
+ * main thread for live listeners — so it sits on the ingest hot path of
+ * <em>every</em> event type. When no plugin has registered a
+ * {@code RecordCommittedEvent} listener (the common case unless a
+ * companion plugin consumes it), allocating the event and dispatching it
+ * through an empty handler list is pure per-record waste, folded into the
+ * profiler self-time of every listener. Guarding on the live
+ * registered-listener count skips both the allocation and the dispatch in
+ * that case, and fires exactly as before the moment any listener
+ * registers — Bukkit's {@code HandlerList} re-bakes its registered array
+ * on every (un)register, so the count is always current and the check is
+ * cheap.
+ *
+ * <p>The two collaborators are injected so the guard is unit-testable
+ * headless, without a running server: {@code registeredListenerCount}
+ * supplies {@code
+ * RecordCommittedEvent.getHandlerList().getRegisteredListeners().length}
+ * and {@code dispatch} performs the actual
+ * {@code Bukkit.getPluginManager().callEvent(...)}. This mirrors why the
+ * committed hook exists at all — to keep the recorder free of a direct
+ * Bukkit call so it stays headless-testable.
+ */
+@ApiStatus.Internal
+public final class RecordCommittedPublisher implements Consumer<EventRecord> {
+
+    private final IntSupplier registeredListenerCount;
+    private final Consumer<EventRecord> dispatch;
+
+    public RecordCommittedPublisher(IntSupplier registeredListenerCount,
+                                    Consumer<EventRecord> dispatch) {
+        this.registeredListenerCount = registeredListenerCount;
+        this.dispatch = dispatch;
+    }
+
+    @Override
+    public void accept(EventRecord record) {
+        if (registeredListenerCount.getAsInt() > 0) {
+            dispatch.accept(record);
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/RecordCommittedPublisherTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/RecordCommittedPublisherTest.java
@@ -1,0 +1,78 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the committed-hook guard (#96): {@code RecordCommittedEvent} must
+ * not be allocated or dispatched when nothing is listening, must fire
+ * unchanged when a listener is present, and must re-read the registration
+ * state per record (no stale caching). The injected {@code dispatch}
+ * stands in for {@code Bukkit.getPluginManager().callEvent(...)} so the
+ * guard is exercised headless, without a running server.
+ */
+class RecordCommittedPublisherTest {
+
+    private static EventRecord sampleRecord() {
+        Instant now = Instant.now();
+        return new JoinRecord(
+                UUID.randomUUID(), "join", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "tester"),
+                new BlockLocation(UUID.randomUUID(), "world", 0, 64, 0),
+                "test", "tester", "127.0.0.1");
+    }
+
+    @Test
+    void skipsDispatchWhenNoListenerIsRegistered() {
+        @SuppressWarnings("unchecked")
+        Consumer<EventRecord> dispatch = mock(Consumer.class);
+        RecordCommittedPublisher publisher = new RecordCommittedPublisher(() -> 0, dispatch);
+
+        publisher.accept(sampleRecord());
+
+        verifyNoInteractions(dispatch);
+    }
+
+    @Test
+    void dispatchesWhenAListenerIsRegistered() {
+        @SuppressWarnings("unchecked")
+        Consumer<EventRecord> dispatch = mock(Consumer.class);
+        RecordCommittedPublisher publisher = new RecordCommittedPublisher(() -> 1, dispatch);
+        EventRecord record = sampleRecord();
+
+        publisher.accept(record);
+
+        verify(dispatch).accept(record);
+    }
+
+    @Test
+    void reflectsListenerCountOnEachCallWithoutCaching() {
+        // The registration state can change at runtime; the guard must
+        // re-read it per record, never cache the first answer.
+        AtomicInteger registered = new AtomicInteger(0);
+        @SuppressWarnings("unchecked")
+        Consumer<EventRecord> dispatch = mock(Consumer.class);
+        RecordCommittedPublisher publisher =
+                new RecordCommittedPublisher(registered::get, dispatch);
+
+        publisher.accept(sampleRecord());   // none registered -> skipped
+        verifyNoInteractions(dispatch);
+
+        registered.set(1);
+        EventRecord second = sampleRecord();
+        publisher.accept(second);           // now registered -> dispatched
+        verify(dispatch).accept(second);
+    }
+}


### PR DESCRIPTION
The committed hook fires on the recording (main) thread for every
record, so when no plugin listens for RecordCommittedEvent the
per-record event allocation + empty-handler dispatch is pure waste,
folded into the profiler self-time of every listener.

Extract RecordCommittedPublisher (a Consumer<EventRecord> with injected
seams) that guards the dispatch on the live registered-listener count.
HandlerList re-bakes its array on every (un)register, so the count is
always current; the guard skips both the allocation and the callEvent
when nothing is listening and fires unchanged the moment a listener
registers. The seams keep the logic unit-testable headless.

Closes #96
