### PR TITLE
perf(item): skip dead-weight NBT blob on pickup/drop records (#103)

### DIFF
--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/BsonBlobsTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/BsonBlobsTest.java
@@ -1,0 +1,78 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Codec contract for {@link BsonBlobs#encodeStoredItem} /
+ * {@link BsonBlobs#decodeStoredItem} — the path the ClickHouse backend
+ * uses to fold a {@link StoredItem} into its {@code item} / {@code
+ * before_item} / {@code after_item} blob columns.
+ *
+ * <p>#103 made forensic-only records (pickups, drops) carry a projection
+ * with a {@code null} {@code data} blob. This pins that a null component
+ * round-trips through the shared record codec without throwing and stays
+ * null — the same {@code RecordCodecProvider} codec the Mongo nested-item
+ * path uses, so it guards both backends' tolerance of the projection
+ * shape. No Mongo / ClickHouse container required.
+ */
+class BsonBlobsTest {
+
+    @Test
+    void storedItemWithNullDataRoundTripsKeepingProjections() {
+        StoredItem projection = new StoredItem(
+                0, "DIAMOND_SWORD", null,
+                "Excaliblur",
+                List.of("Forged in fire", "Blessed by saints"),
+                List.of("sharpness=5", "mending=1"));
+
+        StoredItem back = BsonBlobs.decodeStoredItem(BsonBlobs.encodeStoredItem(projection));
+
+        assertThat(back).isNotNull();
+        assertThat(back.data()).as("null blob must stay null through the blob codec").isNull();
+        assertThat(back.material()).isEqualTo("DIAMOND_SWORD");
+        assertThat(back.name()).isEqualTo("Excaliblur");
+        assertThat(back.lore()).containsExactly("Forged in fire", "Blessed by saints");
+        assertThat(back.enchants()).containsExactly("sharpness=5", "mending=1");
+        assertThat(back).isEqualTo(projection);
+    }
+
+    @Test
+    void storedItemWithNullDataAndNoProjectionsRoundTrips() {
+        // The 3-arg shape the ITs use: material only, null data, empty
+        // projection lists.
+        StoredItem bare = new StoredItem(3, "DIAMOND", null);
+
+        StoredItem back = BsonBlobs.decodeStoredItem(BsonBlobs.encodeStoredItem(bare));
+
+        assertThat(back).isNotNull();
+        assertThat(back.slot()).isEqualTo(3);
+        assertThat(back.material()).isEqualTo("DIAMOND");
+        assertThat(back.data()).isNull();
+        assertThat(back.name()).isNull();
+        assertThat(back.lore()).isEmpty();
+        assertThat(back.enchants()).isEmpty();
+    }
+
+    @Test
+    void itemWithBlobStillRoundTrips() {
+        // Rollbackable/container records keep the blob — make sure the
+        // projection change didn't break the populated-data path.
+        StoredItem withBlob = new StoredItem(
+                1, "IRON_INGOT", "QkFTRTY0", null, List.of(), List.of());
+
+        StoredItem back = BsonBlobs.decodeStoredItem(BsonBlobs.encodeStoredItem(withBlob));
+
+        assertThat(back).isEqualTo(withBlob);
+        assertThat(back.data()).isEqualTo("QkFTRTY0");
+    }
+
+    @Test
+    void nullItemEncodesToNull() {
+        assertThat(BsonBlobs.encodeStoredItem(null)).isNull();
+        assertThat(BsonBlobs.decodeStoredItem(null)).isNull();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
@@ -11,8 +11,10 @@ import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
 import net.medievalrp.spyglass.api.event.ChatRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
@@ -304,6 +306,34 @@ class EventRecordCodecTest {
             assertThat(decoded).isInstanceOf(BlockBreakRecord.class);
             assertThat(((BlockBreakRecord) decoded).event()).isEqualTo(alias);
         }
+    }
+
+    @Test
+    void roundTripsItemRecordWithNullDataProjection() {
+        // #103: pickups/drops store only the searchable projection — the
+        // base64 NBT blob (StoredItem.data) is null. The Mongo write path
+        // must encode a null record component and read it back without
+        // throwing, and null must stay null on the way out.
+        StoredItem projection = new StoredItem(
+                0, "DIAMOND_SWORD", null,
+                "Excaliblur",
+                List.of("Forged in fire"),
+                List.of("sharpness=5"));
+        ItemPickupRecord original = new ItemPickupRecord(
+                UUID.randomUUID(), "pickup", WHEN, WHEN.plusSeconds(3600),
+                Origin.player(), Source.player(ALICE, "Alice"),
+                new BlockLocation(WORLD, "world", 1, 64, 2),
+                "test", "DIAMOND_SWORD", 1, projection);
+
+        EventRecord decoded = decode(encode(original));
+
+        assertThat(decoded).isInstanceOf(ItemPickupRecord.class).isEqualTo(original);
+        StoredItem item = ((ItemPickupRecord) decoded).item();
+        assertThat(item.data()).as("null blob must stay null through the codec").isNull();
+        assertThat(item.material()).isEqualTo("DIAMOND_SWORD");
+        assertThat(item.name()).isEqualTo("Excaliblur");
+        assertThat(item.lore()).containsExactly("Forged in fire");
+        assertThat(item.enchants()).containsExactly("sharpness=5");
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemDropListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemDropListener.java
@@ -22,6 +22,13 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Records item drops (player throws, dispenser/dropper output, entity
+ * drops). {@code ItemDropRecord} is forensic-only — never rolled back or
+ * salvaged — so every path here serializes the searchable projection and
+ * skips the base64 NBT blob via {@link ItemSerialization#storedItemProjection}
+ * (#103); the blob would be dead weight no query or rollback ever reads.
+ */
 @ApiStatus.Internal
 public final class ItemDropListener implements RecordingListener {
 
@@ -41,7 +48,7 @@ public final class ItemDropListener implements RecordingListener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerDropItem(PlayerDropItemEvent event) {
         ItemStack stack = event.getItemDrop().getItemStack();
-        StoredItem stored = ItemSerialization.storedItem(0, stack);
+        StoredItem stored = ItemSerialization.storedItemProjection(0, stack);
         if (stored == null) {
             return;
         }
@@ -59,7 +66,7 @@ public final class ItemDropListener implements RecordingListener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockDispense(BlockDispenseEvent event) {
         ItemStack stack = event.getItem();
-        StoredItem stored = ItemSerialization.storedItem(0, stack);
+        StoredItem stored = ItemSerialization.storedItemProjection(0, stack);
         if (stored == null) {
             return;
         }
@@ -85,7 +92,7 @@ public final class ItemDropListener implements RecordingListener {
             return;
         }
         ItemStack stack = event.getItemDrop().getItemStack();
-        StoredItem stored = ItemSerialization.storedItem(0, stack);
+        StoredItem stored = ItemSerialization.storedItemProjection(0, stack);
         if (stored == null) {
             return;
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/ItemPickupListener.java
@@ -47,13 +47,13 @@ public final class ItemPickupListener implements RecordingListener {
             return;
         }
         // Pickups are the highest-frequency event Spyglass logs (every
-        // player plus every mob with canPickupItems). Item serialization
-        // (NBT -> bytes -> base64, plus Adventure component extraction)
-        // is the bulk of the per-pickup cost, so we keep only a cheap
-        // snapshot on the main thread and hand the heavy work to the
-        // serializer. The clone is independent of the live stack (which
-        // the picked-up entity is about to consume), so serializing the
-        // clone off the main thread is safe.
+        // player plus every mob with canPickupItems). We build only the
+        // searchable projection (material + name/lore/enchants) and skip
+        // the base64 NBT blob: ItemPickupRecord is never rolled back or
+        // salvaged, so nothing decodes it (#103). The remaining projection
+        // work (getItemMeta + Adventure extraction) still runs off the main
+        // thread (#97) on this independent clone, which is safe because the
+        // picked-up entity is about to consume the live stack.
         ItemStack snapshot = stack.clone();
         String target = stack.getType().name();
         int amount = stack.getAmount();
@@ -76,7 +76,7 @@ public final class ItemPickupListener implements RecordingListener {
         // read-your-writes contract.
         RecordContext ctx = support.context(origin, source, location);
         serializer.execute(() -> {
-            StoredItem stored = ItemSerialization.storedItem(0, snapshot);
+            StoredItem stored = ItemSerialization.storedItemProjection(0, snapshot);
             if (stored == null) {
                 return;
             }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
@@ -39,9 +39,31 @@ public final class ItemSerialization {
      * Serialize a stack for storage. Extracts display name, lore, and
      * enchantments into indexable plain-text fields alongside the opaque
      * base64 blob so operators can query by
-     * {@code iname:} / {@code ilore:} / {@code ench:}.
+     * {@code iname:} / {@code ilore:} / {@code ench:}. The blob is the
+     * source of truth for faithful reconstruction (rollback, salvage), so
+     * this variant is for records that may be replayed.
      */
     public static StoredItem storedItem(int slot, ItemStack itemStack) {
+        return build(slot, itemStack, true);
+    }
+
+    /**
+     * Projection-only variant: identical to {@link #storedItem} but leaves
+     * {@code data} {@code null}, skipping the {@code serializeAsBytes()} +
+     * Base64 encode that dominates per-item allocation. Use for forensic
+     * records that are never rolled back or salvaged
+     * ({@code ItemPickupRecord}, {@code ItemDropRecord}) — nothing ever
+     * decodes their blob, so it is pure dead weight in memory and on disk
+     * (#103). {@code material}, {@code name}, {@code lore} and
+     * {@code enchants} are populated exactly as in {@link #storedItem}, so
+     * {@code imaterial:} / {@code iname:} / {@code ilore:} / {@code ench:} /
+     * {@code cu:} queries match unchanged.
+     */
+    public static StoredItem storedItemProjection(int slot, ItemStack itemStack) {
+        return build(slot, itemStack, false);
+    }
+
+    private static StoredItem build(int slot, ItemStack itemStack, boolean includeData) {
         if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;
         }
@@ -70,8 +92,8 @@ public final class ItemSerialization {
                 enchants = enchantStrings(meta.getEnchants());
             }
         }
-        return new StoredItem(slot, itemStack.getType().name(),
-                encode(itemStack), name, lore, enchants);
+        String data = includeData ? encode(itemStack) : null;
+        return new StoredItem(slot, itemStack.getType().name(), data, name, lore, enchants);
     }
 
     /**

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
@@ -2,6 +2,8 @@ package net.medievalrp.spyglass.plugin.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -68,5 +70,61 @@ class ItemSerializationTest {
         assertThat(item.name()).isNull();
         assertThat(item.lore()).isEmpty();
         assertThat(item.enchants()).isEmpty();
+    }
+
+    // ── projection-only path (#103): forensic records skip the blob ──
+
+    @Test
+    void projectionPopulatesFieldsButLeavesDataNullWithoutSerializing() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.DIAMOND_SWORD);
+        // Deliberately do NOT stub serializeAsBytes(): the projection must
+        // never touch it. (If it did, the unstubbed mock returns null and
+        // Base64 encode would NPE — a second guard beyond the verify below.)
+        ItemMeta meta = mock(ItemMeta.class);
+        when(stack.getItemMeta()).thenReturn(meta);
+        when(meta.hasDisplayName()).thenReturn(true);
+        when(meta.displayName()).thenReturn(Component.text("Excaliblur"));
+        when(meta.hasLore()).thenReturn(true);
+        when(meta.lore()).thenReturn(List.of(
+                Component.text("Forged in fire"),
+                Component.text("Blessed by saints")));
+        when(meta.hasEnchants()).thenReturn(false);
+
+        StoredItem item = ItemSerialization.storedItemProjection(0, stack);
+
+        assertThat(item).isNotNull();
+        assertThat(item.data()).as("projection must not carry the NBT blob").isNull();
+        assertThat(item.material()).isEqualTo("DIAMOND_SWORD");
+        assertThat(item.name()).isEqualTo("Excaliblur");
+        assertThat(item.lore()).containsExactly("Forged in fire", "Blessed by saints");
+        assertThat(item.enchants()).isEmpty();
+        verify(stack, never()).serializeAsBytes();
+    }
+
+    @Test
+    void projectionEmptyForAir() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.AIR);
+        assertThat(ItemSerialization.storedItemProjection(0, stack)).isNull();
+        verify(stack, never()).serializeAsBytes();
+    }
+
+    @Test
+    void projectionWithoutMetaStillHasMaterialAndNullData() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.STONE);
+        when(stack.getItemMeta()).thenReturn(null);
+
+        StoredItem item = ItemSerialization.storedItemProjection(7, stack);
+
+        assertThat(item).isNotNull();
+        assertThat(item.slot()).isEqualTo(7);
+        assertThat(item.material()).isEqualTo("STONE");
+        assertThat(item.data()).isNull();
+        assertThat(item.name()).isNull();
+        assertThat(item.lore()).isEmpty();
+        assertThat(item.enchants()).isEmpty();
+        verify(stack, never()).serializeAsBytes();
     }
 }


### PR DESCRIPTION
Closes #103.

## What

`ItemPickupRecord` / `ItemDropRecord` are forensic-only (never rolled back or salvaged), yet they carried the base64 `ItemStack.serializeAsBytes()` blob in `StoredItem.data` — decoded by nothing, and the #1 allocator under load (791 KB of an 880 KB pickup profile; #97 moved it off-thread but didn't shrink it).

- New `ItemSerialization.storedItemProjection(slot, stack)`: same `material` + `name`/`lore`/`enchants` projection as `storedItem()`, but leaves `data` null and skips `serializeAsBytes()`/Base64 entirely (extracted a shared private `build(..., includeData)`).
- `ItemPickupListener` (deferred task) and `ItemDropListener` (all 3 inline paths) route through it.
- `storedItem()` is byte-identical to before; rollbackable/container paths keep the blob.

## AC coverage

- **data null, serializeAsBytes not called** — `ItemSerializationTest` (3 cases, `verify(never()).serializeAsBytes()`).
- **imaterial/iname/ilore/ench/cu unchanged** — existing Mongo IT `queriesItemNameLoreAndEnchantsAcrossPaths` already builds a null-data item inside an `ItemDropRecord` and matches it across paths.
- **null data round-trips both backends, no NPE** — `EventRecordCodecTest` (Mongo record codec, real registry) + `BsonBlobsTest` (ClickHouse blob codec), both no-Docker; plus the live Mongo/ClickHouse ITs already save/read null-data items.
- **rollback/salvage unaffected** — those paths only touch rollbackable/container records, untouched here.

## Verification

`./gradlew check` green with Docker up — store ITs ran on real Mongo + ClickHouse (Mongo 17, ClickHouse 10+5, **0 skipped**); jacoco floors hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)