### PR TITLE
fix(mongo): don't run write-side setup from the read-only Velocity companion (#91)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -78,8 +78,27 @@ public final class MongoRecordStore implements RecordStore {
     private final MongoCollection<EventRecord> polymorphicCollection;
     private final CodecRegistry codecRegistry;
 
+    /**
+     * Opens a store that performs write-side setup on startup: collection
+     * creation (zstd), the chunk-bucket backfill, and index creation. Use
+     * this from the primary backend plugin.
+     */
     public MongoRecordStore(String uri, String databaseName, String collectionName,
                             IndexManager indexManager) {
+        this(uri, databaseName, collectionName, indexManager, true);
+    }
+
+    /**
+     * @param performSetup when {@code false}, the store skips all write-side
+     *     setup — collection creation, the cx/cz backfill, and index creation
+     *     — and only reads. The read-only Velocity companion passes
+     *     {@code false}: it shares a database with the backend plugin, which
+     *     owns schema, indexes, and migrations, so the proxy must not create
+     *     the collection or rewrite records (the backfill is an
+     *     {@code updateMany}) on startup.
+     */
+    public MongoRecordStore(String uri, String databaseName, String collectionName,
+                            IndexManager indexManager, boolean performSetup) {
         this.codecRegistry = CodecRegistries.fromRegistries(
                 // First, so it wins for BlockLocation over both the default
                 // registry's record support and RecordCodecProvider below — it
@@ -101,11 +120,15 @@ public final class MongoRecordStore implements RecordStore {
                 .build();
         this.client = MongoClients.create(settings);
         this.database = client.getDatabase(databaseName).withCodecRegistry(codecRegistry);
-        ensureZstdCollection(database, collectionName);
+        if (performSetup) {
+            ensureZstdCollection(database, collectionName);
+        }
         this.rawCollection = database.getCollection(collectionName, BsonDocument.class);
         this.polymorphicCollection = database.getCollection(collectionName, EventRecord.class);
-        backfillChunkBuckets(rawCollection);
-        indexManager.ensureRecordIndexes(rawCollection);
+        if (performSetup) {
+            backfillChunkBuckets(rawCollection);
+            indexManager.ensureRecordIndexes(rawCollection);
+        }
     }
 
     /**

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -266,6 +266,24 @@ class MongoRecordStoreIT {
     }
 
     @Test
+    void readOnlyStoreSkipsBackfill() {
+        // performSetup=false (the read-only Velocity companion) must not
+        // rewrite records on startup. A doc without cx/cz stays untouched.
+        com.mongodb.client.MongoCollection<org.bson.Document> coll =
+                rawClient.getDatabase("IT").getCollection("EventRecords");
+        coll.insertOne(new org.bson.Document("event", "break").append("location",
+                new org.bson.Document("x", 256).append("y", 64).append("z", 256)));
+
+        new MongoRecordStore(container.getReplicaSetUrl(), "IT", "EventRecords",
+                new IndexManager(), false).close();
+
+        org.bson.BsonDocument loc = rawClient.getDatabase("IT")
+                .getCollection("EventRecords", org.bson.BsonDocument.class)
+                .find(new org.bson.Document("location.x", 256)).first().getDocument("location");
+        assertThat(loc.containsKey("cx")).as("read-only store must not backfill").isFalse();
+    }
+
+    @Test
     void dropEmptyCollectionAndRecreate() {
         rawClient.getDatabase("IT").getCollection("EventRecords").deleteMany(new org.bson.Document());
         QueryRequest empty = new QueryRequest(

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
@@ -95,7 +95,9 @@ public final class SpyglassProxy {
         SpyglassProxyConfig.Database db = cfg.database();
         return switch (db.backend()) {
             case MONGO -> new MongoRecordStore(
-                    db.uri(), db.name(), db.collection(), new IndexManager());
+                    // Read-only companion: skip collection-create, backfill, and
+                    // index writes. The backend plugin owns schema and migrations.
+                    db.uri(), db.name(), db.collection(), new IndexManager(), false);
             case CLICKHOUSE -> {
                 SpyglassProxyConfig.ClickHouse ch = db.clickhouse();
                 yield new ClickHouseRecordStore(


### PR DESCRIPTION
## Problem

`MongoRecordStore`'s constructor performs write-side setup on startup — collection creation (zstd), the cx/cz chunk-bucket backfill (an `updateMany`), and index creation. The **read-only Velocity companion** (`SpyglassProxy`) shares that constructor, so it would create the collection and rewrite records on boot. A "never writes" companion must not do that, and on a large existing collection it could run a multi-second backfill before the backend does.

## Fix

Add a `performSetup` flag. The 4-arg constructor still performs setup (the backend plugin, unchanged). The proxy passes `false` and skips collection-create, backfill, and index creation — it shares a database with the backend, which owns schema, indexes, and migrations.

Verified by `MongoRecordStoreIT.readOnlyStoreSkipsBackfill` (a `performSetup=false` store leaves an un-bucketed record untouched). `./gradlew check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)