### PR TITLE
perf(break): cut per-break allocation in BlockDependents.collectDependents (#104)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockDependents.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockDependents.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import org.bukkit.Material;
 import org.bukkit.Tag;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
@@ -55,22 +56,50 @@ public final class BlockDependents {
         NONE
     }
 
+    /**
+     * The six axial faces, cached so the hot break path never clones
+     * {@link BlockFace#values()} (which copies all ~80 enum constants) and
+     * re-filters it on every block break. Order matches the previous
+     * {@code values()}-then-{@code isAxial} scan so dependent ordering is
+     * unchanged.
+     */
+    private static final BlockFace[] AXIAL_FACES = {
+            BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH,
+            BlockFace.WEST, BlockFace.UP, BlockFace.DOWN,
+    };
+
     private BlockDependents() {
     }
 
     /** Walk each face of {@code broken} and collect neighbors that are attached to it. */
     public static List<Block> collectDependents(Block broken) {
-        List<Block> out = new ArrayList<>();
-        for (BlockFace face : BlockFace.values()) {
-            if (!isAxial(face)) {
+        // The common break (stone, dirt, ore) has no attached neighbors, so
+        // keep that path allocation-free: cached AXIAL_FACES (no values()
+        // clone), no ArrayList until the first dependent, and no Block
+        // wrapper for NONE-style neighbors. A Material probe via
+        // World.getType(x,y,z) returns an enum constant (no CraftBlock),
+        // so getRelative() — which does allocate a Block — is paid only for
+        // a neighbor that could actually attach.
+        World world = broken.getWorld();
+        int x = broken.getX();
+        int y = broken.getY();
+        int z = broken.getZ();
+        List<Block> out = null;
+        for (BlockFace face : AXIAL_FACES) {
+            Material neighborType = world.getType(
+                    x + face.getModX(), y + face.getModY(), z + face.getModZ());
+            if (styleOf(neighborType) == Style.NONE) {
                 continue;
             }
             Block neighbor = broken.getRelative(face);
             if (isAttachedTo(neighbor, face)) {
+                if (out == null) {
+                    out = new ArrayList<>(4);
+                }
                 out.add(neighbor);
             }
         }
-        return out;
+        return out == null ? List.of() : out;
     }
 
     /**
@@ -155,15 +184,6 @@ public final class BlockDependents {
             return directional.getFacing().getOppositeFace() == expectedHostFace;
         }
         return false;
-    }
-
-    private static boolean isAxial(BlockFace face) {
-        return face == BlockFace.UP
-                || face == BlockFace.DOWN
-                || face == BlockFace.NORTH
-                || face == BlockFace.SOUTH
-                || face == BlockFace.EAST
-                || face == BlockFace.WEST;
     }
 
     public static Style styleOf(Material material) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockDependentsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockDependentsTest.java
@@ -1,0 +1,154 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import net.medievalrp.spyglass.plugin.util.BlockDependents;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Directional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Allocation contract for {@link BlockDependents#collectDependents} (#104).
+ *
+ * <p>The block-break path runs this on every break, so the no-dependent
+ * common case (mining stone) must allocate nothing: the shared empty list,
+ * no per-call {@code BlockFace[]} clone, and no {@code Block} wrapper for
+ * NONE-style neighbors (decided by a cheap {@code World.getType} probe).
+ * The dependent case must return the same blocks in the same order as
+ * before.
+ *
+ * <p>{@code styleOf()} touches Bukkit {@link Tag} constants, which are
+ * initialized from the server registry on first access and would NPE in a
+ * plain JVM. We force that one-time init inside a {@code mockStatic} scope
+ * with {@link Bukkit#getTag} stubbed to an empty tag; afterwards the
+ * {@code Tag.*} fields are set for the JVM and the tests need no further
+ * Bukkit stubbing. The switch-based styles used here (WALL_TORCH, LADDER,
+ * TORCH) don't depend on tag membership, so an empty tag is enough.
+ */
+class BlockDependentsTest {
+
+    @BeforeAll
+    static void initBukkitTags() {
+        // A plain Tag impl (not a Mockito mock): instantiating an interface
+        // implementation does NOT initialize the Tag interface, so this
+        // doesn't prematurely run Tag's server-backed field initializers
+        // outside the stubbed scope below.
+        Tag<Material> emptyTag = new Tag<>() {
+            @Override
+            public boolean isTagged(Material item) {
+                return false;
+            }
+
+            @Override
+            public java.util.Set<Material> getValues() {
+                return java.util.Set.of();
+            }
+
+            @Override
+            public org.bukkit.NamespacedKey getKey() {
+                return org.bukkit.NamespacedKey.minecraft("spyglass_test_empty");
+            }
+        };
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getTag(anyString(), any(), any())).thenAnswer(inv -> emptyTag);
+            // First touch of a Tag.* field runs the interface initializer,
+            // which calls the (now stubbed) Bukkit.getTag for every tag.
+            BlockDependents.styleOf(Material.STONE);
+        }
+    }
+
+    @Test
+    void noDependentsReturnsSharedEmptyListWithoutMaterializingBlocks() {
+        World world = mock(World.class);
+        when(world.getType(anyInt(), anyInt(), anyInt())).thenReturn(Material.STONE);
+        Block broken = brokenAt(world, 0, 64, 0);
+
+        List<Block> result = BlockDependents.collectDependents(broken);
+
+        assertThat(result).isEmpty();
+        assertThat(result)
+                .as("empty result must be the shared List.of() singleton — no ArrayList allocated")
+                .isSameAs(List.of());
+        // NONE neighbors are decided by the getType probe; no Block wrapper.
+        verify(broken, never()).getRelative(any(BlockFace.class));
+    }
+
+    @Test
+    void collectsWallTorchDependentAndSkipsBlockWrapperForPlainNeighbors() {
+        World world = mock(World.class);
+        when(world.getType(anyInt(), anyInt(), anyInt())).thenReturn(Material.STONE);
+        when(world.getType(1, 64, 0)).thenReturn(Material.WALL_TORCH); // EAST neighbor
+        Block broken = brokenAt(world, 0, 64, 0);
+
+        Block torch = mock(Block.class);
+        when(torch.getType()).thenReturn(Material.WALL_TORCH);
+        Directional facing = mock(Directional.class);
+        when(facing.getFacing()).thenReturn(BlockFace.EAST); // points away from host
+        when(torch.getBlockData()).thenReturn(facing);
+        when(broken.getRelative(BlockFace.EAST)).thenReturn(torch);
+
+        List<Block> result = BlockDependents.collectDependents(broken);
+
+        assertThat(result).containsExactly(torch);
+        // Only the one attachable neighbor is materialized; the other five
+        // NONE-style faces never allocate a Block (#104 AC3).
+        verify(broken).getRelative(BlockFace.EAST);
+        verify(broken, never()).getRelative(BlockFace.UP);
+        verify(broken, never()).getRelative(BlockFace.DOWN);
+        verify(broken, never()).getRelative(BlockFace.NORTH);
+        verify(broken, never()).getRelative(BlockFace.SOUTH);
+        verify(broken, never()).getRelative(BlockFace.WEST);
+    }
+
+    @Test
+    void preservesFaceOrderAcrossMultipleDependents() {
+        World world = mock(World.class);
+        when(world.getType(anyInt(), anyInt(), anyInt())).thenReturn(Material.STONE);
+        when(world.getType(0, 64, -1)).thenReturn(Material.LADDER); // NORTH neighbor
+        when(world.getType(0, 65, 0)).thenReturn(Material.TORCH);   // UP neighbor
+        Block broken = brokenAt(world, 0, 64, 0);
+
+        Block ladder = mock(Block.class);
+        when(ladder.getType()).thenReturn(Material.LADDER);
+        Directional ladderData = mock(Directional.class);
+        when(ladderData.getFacing()).thenReturn(BlockFace.NORTH);
+        when(ladder.getBlockData()).thenReturn(ladderData);
+        when(broken.getRelative(BlockFace.NORTH)).thenReturn(ladder);
+
+        Block torch = mock(Block.class); // standing torch rests on the host below
+        when(torch.getType()).thenReturn(Material.TORCH);
+        when(broken.getRelative(BlockFace.UP)).thenReturn(torch);
+
+        List<Block> result = BlockDependents.collectDependents(broken);
+
+        // AXIAL_FACES order is NORTH, EAST, SOUTH, WEST, UP, DOWN, so NORTH
+        // precedes UP no matter the stubbing order — same order as the old
+        // values()-then-isAxial scan.
+        assertThat(result).containsExactly(ladder, torch);
+    }
+
+    private static Block brokenAt(World world, int x, int y, int z) {
+        Block broken = mock(Block.class);
+        when(broken.getWorld()).thenReturn(world);
+        when(broken.getX()).thenReturn(x);
+        when(broken.getY()).thenReturn(y);
+        when(broken.getZ()).thenReturn(z);
+        return broken;
+    }
+}


### PR DESCRIPTION
Closes #104.

## What

`BlockDependents.collectDependents` runs on every block break and allocated on every call, even for the overwhelmingly common no-attachment break (mining stone): an unconditional `ArrayList`, `BlockFace.values()` (clones ~80 enum constants) re-filtered through `isAxial`, and a `Block` wrapper for all 6 axial neighbors.

The no-dependent path is now allocation-free:
- cached `static final BlockFace[] AXIAL_FACES` in the original `NORTH,EAST,SOUTH,WEST,UP,DOWN` order (drops the per-call clone + `isAxial`).
- list created lazily on the first dependent; empty case returns the shared `List.of()` singleton (all four callers iterate it read-only).
- a `World.getType(x,y,z)` Material probe (enum constant, no `CraftBlock`) decides NONE-style neighbors, so `getRelative()` (which allocates a `Block`) is paid only for a neighbor that could actually attach — the largest saving.

Behavior is identical: same neighbors, same order. `collectDependentsBeyond` unchanged. Removed the now-unused `isAxial`.

## AC coverage (`BlockDependentsTest`)

- **no dependents → empty list, no alloc** — result `isSameAs(List.of())` and `getRelative` never called.
- **dependents → same blocks, same order** — wall-torch dependent collected; NORTH-before-UP ordering pinned across multiple dependents.
- **NONE neighbors not materialized** — `getRelative` verified called only for the attachable face, never for the 5 plain neighbors (`World.getType` returns an enum constant, strictly lighter than the `CraftBlock` from `getRelative`).

## Verification

`./gradlew check` green with Docker up (store ITs ran, 0 skipped); jacoco floors hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)