### PR TITLE
feat(worldedit): verify full WE/FAWE mutation-path coverage + log non-player edits (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Spyglass runs on MongoDB or ClickHouse, not MySQL or SQLite. If you already run 
 - A database, one of:
   - MongoDB at `mongodb://localhost:27017` (default)
   - ClickHouse (set `database.backend = "clickhouse"` in config)
-- Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for `//set` and `//paste` capture and `-we` queries
+- Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for WorldEdit-edit capture and `-we` queries. Capture hooks the edit-session pipeline, not command names, so every block-mutating operation is recorded — `//set`, `//replace`, `//walls`, `//overlay`, `//paste`, schematic paste, brushes, generation, `//move`/`//stack`, and `//undo`/`//redo` alike — for player and non-player (console/plugin) edits
 
 ## Commands
 

--- a/regression/bot/scenario-worldedit.js
+++ b/regression/bot/scenario-worldedit.js
@@ -1,0 +1,262 @@
+// #105 — WorldEdit/FAWE mutation-path audit.
+//
+// Spyglass hooks WorldEdit at the EditSession extent level (every setBlock),
+// NOT at the command name. The claim under test: *all* block-mutating
+// operations are logged, not just //set and //paste. This scenario drives a
+// representative spread of mutation paths as a real opped player and asserts
+// each one produced worldedit/fawe break|place records in the backend.
+//
+// Each op uses a DISTINCT target material in its own region so its records are
+// attributable by `target=...` regardless of drain ordering. Verification polls
+// the backend (the off-main build + batched insert lands a few seconds later).
+//
+// Usage:  node scenario-worldedit.js           (vanilla WE: LoggingExtent path)
+//         node scenario-worldedit.js --fawe     (FAWE installed: FaweBatchLogger path)
+// The --fawe flag only changes which origin_kind is asserted ('fawe' vs
+// 'worldedit'); the operations are identical.
+import mineflayer from 'mineflayer';
+import net from 'net';
+
+const HOST = '127.0.0.1', PORT = 25566, RCON_PORT = 25576, PASS = 'test123';
+const FAWE = process.argv.includes('--fawe');
+const ORIGIN = FAWE ? 'fawe' : 'worldedit';
+const BOT = 'we105_' + Math.floor(1000 + Math.random() * 8999);
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = (...a) => console.log('[' + new Date().toISOString().slice(11, 19) + ']', ...a);
+
+function pkt(i, t, b) { const u = Buffer.from(b); const l = 10 + u.length; const o = Buffer.alloc(4 + l); o.writeInt32LE(l, 0); o.writeInt32LE(i, 4); o.writeInt32LE(t, 8); u.copy(o, 12); return o; }
+function rcon(cmd) { return new Promise((res, rej) => { const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 60000 }); let st = 0, bs = []; s.on('error', rej); s.on('timeout', () => { s.destroy(); rej('t/o'); }); s.on('connect', () => s.write(pkt(1, 3, PASS))); s.on('data', c => { bs.push(c); const a = Buffer.concat(bs); if (a.length < 4) return; const l = a.readInt32LE(0); if (a.length < l + 4) return; if (st === 0) { st = 1; bs = []; s.write(pkt(1, 2, cmd)); } else { s.end(); res(a.slice(12, 12 + l - 10).toString().replace(/§./g, '')); } }); }); }
+function waitChat(bot, re, t) { return new Promise(r => { const h = m => { if (re.test(m)) { bot.removeListener('messagestr', h); r(m); } }; bot.on('messagestr', h); setTimeout(() => { bot.removeListener('messagestr', h); r(null); }, t); }); }
+async function ch(q) { return (await (await fetch(`http://localhost:8123/?query=${encodeURIComponent(q)}`)).text()).trim(); }
+
+// Count records this bot produced via WE/FAWE, optionally narrowed by extra SQL.
+async function cnt(extra = '') {
+  const q = `SELECT count() FROM spyglass.event_records WHERE origin_kind='${ORIGIN}' AND source_player_name='${BOT}'${extra ? ' AND ' + extra : ''}`;
+  return parseInt(await ch(q)) || 0;
+}
+// Poll until cnt(extra) >= min, or timeout. Returns the final count.
+async function pollCnt(extra, min, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  let c = 0;
+  while (Date.now() < deadline) { c = await cnt(extra); if (c >= min) return c; await sleep(1000); }
+  return c;
+}
+// Wait for this bot's total record count to stop growing — FAWE processes edits
+// async across chunk batches, so the next op must not start (and overlap the
+// same chunks) until the previous op's records have fully drained.
+async function settle(stableMs = 3000, timeoutMs = 25000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = -1, lastChange = Date.now();
+  while (Date.now() < deadline) {
+    const c = await cnt();
+    if (c !== last) { last = c; lastChange = Date.now(); }
+    else if (Date.now() - lastChange >= stableMs) return c;
+    await sleep(1000);
+  }
+  return last;
+}
+
+let pass = 0, fail = 0;
+const results = [];
+const check = (name, ok, detail) => { if (ok) { pass++; log(`  PASS  ${name}`); } else { fail++; log(`  FAIL  ${name} — ${detail}`); } results.push({ name, ok, detail }); };
+
+// One 5-wide lane per selection op; 5x5x5 region (125 cells).
+const BX = 17000, BY = 72, BZ = 17000, SZ = 5;
+let laneN = 0;
+function lane() { const x0 = BX + (laneN++) * 12; return { x0, y0: BY, z0: BZ, x1: x0 + SZ - 1, y1: BY + SZ - 1, z1: BZ + SZ - 1 }; }
+
+let bot = null;
+async function select(L) {
+  bot.chat('//sel cuboid'); await sleep(200);
+  bot.chat(`//pos1 ${L.x0},${L.y0},${L.z0}`); await sleep(200);
+  bot.chat(`//pos2 ${L.x1},${L.y1},${L.z1}`); await sleep(200);
+}
+const DONE_RE = /have been changed|operation completed|blocks? affected|pasted|stacked|moved|Created/i;
+
+(async () => {
+  log(`=== #105 WorldEdit mutation-path audit (origin=${ORIGIN}, bot=${BOT}) ===`);
+  const fx0 = BX - 16, fz0 = BZ - 16, fx1 = BX + 220, fz1 = BZ + 16;
+  await rcon(`forceload add ${fx0} ${fz0} ${fx1} ${fz1}`); await sleep(800);
+
+  bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.4' });
+  await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+  await rcon(`op ${BOT}`); await rcon(`gamemode creative ${BOT}`);
+  await rcon(`tp ${BOT} ${BX} ${BY + 1} ${BZ}`); await sleep(2500);
+  try { await bot.waitForChunksToLoad(); } catch { }
+  await sleep(1500);
+  bot.chat('//limit -1'); await sleep(300); // lift the per-op block cap for opped bot
+
+  // ---- run one selection-based op and verify its records ----
+  async function selOp(label, baseMat, opCmd, verify) {
+    const L = lane();
+    log(`--- ${label} ---`);
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} ${baseMat || 'air'}`); await sleep(300);
+    await select(L);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat(opCmd); await done;
+    await settle();
+    await verify(L);
+    return L;
+  }
+
+  // 1. //set — baseline (already proven in _worldedit-offmain-proof; included for completeness)
+  await selOp('set', 'stone', '//set glass', async () => {
+    const places = await pollCnt(`event='place' AND target='GLASS'`, 1);
+    const breaks = await pollCnt(`event='break' AND target='STONE'`, 1);
+    check(`//set logs place GLASS (${places})`, places >= 1, `got ${places}`);
+    check(`//set logs break STONE (${breaks})`, breaks >= 1, `got ${breaks}`);
+  });
+
+  // 2. //replace
+  await selOp('replace', 'stone', '//replace stone sandstone', async () => {
+    const places = await pollCnt(`event='place' AND target='SANDSTONE'`, 1);
+    check(`//replace logs place SANDSTONE (${places})`, places >= 1, `got ${places}`);
+  });
+
+  // 3. //walls
+  await selOp('walls', null, '//walls bricks', async () => {
+    const places = await pollCnt(`event='place' AND target='BRICKS'`, 1);
+    check(`//walls logs place BRICKS (${places})`, places >= 1, `got ${places}`);
+  });
+
+  // 4. //overlay — places the pattern above the highest block in each column.
+  // Run it HIGH (y=140) over a clean floor: overlay keys off the highest block
+  // in the *full* world column, so near terrain it can no-op (see #105 notes).
+  // High altitude removes that ambiguity, so it reliably places 25.
+  {
+    const L = lane(); const oy = 140; log('--- overlay ---');
+    await rcon(`fill ${L.x0} ${oy - 2} ${L.z0} ${L.x1} ${oy + 6} ${L.z1} air`); await sleep(300);   // clean column
+    await rcon(`fill ${L.x0} ${oy} ${L.z0} ${L.x1} ${oy} ${L.z1} stone`); await sleep(300);          // floor
+    bot.chat('//sel cuboid'); await sleep(200);
+    bot.chat(`//pos1 ${L.x0},${oy},${L.z0}`); await sleep(200);
+    bot.chat(`//pos2 ${L.x1},${oy + 4},${L.z1}`); await sleep(200);
+    const done = waitChat(bot, /overlaid/i, 30000); bot.chat('//overlay red_wool'); await done; await sleep(500);
+    const places = await pollCnt(`event='place' AND target='RED_WOOL'`, 1);
+    check(`//overlay logs place RED_WOOL (${places})`, places >= 1, `got ${places}`);
+  }
+
+  // 5. //stack — copy the region one step east into a cleared dest (so the copy
+  // is a real change; FAWE skips no-op overwrites, vanilla doesn't).
+  {
+    const L = lane(); log('--- stack ---');
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} emerald_block`); await sleep(250);
+    await rcon(`fill ${L.x1 + 1} ${L.y0} ${L.z0} ${L.x1 + SZ} ${L.y1} ${L.z1} air`); await sleep(250);
+    await select(L);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat('//stack 1 east'); await done; await settle();
+    const places = await pollCnt(`event='place' AND target='EMERALD_BLOCK'`, 1);
+    check(`//stack logs place EMERALD_BLOCK (${places})`, places >= 1, `got ${places}`);
+  }
+
+  // 6. //move — break source, place into a cleared dest
+  {
+    const L = lane(); log('--- move ---');
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} lapis_block`); await sleep(250);
+    await rcon(`fill ${L.x0 + 6} ${L.y0} ${L.z0} ${L.x0 + 6 + SZ - 1} ${L.y1} ${L.z1} air`); await sleep(250);
+    await select(L);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat('//move 6 east'); await done; await settle();
+    const breaks = await pollCnt(`event='break' AND target='LAPIS_BLOCK'`, 1);
+    const places = await pollCnt(`event='place' AND target='LAPIS_BLOCK'`, 1);
+    check(`//move logs break+place LAPIS_BLOCK (b=${breaks} p=${places})`, breaks >= 1 && places >= 1, `b=${breaks} p=${places}`);
+  }
+
+  // 7. //copy + //paste — copy, clear the region, paste it back (a real change,
+  // not a no-op overwrite that FAWE dedups). -o pastes at the original position.
+  {
+    const L = lane(); log('--- copy/paste ---');
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} gold_block`); await sleep(300);
+    await select(L);
+    bot.chat('//copy'); await sleep(900);
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} air`); await sleep(400);
+    const before = await cnt(`event='place' AND target='GOLD_BLOCK'`);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat('//paste -o'); await done; await settle();
+    const after = await pollCnt(`event='place' AND target='GOLD_BLOCK'`, before + 1);
+    check(`//paste logs place GOLD_BLOCK (Δ=${after - before})`, after > before, `before=${before} after=${after}`);
+  }
+
+  // 8. //schem save/load/paste — clear the region before pasting the loaded schem
+  {
+    const L = lane(); log('--- schematic paste ---');
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} diamond_block`); await sleep(300);
+    await select(L);
+    bot.chat('//copy'); await sleep(900);
+    bot.chat('//schem save sg105test'); await sleep(1200);
+    bot.chat('//schem load sg105test'); await sleep(1200);
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} air`); await sleep(400);
+    const before = await cnt(`event='place' AND target='DIAMOND_BLOCK'`);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat('//paste -o'); await done; await settle();
+    const after = await pollCnt(`event='place' AND target='DIAMOND_BLOCK'`, before + 1);
+    check(`schematic //paste logs place DIAMOND_BLOCK (Δ=${after - before})`, after > before, `before=${before} after=${after}`);
+    bot.chat('//schem delete sg105test'); await sleep(400);
+  }
+
+  // 9. //undo — the inverse edit must itself be logged (a fresh EditSession)
+  {
+    const L = lane(); log('--- undo ---');
+    await rcon(`fill ${L.x0} ${L.y0} ${L.z0} ${L.x1} ${L.y1} ${L.z1} stone`); await sleep(300);
+    await select(L);
+    let done = waitChat(bot, DONE_RE, 30000); bot.chat('//set obsidian'); await done; await sleep(800);
+    await pollCnt(`event='place' AND target='OBSIDIAN'`, 1);
+    const before = await cnt();
+    done = waitChat(bot, /Undid|undone/i, 30000); bot.chat('//undo'); await done; await sleep(800);
+    // undo restores stone over the obsidian: a fresh edit that breaks OBSIDIAN + places STONE
+    const total = await pollCnt('', before + 1);
+    const undoBreaksObsidian = await pollCnt(`event='break' AND target='OBSIDIAN'`, 1, 8000);
+    check(`//undo is itself logged (total Δ=${total - before})`, total > before, `before=${before} total=${total}`);
+    check(`//undo logs break OBSIDIAN (${undoBreaksObsidian})`, undoBreaksObsidian >= 1, `got ${undoBreaksObsidian}`);
+  }
+
+  // 10. //redo — re-applying the edit must be logged too
+  {
+    log('--- redo ---');
+    const before = await cnt();
+    const done = waitChat(bot, /Redid|redone/i, 30000); bot.chat('//redo'); await done; await sleep(800);
+    const total = await pollCnt('', before + 1);
+    check(`//redo is itself logged (total Δ=${total - before})`, total > before, `before=${before} total=${total}`);
+  }
+
+  // 11. generation (player-centered) — sphere/cyl/pyramid on a platform
+  let genIdx = 0;
+  async function genOp(label, cmd, target) {
+    log(`--- ${label} (generation) ---`);
+    const cx = BX + 120 + (genIdx++) * 14, cz = BZ; // within the forceloaded box
+    await rcon(`fill ${cx - 4} ${BY - 1} ${cz - 4} ${cx + 4} ${BY - 1} ${cz + 4} stone`); await sleep(300); // platform
+    await rcon(`tp ${BOT} ${cx} ${BY} ${cz}`); await sleep(1500);
+    const done = waitChat(bot, DONE_RE, 30000); bot.chat(cmd); await done; await sleep(500);
+    const places = await pollCnt(`event='place' AND target='${target}'`, 1);
+    check(`${label} logs place ${target} (${places})`, places >= 1, `got ${places}`);
+  }
+  await genOp('//sphere', '//sphere mossy_cobblestone 3', 'MOSSY_COBBLESTONE');
+  await genOp('//cyl', '//cyl nether_bricks 3 2', 'NETHER_BRICKS');
+  await genOp('//pyramid', '//pyramid quartz_block 3', 'QUARTZ_BLOCK');
+
+  // 12. brush / tool edit (best-effort: confirm the brush fires in-world before judging logging)
+  try {
+    log('--- brush (sphere) ---');
+    const cx = BX + 200, cz = BZ;
+    await rcon(`fill ${cx - 5} ${BY - 1} ${cz - 5} ${cx + 5} ${BY + 8} ${cz + 5} air`); await sleep(200);
+    await rcon(`tp ${BOT} ${cx} ${BY + 6} ${cz}`); await sleep(1500);
+    await rcon(`give ${BOT} minecraft:stick`); await sleep(600);
+    bot.setQuickBarSlot(0); await sleep(300);
+    bot.chat('//brush sphere prismarine 2'); await sleep(600); // bind brush to held stick
+    await bot.look(0, -Math.PI / 2, true); await sleep(600);     // look straight down
+    for (let i = 0; i < 3; i++) { bot.activateItem(); await sleep(700); if (bot.deactivateItem) bot.deactivateItem(); await sleep(300); }
+    const probe = await rcon(`execute if block ${cx} ${BY} ${cz} prismarine run say BRUSH_HIT_${BOT}`);
+    const fired = /BRUSH_HIT/.test(probe);
+    const places = await pollCnt(`event='place' AND target='PRISMARINE'`, 1, 12000);
+    if (!fired && places === 0) {
+      log(`  SKIP  brush — could not confirm the brush fired in-world (bot aim/range); inconclusive, not a logging verdict`);
+      results.push({ name: 'brush', ok: true, detail: 'skipped/inconclusive', skipped: true });
+    } else {
+      check(`brush logs place PRISMARINE (fired=${fired}, places=${places})`, places >= 1, `fired=${fired} places=${places}`);
+    }
+  } catch (e) { log('  SKIP  brush — harness error: ' + (e?.message || e)); results.push({ name: 'brush', ok: true, detail: 'skipped/error', skipped: true }); }
+
+  // ---- cleanup ----
+  log('cleanup…');
+  bot.quit();
+  await rcon(`forceload remove ${fx0} ${fz0} ${fx1} ${fz1}`);
+
+  log(`\n=== RESULT (origin=${ORIGIN}): ${pass} passed, ${fail} failed ===`);
+  for (const r of results) log(`   ${r.skipped ? 'SKIP' : r.ok ? 'PASS' : 'FAIL'}  ${r.name}${r.ok ? '' : '  — ' + r.detail}`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e?.message || e); process.exit(2); });

