### PR TITLE
perf(container): defer container-transaction serialization off-thread with flush coordination (#98)

### DIFF
--- a/regression/bot/scenario-98.js
+++ b/regression/bot/scenario-98.js
@@ -1,0 +1,152 @@
+// #98 live proof: container deposit burst -> IMMEDIATE rollback (read-your-writes).
+//
+// ContainerTransactionListener now serializes deposits OFF the main thread
+// (#98). A rollback flushes the recorder for read-your-writes, and that flush
+// must drain the deferred serialization stage FIRST — otherwise a rollback
+// issued right after a deposit burst would miss records still mid-serialization
+// and only PARTIALLY revert the chest.
+//
+// A real bot burst-deposits distinct stacks into a chest, then rolls back with
+// NO drain delay. If the flush barrier holds, EVERY deposit is reverted (chest
+// empty); a broken barrier leaves some stacks behind.
+//
+// Built at the bot's spawn chunk (already loaded) with vanilla minecraft:
+// commands (the RP server's plugins shadow /tp, /fill, etc.). Ports are
+// env-overridable; defaults target the standard ../RP_Server. Verified for
+// #98 against an isolated RP_Server_2 via:
+//   SG_PORT=25567 SG_RCON_PORT=25577 node scenario-98.js
+import mineflayer from 'mineflayer';
+import vec3 from 'vec3';
+import net from 'net';
+
+const HOST = process.env.SG_HOST || '127.0.0.1';
+const PORT = Number(process.env.SG_PORT || 25566);
+const RCON_PORT = Number(process.env.SG_RCON_PORT || 25576);
+const PASS = process.env.SG_RCON_PASS || 'test123';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const ts = () => '[' + new Date().toISOString().slice(11, 19) + ']';
+const log = (...a) => console.log(ts(), ...a);
+const ITEMS = ['diamond', 'emerald', 'gold_ingot', 'iron_ingot', 'redstone',
+    'lapis_lazuli', 'coal', 'copper_ingot', 'quartz'];
+
+function packet(id, t, body) {
+    const b = Buffer.from(body, 'utf8');
+    const len = 4 + 4 + b.length + 2;
+    const o = Buffer.alloc(4 + len);
+    o.writeInt32LE(len, 0); o.writeInt32LE(id, 4); o.writeInt32LE(t, 8);
+    b.copy(o, 12); o.writeInt16LE(0, 12 + b.length);
+    return o;
+}
+function rcon(cmd) {
+    return new Promise((res, rej) => {
+        const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 120000 });
+        let st = 0; const bufs = [];
+        s.on('error', rej);
+        s.on('timeout', () => { s.destroy(); rej(new Error('rcon timeout: ' + cmd)); });
+        s.on('connect', () => s.write(packet(0x1337, 3, PASS)));
+        s.on('data', c => {
+            bufs.push(c);
+            const all = Buffer.concat(bufs);
+            if (all.length < 4) return;
+            const len = all.readInt32LE(0);
+            if (all.length < len + 4) return;
+            const id = all.readInt32LE(4);
+            const body = all.slice(12, 12 + len - 10).toString('utf8').replace(/§./g, '');
+            if (st === 0) { if (id === -1) return rej('auth'); st = 1; bufs.length = 0; s.write(packet(0x1337, 2, cmd)); }
+            else { s.end(); res(body); }
+        });
+    });
+}
+
+const BOT = 'sg98' + Date.now().toString(36).slice(-4);
+const results = [];
+const check = (name, ok, detail) => { results.push({ name, ok }); log(`  ${ok ? 'PASS' : 'FAIL'} — ${name}${detail ? ' :: ' + detail : ''}`); };
+
+let bot, CHX, CHY, CHZ;
+async function waitForBlock(x, y, z, want, timeoutMs) {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+        const b = bot.blockAt(vec3(x, y, z));
+        if (b && (!want || b.name === want)) return b;
+        await sleep(500);
+    }
+    return bot.blockAt(vec3(x, y, z));
+}
+async function chestItemCount() {
+    const block = await waitForBlock(CHX, CHY, CHZ, 'chest', 15000);
+    const win = await bot.openContainer(block);
+    const n = win.containerItems().reduce((s, i) => s + i.count, 0);
+    win.close();
+    await sleep(400);
+    return n;
+}
+
+(async () => {
+    log(`#98 deposit->rollback proof. bot=${BOT}`);
+    bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+    await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+    bot.on('kicked', r => { log('KICKED', JSON.stringify(r)); });
+    await sleep(500);
+
+    const p = bot.entity.position;
+    const bx = Math.floor(p.x), by = Math.floor(p.y), bz = Math.floor(p.z);
+    CHX = bx + 1; CHY = by; CHZ = bz; // chest adjacent, same (loaded) chunk
+
+    await rcon(`op ${BOT}`);
+    await rcon(`minecraft:gamemode survival ${BOT}`);
+    await rcon(`minecraft:fill ${bx - 1} ${by - 1} ${bz - 1} ${bx + 2} ${by - 1} ${bz + 2} stone`);
+    await rcon(`minecraft:setblock ${CHX} ${CHY} ${CHZ} air`);
+    await rcon(`minecraft:setblock ${CHX} ${CHY} ${CHZ} chest`);
+    await rcon(`minecraft:teleport ${BOT} ${bx + 0.5} ${by} ${bz + 0.5}`);
+    await sleep(2500);
+
+    const chestBlock = await waitForBlock(CHX, CHY, CHZ, 'chest', 20000);
+    check('SETUP: chest visible to bot', chestBlock?.name === 'chest', `block=${chestBlock?.name} @${CHX},${CHY},${CHZ}`);
+    if (chestBlock?.name !== 'chest') throw new Error('chest not loaded in bot view');
+
+    for (const it of ITEMS) await rcon(`minecraft:give ${BOT} minecraft:${it} 8`);
+    await sleep(1500);
+
+    log('Stage: open chest, burst-deposit all stacks (serialized off-thread)…');
+    const chest = await bot.openContainer(chestBlock);
+    let deposited = 0;
+    for (const it of ITEMS) {
+        const id = bot.registry.itemsByName[it]?.id;
+        if (id == null) continue;
+        try { await chest.deposit(id, null, 8); deposited++; } catch (e) { log('  deposit fail', it, e?.message); }
+    }
+    chest.close();
+    await sleep(300);
+    log(`  deposited ${deposited}/${ITEMS.length} stacks`);
+    check('SETUP: deposits actually happened', deposited > 0, `deposited=${deposited}`);
+
+    // IMMEDIATE rollback — no drain delay. flush() must drain the deferred
+    // serialization stage before reading, or this only partially reverts.
+    log('Stage: IMMEDIATE /sg rollback (no drain delay) — the read-your-writes test…');
+    let summary = null;
+    const h = m => { if (/(revers|rolled back|applied|No results|affected|change)/i.test(m)) summary = m; };
+    bot.on('messagestr', h);
+    bot.chat(`/sg rollback p:${BOT} t:1h -g`);
+    const t0 = Date.now();
+    while (summary == null && Date.now() - t0 < 90000) await sleep(200);
+    bot.removeListener('messagestr', h);
+    log(`  rollback: ${summary ? summary.replace(/\s+/g, ' ').trim() : '(none/timeout)'}`);
+    check('ROLLBACK: found deposits to revert (not "No results")',
+        summary != null && !/No results/i.test(summary), `summary=${summary ? summary.replace(/\s+/g, ' ').trim().slice(0, 120) : '(none)'}`);
+    await sleep(4000); // let the world-write pool apply
+
+    const left = await chestItemCount();
+    check('READ-YOUR-WRITES: chest fully reverted after immediate rollback',
+        left === 0, `items left=${left} (deposited ${deposited} stacks; >0 means flush missed in-flight records)`);
+
+    const passed = results.filter(r => r.ok).length;
+    log(`\n──────── #98 SUITE: ${passed}/${results.length} checks passed ────────`);
+    for (const r of results) log(`  ${r.ok ? '✓' : '✗'} ${r.name}`);
+    const allPass = results.every(r => r.ok);
+    log(`\n  VERDICT: ${allPass ? 'PASS — deferred container serialization holds the rollback flush contract.' : 'FAIL — see checks.'}`);
+
+    bot.quit();
+    await sleep(1000);
+    await rcon(`minecraft:setblock ${CHX} ${CHY} ${CHZ} air`);
+    process.exit(allPass ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e); try { bot?.quit(); } catch { } process.exit(2); });

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -92,6 +92,7 @@ import net.medievalrp.spyglass.plugin.listener.player.JoinListener;
 import net.medievalrp.spyglass.plugin.listener.player.QuitListener;
 import net.medievalrp.spyglass.plugin.listener.player.TeleportListener;
 import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
