### PR TITLE
perf(listener): serialize item pickups off the main thread (#97)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -137,6 +137,14 @@ public final class SpyglassPlugin extends JavaPlugin {
     private ToolStateStore toolStateStore;
     private SalvageStore salvageStore;
     private Executor queryExecutor;
+    /**
+     * Off-main serialization stage for the highest-frequency listeners.
+     * Item serialization (NBT to bytes to base64) is the bulk of the
+     * per-pickup main-thread cost; the pickup listener snapshots on the
+     * main thread and hands the heavy work here. Drained before the
+     * recorder on shutdown so nothing in flight is lost (see onDisable).
+     */
+    private java.util.concurrent.ExecutorService serializationExecutor;
     private SpyglassConfig config;
     private WorldEditSubscriber worldEditSubscriber;
     private WorldEditLifecycleListener worldEditLifecycle;
@@ -199,6 +207,21 @@ public final class SpyglassPlugin extends JavaPlugin {
         }
 
         queryExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        java.util.concurrent.ExecutorService serializer =
+                Executors.newVirtualThreadPerTaskExecutor();
+        serializationExecutor = serializer;
+        // Listeners submit through a guarded view: a poison item that
+        // makes serialization throw must not escape to the worker's
+        // default handler (stderr) — structured logging only. On failure
+        // the record is skipped and the cause is logged.
+        Executor guardedSerializer = task -> serializer.execute(() -> {
+            try {
+                task.run();
+            } catch (RuntimeException ex) {
+                getLogger().warning("Spyglass deferred record serialization failed;"
+                        + " record skipped: " + ex);
+            }
+        });
 
         boolean walEnabled = config.storage().durability()
                 == SpyglassConfig.Durability.WAL_BATCHED;
@@ -272,7 +295,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new StructureGrowListener(recorder, support),
                 new BlockIgniteListener(recorder, support, this),
                 new ItemDropListener(recorder, support),
-                new ItemPickupListener(recorder, support),
+                new ItemPickupListener(recorder, support, guardedSerializer),
                 new CreativeCloneListener(recorder, support),
                 new TeleportListener(recorder, support),
                 new EntityDeathListener(recorder, support),
@@ -542,6 +565,23 @@ public final class SpyglassPlugin extends JavaPlugin {
                 active.unregister();
             } catch (Throwable ignored) {
             }
+        }
+        // Drain the off-thread serialization stage BEFORE the recorder,
+        // so any in-flight snapshots (deferred item pickups) finish
+        // serializing and reach the recorder's queue before it drains.
+        // Ordering matters: reversed, the recorder would close while
+        // pickups were still mid-serialization and lose them.
+        if (serializationExecutor != null) {
+            serializationExecutor.shutdown();
+            try {
+                if (!serializationExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)) {
+                    serializationExecutor.shutdownNow();
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                serializationExecutor.shutdownNow();
+            }
+            serializationExecutor = null;
         }
         if (recorder != null) {
             try {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListener.java
@@ -2,6 +2,7 @@ package net.medievalrp.spyglass.plugin.listener.item;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.ItemPickupRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.RecordContext;
@@ -13,6 +14,7 @@ import net.medievalrp.spyglass.plugin.listener.RecordingListener;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -25,10 +27,12 @@ public final class ItemPickupListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor serializer;
 
-    public ItemPickupListener(Recorder recorder, RecordingSupport support) {
+    public ItemPickupListener(Recorder recorder, RecordingSupport support, Executor serializer) {
         this.recorder = recorder;
         this.support = support;
+        this.serializer = serializer;
     }
 
     @Override
@@ -39,10 +43,20 @@ public final class ItemPickupListener implements RecordingListener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityPickupItem(EntityPickupItemEvent event) {
         ItemStack stack = event.getItem().getItemStack();
-        StoredItem stored = ItemSerialization.storedItem(0, stack);
-        if (stored == null) {
+        if (stack == null || stack.getType() == Material.AIR) {
             return;
         }
+        // Pickups are the highest-frequency event Spyglass logs (every
+        // player plus every mob with canPickupItems). Item serialization
+        // (NBT -> bytes -> base64, plus Adventure component extraction)
+        // is the bulk of the per-pickup cost, so we keep only a cheap
+        // snapshot on the main thread and hand the heavy work to the
+        // serializer. The clone is independent of the live stack (which
+        // the picked-up entity is about to consume), so serializing the
+        // clone off the main thread is safe.
+        ItemStack snapshot = stack.clone();
+        String target = stack.getType().name();
+        int amount = stack.getAmount();
         BlockLocation location = BlockLocations.fromLocation(event.getItem().getLocation());
         Origin origin;
         Source source;
@@ -55,7 +69,18 @@ public final class ItemPickupListener implements RecordingListener {
             origin = support.environmentOrigin("pickup:" + entityType);
             source = support.entitySource(entityId, entityType);
         }
+        // Build the context (which stamps occurred + the time-ordered v7
+        // id) on the main thread, so the record reflects event time, not
+        // serialization time. ItemPickupRecord is not Rollbackable, so
+        // deferring it has no interaction with the rollback flush /
+        // read-your-writes contract.
         RecordContext ctx = support.context(origin, source, location);
-        recorder.record(ItemPickupRecord.of(ctx, stack.getType().name(), stack.getAmount(), stored));
+        serializer.execute(() -> {
+            StoredItem stored = ItemSerialization.storedItem(0, snapshot);
+            if (stored == null) {
+                return;
+            }
+            recorder.record(ItemPickupRecord.of(ctx, target, amount, stored));
+        });
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListenerTest.java
@@ -1,0 +1,165 @@
+package net.medievalrp.spyglass.plugin.listener.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the off-main pickup serialization (#97): the heavy item
+ * serialization is handed to the injected executor, while the cheap
+ * snapshot (clone) and the context (occurred + the time-ordered v7 id)
+ * are taken on the handling (main) thread so the record reflects event
+ * time, not serialization time. {@code ItemPickupRecord} is not
+ * Rollbackable, so this deferral has no flush / read-your-writes
+ * interaction.
+ */
+class ItemPickupListenerTest {
+
+    private static final UUID PLAYER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Location's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void serializesAndRecordsOnTheExecutorNotInline() {
+        List<Runnable> deferred = new ArrayList<>();
+        ItemPickupListener listener = new ItemPickupListener(recorder, support, deferred::add);
+
+        listener.onEntityPickupItem(playerPickup(mockStack(Material.IRON_INGOT, 5)));
+
+        // Heavy work deferred: one task queued, nothing recorded inline.
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        ItemPickupRecord record = (ItemPickupRecord) recorder.records.get(0);
+        assertThat(record.target()).isEqualTo("IRON_INGOT");
+        assertThat(record.amount()).isEqualTo(5);
+        assertThat(record.item()).isNotNull();
+        assertThat(record.item().material()).isEqualTo("IRON_INGOT");
+    }
+
+    @Test
+    void stampsOccurredAndIdOnHandlingThreadNotAtSerializationTime() {
+        List<Runnable> deferred = new ArrayList<>();
+        ItemPickupListener listener = new ItemPickupListener(recorder, support, deferred::add);
+
+        Instant before = Instant.now();
+        listener.onEntityPickupItem(playerPickup(mockStack(Material.IRON_INGOT, 1)));
+        Instant after = Instant.now();
+
+        // The record is only built when the deferred task runs, strictly
+        // after the handling window — yet occurred must fall inside it.
+        deferred.get(0).run();
+
+        ItemPickupRecord record = (ItemPickupRecord) recorder.records.get(0);
+        assertThat(record.occurred()).isBetween(before, after);
+        assertThat(record.id()).isNotNull();
+    }
+
+    @Test
+    void clonesStackOnHandlingThreadBeforeDeferring() {
+        ItemStack live = mockStack(Material.DIAMOND, 2);
+        List<Runnable> deferred = new ArrayList<>();
+        ItemPickupListener listener = new ItemPickupListener(recorder, support, deferred::add);
+
+        listener.onEntityPickupItem(playerPickup(live));
+
+        // The snapshot must be taken synchronously, before the deferred
+        // task could observe a mutated/consumed live stack.
+        verify(live).clone();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void ignoresAirWithoutCloningOrDeferring() {
+        ItemStack air = mock(ItemStack.class);
+        when(air.getType()).thenReturn(Material.AIR);
+        List<Runnable> deferred = new ArrayList<>();
+        ItemPickupListener listener = new ItemPickupListener(recorder, support, deferred::add);
+
+        listener.onEntityPickupItem(playerPickup(air));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+        verify(air, never()).clone();
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────
+
+    private EntityPickupItemEvent playerPickup(ItemStack stack) {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        Item itemEntity = mock(Item.class);
+        when(itemEntity.getItemStack()).thenReturn(stack);
+        when(itemEntity.getLocation()).thenReturn(new Location(world, 10, 64, 20));
+
+        EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+        when(event.getItem()).thenReturn(itemEntity);
+        when(event.getEntity()).thenReturn(player);
+        return event;
+    }
+
+    private static ItemStack mockStack(Material material, int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(material);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.getItemMeta()).thenReturn(null);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
+        ItemStack clone = mock(ItemStack.class);
+        when(clone.getType()).thenReturn(material);
+        when(clone.getAmount()).thenReturn(amount);
+        when(clone.getItemMeta()).thenReturn(null);
+        when(clone.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
+        when(stack.clone()).thenReturn(clone);
+        return stack;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
ItemPickupListener was the hottest Spyglass listener at 200 players
(0.04%, 4x CoreProtect) because it ran full item serialization
(NBT -> bytes -> base64 plus Adventure component extraction) on the main
thread for the highest-frequency event Spyglass logs (every player plus
every mob with canPickupItems).

Snapshot on the main thread (clone the stack + capture
material/amount/location/origin/source + build the RecordContext, which
stamps occurred and the time-ordered v7 id at event time), then hand the
heavy serialization to a virtual-thread stage that builds the record and
queues it. The clone is independent of the live stack, so off-thread
serialization is safe; occurred/id are stamped on the main thread so the
record reflects event time, not serialization time.

Safe to defer because ItemPickupRecord is not Rollbackable -- no
interaction with the rollback flush / read-your-writes contract.
Listeners submit through a guarded executor view so a poison item can't
escape to stderr (structured logging only). The stage is drained before
the recorder on shutdown so nothing in flight is lost.

Closes #97