--- a/spyglass/build.gradle.kts
+++ b/spyglass/build.gradle.kts
@@ -68,11 +68,12 @@ dependencies {
     testImplementation(project(":spyglass-api"))
     testImplementation("io.papermc.paper:paper-api:$paperApiVersion")
     // WorldEdit is compileOnly for the production jar (server provides
-    // it), but RollbackEngineChaosTest exercises the FAWE-availability
-    // branch via mockStatic, which requires the WE classes to be
-    // verifiable at test runtime. Pull the same coordinates onto the
-    // test runtime classpath only.
-    testRuntimeOnly("com.sk89q.worldedit:worldedit-core:$worldeditVersion")
+    // it). worldedit-core is on the test *compile* classpath so
+    // WorldEditActorsTest can mock the WE Actor; worldedit-bukkit stays
+    // runtime-only for RollbackEngineChaosTest's FAWE-availability branch
+    // (exercised via mockStatic, which only needs the classes verifiable
+    // at test runtime).
+    testImplementation("com.sk89q.worldedit:worldedit-core:$worldeditVersion")
     testRuntimeOnly("com.sk89q.worldedit:worldedit-bukkit:$worldeditVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("org.assertj:assertj-core:$assertjVersion")

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/FaweBatchLogger.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/FaweBatchLogger.java
@@ -39,18 +39,16 @@ final class FaweBatchLogger implements IBatchProcessor {
 
     private final Recorder recorder;
     private final RecordingSupport support;
-    private final UUID playerId;
-    private final String playerName;
+    private final Source source;
     private final UUID worldId;
     private final String worldName;
 
     FaweBatchLogger(Recorder recorder, RecordingSupport support,
-                    UUID playerId, String playerName,
+                    Source source,
                     UUID worldId, String worldName) {
         this.recorder = recorder;
         this.support = support;
-        this.playerId = playerId;
-        this.playerName = playerName;
+        this.source = source;
         this.worldId = worldId;
         this.worldName = worldName;
     }
@@ -67,7 +65,7 @@ final class FaweBatchLogger implements IBatchProcessor {
         Instant occurred = support.now();
         Instant expires = support.expiresAt(occurred);
         Origin origin = Origin.fawe();
-        Source source = Source.player(playerId, playerName);
+        Source source = this.source;
 
         for (int sy = minSection; sy <= maxSection; sy++) {
             if (!set.hasSection(sy)) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/FaweHook.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/FaweHook.java
@@ -4,11 +4,10 @@ import com.fastasyncworldedit.core.extent.processor.ExtentBatchProcessorHolder;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extent.AbstractDelegateExtent;
 import com.sk89q.worldedit.extent.Extent;
-import java.util.UUID;
+import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -20,7 +19,7 @@ final class FaweHook {
     }
 
     static boolean tryInstall(Recorder recorder, RecordingSupport support,
-                              EditSessionEvent event, Player player, World world) {
+                              EditSessionEvent event, Source source, World world) {
         Extent extent = event.getExtent();
         if (extent == null) {
             return false;
@@ -29,12 +28,8 @@ final class FaweHook {
         if (holder == null) {
             return false;
         }
-        UUID worldId = world.getUID();
-        String worldName = world.getName();
         FaweBatchLogger logger = new FaweBatchLogger(
-                recorder, support,
-                player.getUniqueId(), player.getName(),
-                worldId, worldName);
+                recorder, support, source, world.getUID(), world.getName());
         try {
             holder.addProcessor(logger);
             return true;

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditActors.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditActors.java
@@ -1,0 +1,42 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import com.sk89q.worldedit.extension.platform.Actor;
+import net.medievalrp.spyglass.api.event.Source;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Maps a WorldEdit {@link Actor} to the Spyglass {@link Source} its edits should
+ * be attributed to.
+ *
+ * <p>A player actor carries the player's identity ({@link Source#player}). Every
+ * non-player actor — the console, an RCON sender, a command block, or a plugin
+ * driving WorldEdit through its API with no live player — is attributed to
+ * {@link Source#console()} so the edit is still audited and rollbackable. This
+ * mirrors how the rest of Spyglass records non-player block changes (it already
+ * tags command-block, console, entity, and environment sources) rather than
+ * dropping them.
+ *
+ * <p>Before #105 the WorldEdit hook recorded player edits only: a console or
+ * plugin {@code //set} changed blocks that never appeared in the audit log and
+ * could not be rolled back. Pulled out as its own class so the mapping is unit
+ * testable without a live WorldEdit platform.
+ */
+@ApiStatus.Internal
+final class WorldEditActors {
+
+    private WorldEditActors() {
+    }
+
+    /**
+     * @param actor the WorldEdit actor behind an edit session, or {@code null}
+     *              for an API edit with no actor
+     * @return {@link Source#player} for a live player, else {@link Source#console()}
+     */
+    static Source resolveSource(@Nullable Actor actor) {
+        if (actor != null && actor.isPlayer()) {
+            return Source.player(actor.getUniqueId(), actor.getName());
+        }
+        return Source.console();
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
@@ -36,11 +36,21 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.IllegalPluginAccessException;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Subscribes to WorldEdit's EditSessionEvent and wraps the extent chain with a
  * logger. Every setBlock on the wrapped extent yields a break + place record
- * tagged with Origin.worldEdit().
+ * tagged with Origin.worldEdit(). Because the hook is at the edit-session /
+ * setBlock level rather than on command names, every block-mutating operation
+ * is captured the same way — set, replace, walls, overlay, paste, schematic
+ * paste, brushes, generation, move/stack and undo/redo (each a fresh edit
+ * session) alike.
+ *
+ * <p><b>Actor attribution.</b> Edits are tagged with the source resolved by
+ * {@link WorldEditActors#resolveSource} — the player when one is driving the
+ * edit, otherwise the console (covering RCON, command blocks and plugin-API
+ * edits). Non-player edits are logged too so they stay audited and rollbackable.
  *
  * <p><b>Off-main design.</b> Vanilla WorldEdit runs the whole edit on the main
  * thread, so the one thing we cannot move is reading the <em>before</em> block —
@@ -94,28 +104,29 @@ public final class WorldEditSubscriber {
         if (event.getStage() != EditSession.Stage.BEFORE_CHANGE) {
             return;
         }
-        Actor actor = event.getActor();
-        if (actor == null || !actor.isPlayer()) {
-            return;
-        }
-        Player bukkitPlayer = Bukkit.getPlayer(actor.getUniqueId());
-        if (bukkitPlayer == null) {
-            return;
-        }
         World world = BukkitAdapter.adapt(event.getWorld());
         if (world == null) {
             return;
         }
+        // Attribute the edit to its actor — a player when one is driving it,
+        // otherwise the console (covers RCON, command blocks and plugin-API
+        // edits). Non-player edits used to be dropped here (#105).
+        Actor actor = event.getActor();
+        Source source = WorldEditActors.resolveSource(actor);
+        // The live Bukkit player, when there is one, drives the main-thread
+        // falling-block cascade; it stays null for non-player edits.
+        Player bukkitPlayer = (actor != null && actor.isPlayer())
+                ? Bukkit.getPlayer(actor.getUniqueId()) : null;
         if (isFawePresent()) {
             try {
-                if (FaweHook.tryInstall(recorder, support, event, bukkitPlayer, world)) {
+                if (FaweHook.tryInstall(recorder, support, event, source, world)) {
                     return;
                 }
             } catch (Throwable thrown) {
                 logger.warning("Spyglass: FAWE hook failed: " + thrown);
             }
         }
-        event.setExtent(new LoggingExtent(event.getExtent(), bukkitPlayer, world));
+        event.setExtent(new LoggingExtent(event.getExtent(), bukkitPlayer, source, world));
     }
 
     private boolean isFawePresent() {
@@ -138,10 +149,15 @@ public final class WorldEditSubscriber {
          *  waits for the whole op to finish before any record is built. */
         private static final int DRAIN_THRESHOLD = 50_000;
 
+        // Nullable: the live player driving the edit, present only for player
+        // edits. Drives the main-thread falling-block cascade, which is keyed to
+        // a player; non-player (console/plugin) edits log their direct block
+        // changes but skip the predictive gravity cascade.
+        @Nullable
         private final Player player;
+        // Attribution for every record this extent emits — player or console.
+        private final Source source;
         private final World world;
-        private final UUID playerId;
-        private final String playerName;
         private final UUID worldId;
         private final String worldName;
 
@@ -158,12 +174,11 @@ public final class WorldEditSubscriber {
         // commit() on this particular extent.
         private boolean drainScheduled = false;
 
-        LoggingExtent(Extent extent, Player player, World world) {
+        LoggingExtent(Extent extent, @Nullable Player player, Source source, World world) {
             super(extent);
             this.player = player;
+            this.source = source;
             this.world = world;
-            this.playerId = player.getUniqueId();
-            this.playerName = player.getName();
             this.worldId = world.getUID();
             this.worldName = world.getName();
         }
@@ -211,10 +226,12 @@ public final class WorldEditSubscriber {
 
             // Falling-block cascade stays on the main thread: it walks the live
             // column above a break-to-air, which is rare relative to the bulk
-            // per-block path and inherently a main-thread world read.
+            // per-block path and inherently a main-thread world read. It is
+            // keyed to a player (landing attribution), so it runs only for
+            // player edits; non-player edits still log the direct break below.
             boolean beforeAir = !beforeTile && weBefore.getBlockType().getMaterial().isAir();
             boolean afterAir = !afterTile && weAfter.getBlockType().getMaterial().isAir();
-            if (!beforeAir && afterAir) {
+            if (player != null && !beforeAir && afterAir) {
                 FallingBlockCascade.emitCascadeAbove(recorder, support, player, world,
                         x, y, z, cascadedAbove);
             }
@@ -273,7 +290,7 @@ public final class WorldEditSubscriber {
         private void build(List<Pending> batch) {
             try {
                 Origin origin = Origin.worldEdit();
-                Source source = Source.player(playerId, playerName);
+                Source source = this.source;
                 String serverName = support.serverName();
                 List<EventRecord> out = new ArrayList<>(batch.size() * 2);
                 for (Pending p : batch) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditActorsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditActorsTest.java
@@ -1,0 +1,49 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sk89q.worldedit.extension.platform.Actor;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.Source;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The WorldEdit actor -> Spyglass source mapping (#105). A player edit carries
+ * the player's identity; every non-player actor (console / RCON / command block
+ * / plugin API) is attributed to the console so the edit is still recorded.
+ */
+class WorldEditActorsTest {
+
+    @Test
+    void playerActorResolvesToPlayerSource() {
+        UUID id = UUID.randomUUID();
+        Actor actor = mock(Actor.class);
+        when(actor.isPlayer()).thenReturn(true);
+        when(actor.getUniqueId()).thenReturn(id);
+        when(actor.getName()).thenReturn("Builder");
+
+        Source source = WorldEditActors.resolveSource(actor);
+
+        assertThat(source.kind()).isEqualTo(Source.PLAYER);
+        assertThat(source.playerId()).isEqualTo(id);
+        assertThat(source.playerName()).isEqualTo("Builder");
+    }
+
+    @Test
+    void nonPlayerActorResolvesToConsoleSource() {
+        Actor actor = mock(Actor.class);
+        when(actor.isPlayer()).thenReturn(false);
+
+        Source source = WorldEditActors.resolveSource(actor);
+
+        assertThat(source).isEqualTo(Source.console());
+    }
+
+    @Test
+    void nullActorResolvesToConsoleSource() {
+        // An API edit with no actor still gets logged, attributed to console.
+        assertThat(WorldEditActors.resolveSource(null)).isEqualTo(Source.console());
+    }
+}


### PR DESCRIPTION
Closes #105.

## Audit result: all mutation paths are logged

Spyglass hooks WorldEdit at the **edit-session / setBlock level, not on command names**, so every block-mutating operation is captured the same way. Verified in-game as a real opped player against the live dev server (ClickHouse backend), driving each operation and asserting `origin=worldedit`/`origin=fawe` break/place records landed:

| Path | set | replace | walls | overlay | stack | move | copy/paste | schem paste | undo | redo | sphere | cyl | pyramid | brush |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| **Vanilla WE** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| **FAWE** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

So the "only `//set` and `//paste`" framing was a documentation artifact, not a real limitation. `//undo`/`//redo` are themselves logged (each is a fresh edit session that re-writes blocks). The new `regression/bot/scenario-worldedit.js` drives this matrix (16 checks) on either backend (`--fawe`), and the README requirement line is corrected.

## The one real gap: non-player actors (now fixed)

The hook dropped any edit whose actor was not a live player, so **console / RCON / command-block / plugin-API** WorldEdit edits changed blocks that never appeared in the audit log and could not be rolled back — even though the rest of Spyglass already records console/command-block/entity/environment sources.

Fix: resolve the WE `Actor` to a `Source` (`WorldEditActors.resolveSource` — player when present, else console) in **both** the vanilla `LoggingExtent` and the FAWE `FaweBatchLogger` paths. No new event type (a `Source` change on existing break/place records), so no codec/parity change. The player-keyed falling-block cascade stays player-only; non-player edits still log their direct block changes.

## Tests
- `WorldEditActorsTest` — actor→source mapping (player / non-player / null).
- `./gradlew check` green (all modules, jacoco floors).
- Live: vanilla matrix 16/16 and FAWE matrix 16/16 with this jar; vanilla shows no regression vs. before.

## Out of scope (follow-up)
FAWE's fast path over-logs (e.g. ~664 break records for a 125-cell `//set`) — pre-existing, unrelated to this change, filed separately.