+import net.medievalrp.spyglass.plugin.pipeline.DeferredSerializer;
 import net.medievalrp.spyglass.plugin.pipeline.RecordCommittedPublisher;
 import net.medievalrp.spyglass.plugin.rollback.ClickHouseUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.MongoUndoStack;
@@ -138,13 +139,15 @@ public final class SpyglassPlugin extends JavaPlugin {
     private SalvageStore salvageStore;
     private Executor queryExecutor;
     /**
-     * Off-main serialization stage for the highest-frequency listeners.
-     * Item serialization (NBT to bytes to base64) is the bulk of the
-     * per-pickup main-thread cost; the pickup listener snapshots on the
-     * main thread and hands the heavy work here. Drained before the
-     * recorder on shutdown so nothing in flight is lost (see onDisable).
+     * Off-main serialization stage for the item-heavy listeners. Item
+     * serialization (NBT to bytes to base64) is the bulk of their
+     * main-thread cost; pickups (#97/#103) and container transactions
+     * (#98) snapshot on the main thread and hand the heavy work here.
+     * For the rollbackable container records it also gates the recorder's
+     * flush (read-your-writes). Drained before the recorder on shutdown so
+     * nothing in flight is lost (see onDisable).
      */
-    private java.util.concurrent.ExecutorService serializationExecutor;
+    private DeferredSerializer deferredSerializer;
     private SpyglassConfig config;
     private WorldEditSubscriber worldEditSubscriber;
     private WorldEditLifecycleListener worldEditLifecycle;
@@ -207,21 +210,12 @@ public final class SpyglassPlugin extends JavaPlugin {
         }
 
         queryExecutor = Executors.newVirtualThreadPerTaskExecutor();
-        java.util.concurrent.ExecutorService serializer =
-                Executors.newVirtualThreadPerTaskExecutor();
-        serializationExecutor = serializer;
-        // Listeners submit through a guarded view: a poison item that
-        // makes serialization throw must not escape to the worker's
-        // default handler (stderr) — structured logging only. On failure
-        // the record is skipped and the cause is logged.
-        Executor guardedSerializer = task -> serializer.execute(() -> {
-            try {
-                task.run();
-            } catch (RuntimeException ex) {
-                getLogger().warning("Spyglass deferred record serialization failed;"
-                        + " record skipped: " + ex);
-            }
-        });
+        // One off-thread serialization stage for the item-heavy listeners
+        // (pickups #97/#103, container transactions #98). It guards poison
+        // items (logs + skips, never stderr), runs the heavy work on
+        // virtual threads, and tracks in-flight tasks so the recorder's
+        // flush can drain it before a rollback reads.
+        deferredSerializer = new DeferredSerializer(getLogger());
 
         boolean walEnabled = config.storage().durability()
                 == SpyglassConfig.Durability.WAL_BATCHED;
@@ -244,6 +238,12 @@ public final class SpyglassPlugin extends JavaPlugin {
         recorder.onCommitted(new RecordCommittedPublisher(
                 () -> RecordCommittedEvent.getHandlerList().getRegisteredListeners().length,
                 record -> Bukkit.getPluginManager().callEvent(new RecordCommittedEvent(record))));
+        // #98: rollbackable container records serialize off-thread through
+        // deferredSerializer before reaching the queue. A rollback flushes
+        // the recorder for read-your-writes, so make flush() drain that
+        // stage first — otherwise a rollback right after a deposit burst
+        // would snapshot the queue before the in-flight records land.
+        recorder.setFlushBarrier(deferredSerializer::awaitQuiescence);
 
         // Replay any WAL files left from a prior crash before the
         // listeners come online, so recovered records land in the DB
@@ -278,7 +278,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new BlockPlaceListener(recorder, support),
                 new BlockMultiPlaceListener(recorder, support),
                 new FallingBlockLandListener(recorder, support),
-                new ContainerTransactionListener(recorder, support),
+                new ContainerTransactionListener(recorder, support, deferredSerializer),
                 new ContainerDragListener(recorder, support),
                 new ContainerInteractListener(recorder, support),
                 new BlockUseListener(recorder, support),
@@ -295,7 +295,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new StructureGrowListener(recorder, support),
                 new BlockIgniteListener(recorder, support, this),
                 new ItemDropListener(recorder, support),
-                new ItemPickupListener(recorder, support, guardedSerializer),
+                new ItemPickupListener(recorder, support, deferredSerializer),
                 new CreativeCloneListener(recorder, support),
                 new TeleportListener(recorder, support),
                 new EntityDeathListener(recorder, support),
@@ -571,17 +571,9 @@ public final class SpyglassPlugin extends JavaPlugin {
         // serializing and reach the recorder's queue before it drains.
         // Ordering matters: reversed, the recorder would close while
         // pickups were still mid-serialization and lose them.
-        if (serializationExecutor != null) {
-            serializationExecutor.shutdown();
-            try {
-                if (!serializationExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)) {
-                    serializationExecutor.shutdownNow();
-                }
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                serializationExecutor.shutdownNow();
-            }
-            serializationExecutor = null;
+        if (deferredSerializer != null) {
+            deferredSerializer.shutdown(Duration.parse("2s"));
+            deferredSerializer = null;
         }
         if (recorder != null) {
             try {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
@@ -2,9 +2,12 @@ package net.medievalrp.spyglass.plugin.listener.container;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
-import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.listener.RecordingListener;
@@ -33,15 +36,29 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Records chest/barrel/minecart deposits and withdrawals. These records
+ * are <em>rollbackable</em> ({@code ContainerSlotWrite}), so the item
+ * serialization is deferred off the main thread through a
+ * {@link net.medievalrp.spyglass.plugin.pipeline.DeferredSerializer}
+ * whose quiescence the recorder's {@code flush()} awaits before a rollback
+ * (#98). Each handler captures a cheap snapshot on the main thread —
+ * cloning the pre-click stacks and minting the time-ordered id at event
+ * time — and hands the {@code serializeAsBytes()} + record build to the
+ * serializer, which calls {@code recorder.record()} from there.
+ */
 @ApiStatus.Internal
 public final class ContainerTransactionListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor serializer;
 
-    public ContainerTransactionListener(Recorder recorder, RecordingSupport support) {
+    public ContainerTransactionListener(Recorder recorder, RecordingSupport support,
+                                        Executor serializer) {
         this.recorder = recorder;
         this.support = support;
+        this.serializer = serializer;
     }
 
     @Override
@@ -114,7 +131,9 @@ public final class ContainerTransactionListener implements RecordingListener {
 
         BlockLocation location = containerTarget.location();
         String containerType = containerTarget.type();
-        StoredItem before = ItemSerialization.storedItem(slot, slotItem);
+        // Clone the pre-click slot state on the main thread; the heavy
+        // serialization of it runs off-thread (#98).
+        ItemStack beforeSnapshot = cloneOrNull(slotItem);
 
         // (before, after) must be the SLOT's exact state pair — the
         // rollback effect writes `before` back only when the live slot
@@ -134,13 +153,9 @@ public final class ContainerTransactionListener implements RecordingListener {
                     afterStack.setAmount(Math.min(slotItem.getMaxStackSize(),
                             slotItem.getAmount() + amount));
                 }
-                StoredItem after = ItemSerialization.storedItem(slot, afterStack);
                 String target = cursor == null ? "UNKNOWN" : cursor.getType().name();
-                recorder.record(new ContainerDepositRecord(
-                        support.newId(), "deposit", occurred,
-                        support.expiresAt(occurred),
-                        support.playerOrigin(), support.playerSource(player),
-                        location, support.serverName(), target, containerType, slot, amount, before, after));
+                deferDeposit(player, location, containerType, slot, amount, target,
+                        occurred, slot, beforeSnapshot, afterStack);
             }
             case WITHDRAW -> {
                 ItemStack afterStack = null;
@@ -149,13 +164,9 @@ public final class ContainerTransactionListener implements RecordingListener {
                     afterStack = slotItem.clone();
                     afterStack.setAmount(slotItem.getAmount() - amount);
                 }
-                StoredItem after = ItemSerialization.storedItem(slot, afterStack);
                 String target = slotItem == null ? "UNKNOWN" : slotItem.getType().name();
-                recorder.record(new ContainerWithdrawRecord(
-                        support.newId(), "withdraw", occurred,
-                        support.expiresAt(occurred),
-                        support.playerOrigin(), support.playerSource(player),
-                        location, support.serverName(), target, containerType, slot, amount, before, after));
+                deferWithdraw(player, location, containerType, slot, amount, target,
+                        occurred, slot, beforeSnapshot, afterStack);
             }
         }
     }
@@ -189,29 +200,23 @@ public final class ContainerTransactionListener implements RecordingListener {
         BlockLocation location = containerTarget.location();
         String containerType = containerTarget.type();
 
+        ItemStack movedSnapshot = moved.clone(); // pre-click; serialized off-thread
+        String target = moved.getType().name();
         if (clickedIsTop) {
             // Shift-click from container to player inventory -> withdraw.
             int recordSlot = resolved.slot();
-            StoredItem before = ItemSerialization.storedItem(recordSlot, moved);
-            recorder.record(new ContainerWithdrawRecord(
-                    support.newId(), "withdraw", occurred,
-                    support.expiresAt(occurred),
-                    support.playerOrigin(), support.playerSource(player),
-                    location, support.serverName(), moved.getType().name(), containerType, recordSlot, amount, before, null));
+            deferWithdraw(player, location, containerType, recordSlot, amount, target,
+                    occurred, recordSlot, movedSnapshot, null);
             return;
         }
         if (!clicked.equals(bottom)) {
             return;
         }
         // Shift-click from player inventory to container -> deposit. Slot is
-        // -1 (no specific container slot); `before` carries the source
+        // -1 (no specific container slot); the after-item carries the source
         // player-inventory slot, matching the single-chest behavior.
-        StoredItem before = ItemSerialization.storedItem(event.getSlot(), moved);
-        recorder.record(new ContainerDepositRecord(
-                support.newId(), "deposit", occurred,
-                support.expiresAt(occurred),
-                support.playerOrigin(), support.playerSource(player),
-                location, support.serverName(), moved.getType().name(), containerType, -1, amount, null, before));
+        deferDeposit(player, location, containerType, -1, amount, target,
+                occurred, event.getSlot(), null, movedSnapshot);
     }
 
     private void handleHotbarSwap(InventoryClickEvent event, ContainerTarget containerTarget, Player player,
@@ -230,24 +235,17 @@ public final class ContainerTransactionListener implements RecordingListener {
         String containerType = containerTarget.type();
         // A hotbar swap replaces the container slot's contents with the
         // hotbar stack (or empties it): one (before=slotItem,
-        // after=hotbarItem) state pair shared by both records (#28).
-        StoredItem beforePair = slotHadItem ? ItemSerialization.storedItem(slot, slotItem) : null;
-        StoredItem afterPair = hotbarHadItem ? ItemSerialization.storedItem(slot, hotbarItem) : null;
+        // after=hotbarItem) state pair shared by both records (#28). Clone
+        // both pre-click stacks on the main thread; serialize off it.
+        ItemStack beforeSnapshot = slotHadItem ? slotItem.clone() : null;
+        ItemStack afterSnapshot = hotbarHadItem ? hotbarItem.clone() : null;
         if (slotHadItem) {
-            recorder.record(new ContainerWithdrawRecord(
-                    support.newId(), "withdraw", occurred,
-                    support.expiresAt(occurred),
-                    support.playerOrigin(), support.playerSource(player),
-                    location, support.serverName(), slotItem.getType().name(), containerType, slot,
-                    slotItem.getAmount(), beforePair, afterPair));
+            deferWithdraw(player, location, containerType, slot, slotItem.getAmount(),
+                    slotItem.getType().name(), occurred, slot, beforeSnapshot, afterSnapshot);
         }
         if (hotbarHadItem) {
-            recorder.record(new ContainerDepositRecord(
-                    support.newId(), "deposit", occurred,
-                    support.expiresAt(occurred),
-                    support.playerOrigin(), support.playerSource(player),
-                    location, support.serverName(), hotbarItem.getType().name(), containerType, slot,
-                    hotbarItem.getAmount(), beforePair, afterPair));
+            deferDeposit(player, location, containerType, slot, hotbarItem.getAmount(),
+                    hotbarItem.getType().name(), occurred, slot, beforeSnapshot, afterSnapshot);
         }
     }
 
@@ -260,24 +258,60 @@ public final class ContainerTransactionListener implements RecordingListener {
         if (!hadSlotItem && !hadCursorItem) {
             return;
         }
+        // Shared (before=slotItem, after=cursor) pair; clone both pre-click
+        // stacks on the main thread, serialize off it (#98).
+        ItemStack beforeSnapshot = hadSlotItem ? slotItem.clone() : null;
+        ItemStack afterSnapshot = hadCursorItem ? cursor.clone() : null;
         if (hadSlotItem) {
-            recorder.record(new ContainerWithdrawRecord(
-                    support.newId(), "withdraw", occurred,
-                    support.expiresAt(occurred),
-                    support.playerOrigin(), support.playerSource(player),
-                    location, support.serverName(), slotItem.getType().name(), containerType, slot, slotItem.getAmount(),
-                    ItemSerialization.storedItem(slot, slotItem),
-                    hadCursorItem ? ItemSerialization.storedItem(slot, cursor) : null));
+            deferWithdraw(player, location, containerType, slot, slotItem.getAmount(),
+                    slotItem.getType().name(), occurred, slot, beforeSnapshot, afterSnapshot);
         }
         if (hadCursorItem) {
-            recorder.record(new ContainerDepositRecord(
-                    support.newId(), "deposit", occurred,
-                    support.expiresAt(occurred),
-                    support.playerOrigin(), support.playerSource(player),
-                    location, support.serverName(), cursor.getType().name(), containerType, slot, cursor.getAmount(),
-                    hadSlotItem ? ItemSerialization.storedItem(slot, slotItem) : null,
-                    ItemSerialization.storedItem(slot, cursor)));
+            deferDeposit(player, location, containerType, slot, cursor.getAmount(),
+                    cursor.getType().name(), occurred, slot, beforeSnapshot, afterSnapshot);
         }
+    }
+
+    // ── deferral helpers ─────────────────────────────────────────────
+    // Each captures the time-ordered id + player-derived context on the
+    // MAIN thread (so the record reflects event time and reads the live
+    // Player safely), then hands the heavy storedItem() serialization of
+    // the already-cloned stacks to the off-thread serializer (#98).
+    // itemSlot is the slot stamped into the before/after StoredItems, which
+    // differs from recordSlot only for slotless shift-click deposits.
+
+    private void deferDeposit(Player player, BlockLocation location, String containerType,
+                             int recordSlot, int amount, String target, Instant occurred,
+                             int itemSlot, @Nullable ItemStack before, @Nullable ItemStack after) {
+        UUID id = support.newId();
+        Origin origin = support.playerOrigin();
+        Source source = support.playerSource(player);
+        Instant expiresAt = support.expiresAt(occurred);
+        String server = support.serverName();
+        serializer.execute(() -> recorder.record(new ContainerDepositRecord(
+                id, "deposit", occurred, expiresAt, origin, source, location, server,
+                target, containerType, recordSlot, amount,
+                ItemSerialization.storedItem(itemSlot, before),
+                ItemSerialization.storedItem(itemSlot, after))));
+    }
+
+    private void deferWithdraw(Player player, BlockLocation location, String containerType,
+                              int recordSlot, int amount, String target, Instant occurred,
+                              int itemSlot, @Nullable ItemStack before, @Nullable ItemStack after) {
+        UUID id = support.newId();
+        Origin origin = support.playerOrigin();
+        Source source = support.playerSource(player);
+        Instant expiresAt = support.expiresAt(occurred);
+        String server = support.serverName();
+        serializer.execute(() -> recorder.record(new ContainerWithdrawRecord(
+                id, "withdraw", occurred, expiresAt, origin, source, location, server,
+                target, containerType, recordSlot, amount,
+                ItemSerialization.storedItem(itemSlot, before),
+                ItemSerialization.storedItem(itemSlot, after))));
+    }
+
+    private static @Nullable ItemStack cloneOrNull(@Nullable ItemStack stack) {
+        return stack == null ? null : stack.clone();
     }
 
     /**

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -69,6 +69,20 @@ public final class AsyncRecorder implements Recorder {
     private final AtomicLong dropped = new AtomicLong();
     private final AtomicLong lastWarnedDepth = new AtomicLong();
     private volatile Consumer<EventRecord> committedHook = r -> {};
+    private volatile FlushBarrier flushBarrier = timeout -> true;
+
+    /**
+     * Pre-flush gate. {@link #flush} awaits this before snapshotting the
+     * queue high-water mark, so a deferred-serialization stage that feeds
+     * {@link #record} off-thread (see {@code DeferredSerializer}, #98) can
+     * be drained first — otherwise a rollback right after a burst would
+     * snapshot the queue before the in-flight records reach it.
+     */
+    @FunctionalInterface
+    public interface FlushBarrier {
+        /** @return {@code true} if the stage drained within {@code timeout}. */
+        boolean awaitQuiescent(Duration timeout);
+    }
 
     /**
      * @param warnThreshold queue depth at which we start warning the operator.
@@ -116,6 +130,17 @@ public final class AsyncRecorder implements Recorder {
      */
     public void onCommitted(Consumer<EventRecord> hook) {
         this.committedHook = hook == null ? r -> {} : hook;
+    }
+
+    /**
+     * Install a barrier that {@link #flush} drains before waiting on the
+     * queue. Used to make flush await an off-thread serialization stage
+     * (rollbackable records mid-serialization) so read-your-writes holds
+     * for a rollback issued right after a burst (#98). Default is a no-op,
+     * so setups without a deferred stage (and unit tests) are unaffected.
+     */
+    public void setFlushBarrier(FlushBarrier barrier) {
+        this.flushBarrier = barrier == null ? (timeout -> true) : barrier;
     }
 
     @Override
@@ -185,6 +210,16 @@ public final class AsyncRecorder implements Recorder {
         // cycle either way.
         long deadlineNanos = System.nanoTime()
                 + TimeUnit.SECONDS.toNanos(Math.max(0L, timeout.seconds()));
+        // Drain the deferred-serialization stage first (#98): records still
+        // mid-serialization must be handed to the queue before we snapshot
+        // the high-water mark, or a rollback right after a burst would miss
+        // them and partially restore. The barrier is given the full timeout
+        // budget; the queue wait below is still bounded by the same overall
+        // deadline, so a barrier that consumes the budget surfaces as a
+        // flush timeout rather than an unbounded wait.
+        if (!flushBarrier.awaitQuiescent(timeout)) {
+            return false;
+        }
         long highWaterMark = drained.get() + queue.size();
         while (drained.get() < highWaterMark) {
             if (System.nanoTime() >= deadlineNanos) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializer.java
@@ -1,0 +1,147 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.util.Duration;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Off-main-thread serialization stage for listeners whose per-record cost
+ * is dominated by item serialization (NBT -&gt; bytes -&gt; base64 plus
+ * Adventure text extraction). A listener captures a cheap snapshot on the
+ * main thread and hands the heavy build to {@link #execute}, which runs it
+ * on a virtual thread and calls {@code Recorder.record()} from there.
+ *
+ * <h2>Flush coordination (rollbackable records)</h2>
+ *
+ * <p>Pickups are forensic-only, but this stage is also used for
+ * <em>rollbackable</em> container records (#98). Those sit in front of the
+ * recorder queue, so a rollback's read-your-writes flush must drain this
+ * stage <em>first</em>: {@link #awaitQuiescence} blocks until every task
+ * submitted before the call has finished handing its record to the
+ * recorder. Wire it as the recorder's pre-flush barrier
+ * ({@link AsyncRecorder#setFlushBarrier}) so
+ * {@code flush()} = drain this stage, then drain the queue.
+ *
+ * <h2>Durability tradeoff</h2>
+ *
+ * <p>A task in flight here has been snapshotted off the live world but not
+ * yet enqueued, so it sits <b>outside</b> the recorder's no-drop/WAL
+ * guarantee — a hard JVM crash in that window (the few ms of
+ * serialization) loses it. For pickups this is irrelevant (never rolled
+ * back); for rollbackable container records it is a small, deliberate
+ * weakening of rollback completeness, accepted for the tick-latency win
+ * (#98). {@code flush()} still guarantees correctness for an
+ * <em>orderly</em> rollback — only an unclean crash mid-serialization can
+ * lose a deferred record.
+ */
+@ApiStatus.Internal
+public final class DeferredSerializer implements Executor {
+
+    private final ExecutorService executor;
+    private final Logger logger;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition idle = lock.newCondition();
+    private long inFlight;
+
+    public DeferredSerializer(Logger logger) {
+        this(Executors.newVirtualThreadPerTaskExecutor(), logger);
+    }
+
+    /** Visible for tests: inject a deterministic executor (e.g. same-thread). */
+    DeferredSerializer(ExecutorService executor, Logger logger) {
+        this.executor = executor;
+        this.logger = logger;
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        lock.lock();
+        try {
+            inFlight++;
+        } finally {
+            lock.unlock();
+        }
+        try {
+            executor.execute(() -> run(task));
+        } catch (RejectedExecutionException rejected) {
+            // Executor already shutting down. Run inline so a rollbackable
+            // record isn't silently dropped, then settle the counter.
+            run(task);
+        }
+    }
+
+    private void run(Runnable task) {
+        try {
+            task.run();
+        } catch (RuntimeException ex) {
+            // Structured logging only: a poison item that makes
+            // serialization throw must not escape to the worker's default
+            // handler (stderr). The record is skipped; the cause is logged.
+            logger.warning("Spyglass deferred record serialization failed;"
+                    + " record skipped: " + ex);
+        } finally {
+            lock.lock();
+            try {
+                if (--inFlight == 0) {
+                    idle.signalAll();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Block until every task submitted before this call has finished (its
+     * record handed to the recorder), or {@code timeout} elapses. Tasks
+     * submitted concurrently during the wait may also be awaited; the
+     * contract the rollback flush relies on is that nothing submitted
+     * before the call is still in flight on success.
+     *
+     * @return {@code true} if the stage reached quiescence, {@code false} on timeout
+     */
+    public boolean awaitQuiescence(Duration timeout) {
+        long deadlineNanos = System.nanoTime()
+                + TimeUnit.SECONDS.toNanos(Math.max(0L, timeout.seconds()));
+        lock.lock();
+        try {
+            while (inFlight > 0) {
+                long remaining = deadlineNanos - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                idle.awaitNanos(remaining);
+            }
+            return true;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Stop accepting new tasks and wait up to {@code timeout} for in-flight
+     * tasks to finish. Call before the recorder shuts down so deferred
+     * records reach the queue before the drain stops.
+     */
+    public void shutdown(Duration timeout) {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(Math.max(0L, timeout.seconds()), TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
@@ -70,26 +70,33 @@ public final class ItemSerialization {
         String name = null;
         List<String> lore = List.of();
         List<String> enchants = List.of();
-        ItemMeta meta = itemStack.getItemMeta();
-        if (meta != null) {
-            if (meta.hasDisplayName()) {
-                Component displayName = meta.displayName();
-                if (displayName != null) {
-                    name = RecordingSupport.safeText(PLAIN.serialize(displayName));
-                }
-            }
-            if (meta.hasLore()) {
-                List<Component> metaLore = meta.lore();
-                if (metaLore != null && !metaLore.isEmpty()) {
-                    List<String> out = new ArrayList<>(metaLore.size());
-                    for (Component line : metaLore) {
-                        out.add(RecordingSupport.safeText(PLAIN.serialize(line)));
+        // hasItemMeta() short-circuits the common no-NBT item (cobblestone,
+        // plain tools): getItemMeta() allocates a fresh ItemMeta snapshot
+        // even when there's nothing to extract, so skip it entirely there
+        // (#98 micro-opt). Output is identical — a meta-less stack has no
+        // name/lore/enchants.
+        if (itemStack.hasItemMeta()) {
+            ItemMeta meta = itemStack.getItemMeta();
+            if (meta != null) {
+                if (meta.hasDisplayName()) {
+                    Component displayName = meta.displayName();
+                    if (displayName != null) {
+                        name = RecordingSupport.safeText(PLAIN.serialize(displayName));
                     }
-                    lore = out;
                 }
-            }
-            if (meta.hasEnchants()) {
-                enchants = enchantStrings(meta.getEnchants());
+                if (meta.hasLore()) {
+                    List<Component> metaLore = meta.lore();
+                    if (metaLore != null && !metaLore.isEmpty()) {
+                        List<String> out = new ArrayList<>(metaLore.size());
+                        for (Component line : metaLore) {
+                            out.add(RecordingSupport.safeText(PLAIN.serialize(line)));
+                        }
+                        lore = out;
+                    }
+                }
+                if (meta.hasEnchants()) {
+                    enchants = enchantStrings(meta.getEnchants());
+                }
             }
         }
         String data = includeData ? encode(itemStack) : null;

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
@@ -40,8 +40,11 @@ class ContainerTransactionListenerTest {
 
     private final CapturingRecorder recorder = new CapturingRecorder();
     private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    // Same-thread serializer so the deferred build (#98) runs inline and the
+    // (before, after) assertions below see the records immediately. A
+    // separate test exercises the actual deferral handoff.
     private final ContainerTransactionListener listener =
-            new ContainerTransactionListener(recorder, support);
+            new ContainerTransactionListener(recorder, support, Runnable::run);
 
     // Strong refs so Location's weak World reference can't be collected
     // mid-test (see ChatListenerTest.mockPlayer).
@@ -152,6 +155,30 @@ class ContainerTransactionListenerTest {
         assertThat(record.slot())
                 .as("slot 30 re-bases to local slot 3 in the right half")
                 .isEqualTo(3);
+    }
+
+    @Test
+    void serializationIsDeferredToTheExecutor() {
+        // #98: the heavy storedItem() build is handed to the serializer, not
+        // run on the listener (main) thread. With a queuing executor, no
+        // record exists until the deferred task runs.
+        List<Runnable> deferred = new java.util.ArrayList<>();
+        ContainerTransactionListener deferredListener =
+                new ContainerTransactionListener(recorder, support, deferred::add);
+        InventoryClickEvent event = clickEvent(InventoryAction.PLACE_ALL, 0, null, ironStack(64));
+
+        deferredListener.onInventoryClick(event);
+
+        assertThat(recorder.records).as("record must not be built on the listener thread").isEmpty();
+        assertThat(deferred).hasSize(1);
+
+        deferred.forEach(Runnable::run);
+
+        assertThat(recorder.records).hasSize(1);
+        ContainerDepositRecord record = (ContainerDepositRecord) recorder.records.get(0);
+        assertThat(record.amount()).isEqualTo(64);
+        assertThat(record.afterItem()).isNotNull();
+        assertThat(record.afterItem().material()).isEqualTo("IRON_INGOT");
     }
 
     // ── fixtures ─────────────────────────────────────────────────

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import net.medievalrp.spyglass.api.event.EventRecord;
@@ -83,6 +84,45 @@ class AsyncRecorderTest {
                     .isEqualTo(50);
         } finally {
             store.open();
+        }
+    }
+
+    @Test
+    void flushReturnsFalseWhenBarrierTimesOut() {
+        // #98: if the deferred-serialization stage can't drain in time, flush
+        // must NOT claim success — a rollback relying on it would otherwise
+        // read before the in-flight records landed (partial restore).
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            recorder.setFlushBarrier(timeout -> false);
+            assertThat(recorder.flush(Duration.parse("1s"))).isFalse();
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
+    void flushAwaitsBarrierThenDrainsQueue() {
+        // #98: flush drains the serialization barrier first, then the queue.
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            AtomicBoolean barrierCalled = new AtomicBoolean(false);
+            recorder.setFlushBarrier(timeout -> {
+                barrierCalled.set(true);
+                return true;
+            });
+            for (int index = 0; index < 10; index++) {
+                recorder.record(sampleRecord());
+            }
+            assertThat(recorder.flush(Duration.parse("3s"))).isTrue();
+            assertThat(barrierCalled)
+                    .as("flush must drain the serialization barrier before the queue")
+                    .isTrue();
+            assertThat(store.totalSaved()).isEqualTo(10);
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
         }
     }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializerTest.java
@@ -1,0 +1,91 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.util.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract for the off-thread serialization stage (#98). The flush
+ * coordination ({@link DeferredSerializer#awaitQuiescence}) is what lets a
+ * rollback drain in-flight rollbackable container serialization before it
+ * reads, so it gets the most attention here.
+ */
+class DeferredSerializerTest {
+
+    private final Logger logger = mock(Logger.class);
+
+    @Test
+    void runsSubmittedTaskAndReachesQuiescence() {
+        DeferredSerializer serializer = new DeferredSerializer(logger);
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        serializer.execute(() -> ran.set(true));
+
+        assertThat(serializer.awaitQuiescence(Duration.parse("5s"))).isTrue();
+        assertThat(ran).isTrue();
+        serializer.shutdown(Duration.parse("1s"));
+    }
+
+    @Test
+    void awaitQuiescenceBlocksUntilInFlightTaskCompletes() throws InterruptedException {
+        DeferredSerializer serializer = new DeferredSerializer(logger);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        serializer.execute(() -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // The task is parked, so quiescence can't be reached in a short window.
+        assertThat(serializer.awaitQuiescence(Duration.parse("1s")))
+                .as("must not report quiescent while a task is still in flight")
+                .isFalse();
+
+        release.countDown();
+        assertThat(serializer.awaitQuiescence(Duration.parse("5s"))).isTrue();
+        serializer.shutdown(Duration.parse("1s"));
+    }
+
+    @Test
+    void guardsTaskExceptionsAndStillReachesQuiescence() {
+        DeferredSerializer serializer = new DeferredSerializer(logger);
+
+        serializer.execute(() -> {
+            throw new RuntimeException("poison item");
+        });
+
+        // A throwing task must not leak the in-flight count (else flush hangs)
+        // and must be logged, not escape to stderr.
+        assertThat(serializer.awaitQuiescence(Duration.parse("5s"))).isTrue();
+        verify(logger, timeout(5_000)).warning(contains("poison item"));
+        serializer.shutdown(Duration.parse("1s"));
+    }
+
+    @Test
+    void executeAfterShutdownRunsInlineSoRecordsAreNotDropped() {
+        DeferredSerializer serializer = new DeferredSerializer(logger);
+        serializer.shutdown(Duration.parse("1s"));
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        serializer.execute(() -> ran.set(true));
+
+        assertThat(ran)
+                .as("a rollbackable record must not be dropped once the executor is down")
+                .isTrue();
+        assertThat(serializer.awaitQuiescence(Duration.parse("1s"))).isTrue();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
@@ -29,6 +29,7 @@ class ItemSerializationTest {
         when(stack.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
 
         ItemMeta meta = mock(ItemMeta.class);
+        when(stack.hasItemMeta()).thenReturn(true);
         when(stack.getItemMeta()).thenReturn(meta);
         when(meta.hasDisplayName()).thenReturn(true);
         when(meta.displayName()).thenReturn(Component.text("Excaliblur"));
@@ -82,6 +83,7 @@ class ItemSerializationTest {
         // never touch it. (If it did, the unstubbed mock returns null and
         // Base64 encode would NPE — a second guard beyond the verify below.)
         ItemMeta meta = mock(ItemMeta.class);
+        when(stack.hasItemMeta()).thenReturn(true);
         when(stack.getItemMeta()).thenReturn(meta);
         when(meta.hasDisplayName()).thenReturn(true);
         when(meta.displayName()).thenReturn(Component.text("Excaliblur"));
@@ -126,5 +128,25 @@ class ItemSerializationTest {
         assertThat(item.lore()).isEmpty();
         assertThat(item.enchants()).isEmpty();
         verify(stack, never()).serializeAsBytes();
+    }
+
+    @Test
+    void skipsGetItemMetaWhenStackHasNoMeta() {
+        // #98 micro-opt: getItemMeta() allocates a fresh meta snapshot even
+        // for a plain item, so it must be skipped when hasItemMeta() is
+        // false. Output is unchanged (no name/lore/enchants).
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.STONE);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{0});
+        when(stack.hasItemMeta()).thenReturn(false);
+
+        StoredItem item = ItemSerialization.storedItem(0, stack);
+
+        assertThat(item).isNotNull();
+        assertThat(item.material()).isEqualTo("STONE");
+        assertThat(item.name()).isNull();
+        assertThat(item.lore()).isEmpty();
+        assertThat(item.enchants()).isEmpty();
+        verify(stack, never()).getItemMeta();
     }
 }


### PR DESCRIPTION
Addresses #98. **Do not merge until live regression passes** (see checklist) — this touches the rollback flush contract.

## What

`ContainerTransactionListener` serialized deposit/withdraw items on the main thread. These records are **rollbackable**, so — unlike pickups (#97/#103) — deferral must preserve the read-your-writes flush contract: a rollback right after a deposit burst must not read before the in-flight records land.

**Infra**
- `DeferredSerializer` — an `Executor` that serializes on virtual threads, guards poison items (log + skip), and tracks in-flight tasks. `awaitQuiescence(timeout)` blocks until everything submitted before the call has handed its record to the recorder.
- `AsyncRecorder.setFlushBarrier(...)` — `flush()` now drains the barrier (the serialization stage) **before** snapshotting the queue high-water mark, then drains the queue. Default no-op, so other setups/tests are unaffected.
- `SpyglassPlugin` wires one `DeferredSerializer` for both the pickup and container listeners and sets it as the recorder's flush barrier.

**Listener** — every handler (click deposit/withdraw, shift-click move, hotbar swap, cursor swap) clones the pre-click stacks and mints the time-ordered id on the main thread, then hands `storedItem()` + `record()` to the serializer. Output is equivalent to the inline version.

**Micro-opt** — `ItemSerialization` skips `getItemMeta()` when `!hasItemMeta()` (avoids the meta-snapshot alloc for the common no-NBT item, on every caller — including the container-on-break capture loop).

## Durability tradeoff (deliberate, documented)

A hard JVM crash in the few-ms snapshot→enqueue window loses a deferred rollbackable record (that window is outside the no-drop/WAL guarantee). `flush()` still guarantees correctness for an **orderly** rollback. You chose this tradeoff when scoping the work.

## Scope — what's deferred to follow-ups

- **Container-on-break** (`BlockSnapshots.capture`): `capture()` is a shared synchronous utility called from 10+ break listeners and reads live state; deferring it cleanly is a separate, larger refactor (a `captureState`/`serialize` split + changing every rollbackable break listener). The micro-opt above partially mitigates its cost.
- **`ShulkerTransactionListener`**: parallel listener with the same pattern; gets the micro-opt for free but not the deferral.

## Verified (unit / build)

`./gradlew check` green with Docker up (store ITs ran, 0 skipped); jacoco floors hold.
- `DeferredSerializerTest` — quiescence blocks on in-flight work; guards exceptions; runs inline after shutdown.
- `AsyncRecorderTest` — flush awaits the barrier, then drains; flush returns false on barrier timeout.
- `ContainerTransactionListenerTest` — build is deferred to the executor; existing (before, after) pairs unchanged.
- `ItemSerializationTest` — `getItemMeta()` skipped when no meta.

## Live regression checklist (required before merge)

- [ ] `./gradlew regression` against a running `../RP_Server` — clean.
- [ ] Burst of deposits/withdraws immediately followed by `/sg rollback` → no partial restore (every transaction reflected).
- [ ] Double-chest + hotbar-swap + shift-click transactions still record correct (before, after) pairs.
- [ ] TPS holds during a chest-heavy interaction burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)