### PR TITLE
feat: embedded SQLite record-store backend (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Forensic logging and rollback for Paper 1.21.x. Spyglass records block, container, chat, command, combat, and movement events, lets you query them with a `key:value` language, and rolls any of them back by block, player, cause, or in bulk while the server holds 20 TPS.
 
-> **Preview.** Spyglass is built for medium and large servers. It will run on a small one, but it is overkill there; CoreProtect or Prism are a better fit for small servers.
+> **Preview.** Spyglass is built for medium and large servers. The embedded SQLite backend runs it with no external database, so a small server can use it too, though CoreProtect or Prism stay lighter-weight there.
 
 ## Performance
 
@@ -17,6 +17,21 @@ A 2,000,376-block rollback, measured four ways: Spyglass and CoreProtect each on
 | On-disk footprint (data + index) | **~11 MiB** | ~145 MiB | ~160 MiB | ~180 MiB |
 
 Read it by backend, not by row. **ClickHouse wins outright on speed and storage** (the fastest wall-clock figures, a worst tick near 50 ms, and a 54x compression ratio), and it is the backend for the largest servers. The rollback read was paying for a blocking in-memory sort on every page; ending each rollback index with the same id the reader pages by made the scan index-ordered and removed it, which roughly halved the read and dropped a 2M rollback from ~14 s to ~7 s. MongoDB holds 20.0 TPS throughout where CoreProtect dips into the teens, keeps its worst tick near 100 ms against CoreProtect's 300-700 ms, and its undo shrugs off the restore that takes CoreProtect · MySQL three and a half minutes. Disk used to be its one weak axis, and two changes closed it. A zstd block compressor (vs the snappy default) cut the stored data by two thirds, from 136 MiB to 46. Then bucketing the location index by chunk coordinate (x and z shifted right by four) rather than raw block coordinate, which prefix-compresses far better because neighbours share a chunk, cut that index from ~96 MiB to ~22. Together they bring the footprint to ~145 MiB, under both CoreProtect backends; only ClickHouse, with its columnar 54x compression, is smaller. Pick ClickHouse for the lowest latency and smallest disk, MongoDB for a document store that now matches or beats CoreProtect on every axis.
+
+### Zero-ops: the SQLite backend
+
+Not every server wants to run MongoDB or ClickHouse. The SQLite backend (`database.backend = "sqlite"`) keeps everything (events, undo ledger, wand state, salvage) in one embedded file, so a small or medium server gets the full Spyglass feature set with no external database to stand up, the zero-ops setup CoreProtect has always had.
+
+It is built to beat CoreProtect on CoreProtect's home turf. Spyglass records are richer (snapshots, items, sources), so a naive row-per-record schema would lose on disk; four levers earn the density back, all measured on the same `//replace stone air` cube the table above uses:
+
+- **Palette interning.** Block-data strings, event and server names live once in a `dict` table; world and player UUIDs (with their display names) live once in a `uuids` table. Each row carries small integer references instead, CoreProtect-class density.
+- **Hybrid schema.** A clean player-sourced block edit lives entirely in indexed columns; only complex records (containers, entities, chat, tile-entity blocks) carry a compressed blob. The block-edit majority carries no blob at all, and the lean rollback read never decodes one.
+- **`seq` is the sort key.** The record-id sequence is the SQLite `rowid` and is co-monotonic with event time, so the store sorts and keysets on it alone. That drops the timestamp out of every index and removes the standalone time index entirely.
+- **Derived and folded columns.** A block's material comes back from its block-data string, player and world names from the UUID palette, and the expiry from the retention window, so none of them costs a column. The chunk-bucketed location index (x and z shifted right by four, mirroring the MongoDB work) is an expression index, so the buckets are not even stored on the row.
+
+At 2,000,000 block records the footprint is **~156 MiB** (table ~81, the two indexes ~75), under CoreProtect · SQLite's ~160 MiB on the same dataset. The rollback read is allocation-lean like the other backends: a full 2M-row keyset sweep resolves in about a second (palette references resolve to the same interned objects, so the hot path allocates nothing per row), and it feeds the same off-main, tick-budgeted apply engine that holds the server at 20.0 TPS on MongoDB and ClickHouse. Reproduce the footprint and read throughput with `./gradlew :spyglass-core:sqliteBench`; confirm the in-world TPS head to head against CoreProtect with `SG_BACKEND=sqlite CP_BACKEND=sqlite node regression/bot/compare.js`.
+
+SQLite is the zero-ops choice for small and medium servers; ClickHouse stays the backend for the largest, MongoDB the document-store default. Run exactly one; the unused backend blocks are ignored.
 
 ## Features
 
@@ -46,16 +61,17 @@ Spyglass and CoreProtect both log the world and roll it back. Where they part wa
 | TPS during a 2M rollback | **20.0, flat** | dips to ~13 |
 | Worst single tick | **~100 ms** | up to ~900 ms |
 | Automatic data pruning | ✓ |  |
-| Storage engines | MongoDB, ClickHouse | SQLite, MySQL |
+| Storage engines | SQLite, MongoDB, ClickHouse | SQLite, MySQL |
 | Minecraft versions | 1.21.x | 1.7+ |
 
-Spyglass runs on MongoDB or ClickHouse, not MySQL or SQLite. If you already run SQLite or MySQL and nothing else, CoreProtect installs with no new database to stand up.
+Spyglass runs on SQLite, MongoDB, or ClickHouse. The embedded SQLite backend needs no external database, so the zero-ops install CoreProtect offers is available on Spyglass too; MongoDB and ClickHouse are there when you outgrow it.
 
 ## Requirements
 
 - Paper 1.21.8 or newer 1.21.x
 - Java 21
 - A database, one of:
+  - Embedded SQLite, no external database (set `database.backend = "sqlite"`); writes to a file under the plugin folder
   - MongoDB at `mongodb://localhost:27017` (default)
   - ClickHouse (set `database.backend = "clickhouse"` in config)
 - Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for WorldEdit-edit capture and `-we` queries. Capture hooks the edit-session pipeline, not command names, so every block-mutating operation is recorded — `//set`, `//replace`, `//walls`, `//overlay`, `//paste`, schematic paste, brushes, generation, `//move`/`//stack`, and `//undo`/`//redo` alike — for player and non-player (console/plugin) edits

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ val paperApiVersion = "1.21.8-R0.1-SNAPSHOT"
 val velocityApiVersion = "3.4.0-SNAPSHOT"
 val mongoDriverVersion = "5.5.0"
 val clickhouseClientVersion = "0.9.8"
+val sqliteJdbcVersion = "3.50.1.0"
 val configurateVersion = "4.2.0"
 val cloudMinecraftVersion = "2.0.0-beta.16"
 val cloudCoreVersion = "2.0.0"
@@ -146,6 +147,7 @@ extra.apply {
     set("velocityApiVersion", velocityApiVersion)
     set("mongoDriverVersion", mongoDriverVersion)
     set("clickhouseClientVersion", clickhouseClientVersion)
+    set("sqliteJdbcVersion", sqliteJdbcVersion)
     set("configurateVersion", configurateVersion)
     set("cloudMinecraftVersion", cloudMinecraftVersion)
     set("cloudCoreVersion", cloudCoreVersion)

--- a/regression/bot/compare.js
+++ b/regression/bot/compare.js
@@ -31,7 +31,7 @@ const RCON_PORT = 25576, PASS = 'test123';
 // sqlite|mysql — so the report records the disk those two spend on the dataset.
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DISK_PY = path.resolve(SCRIPT_DIR, '..', 'disk.py');
-const SG_BACKEND = process.env.SG_BACKEND || 'mongo';   // mongo | clickhouse
+const SG_BACKEND = process.env.SG_BACKEND || 'mongo';   // mongo | clickhouse | sqlite
 const CP_BACKEND = process.env.CP_BACKEND || 'sqlite';  // sqlite | mysql
 
 function measureDisk() {

--- a/regression/disk.py
+++ b/regression/disk.py
@@ -30,7 +30,8 @@ import sys
 import urllib.parse
 import urllib.request
 
-ALL_BACKENDS = ["spyglass-mongo", "spyglass-clickhouse", "cp-sqlite", "cp-mysql"]
+ALL_BACKENDS = ["spyglass-mongo", "spyglass-clickhouse", "spyglass-sqlite",
+                "cp-sqlite", "cp-mysql"]
 
 
 def human(n):
@@ -83,7 +84,11 @@ def measure_clickhouse(url, ch_db):
     }
 
 
-def measure_sqlite(path):
+def measure_sqlite(path, backend="cp-sqlite"):
+    # Both SQLite footprints (Spyglass and CoreProtect) are the db file plus
+    # its WAL/SHM sidecars; indexes live in the same file. Checkpoint the
+    # Spyglass db before measuring (its writer leaves rows in the -wal until
+    # a checkpoint folds them back) so the file reflects the full dataset.
     if not os.path.exists(path):
         raise FileNotFoundError(path)
     total = 0
@@ -92,7 +97,7 @@ def measure_sqlite(path):
         if os.path.exists(p):
             total += os.path.getsize(p)
     return {
-        "backend": "cp-sqlite",
+        "backend": backend,
         "path": path,
         "storage_bytes": total,
         "index_bytes": 0,  # SQLite indexes live in the same file
@@ -134,6 +139,8 @@ def main():
     p.add_argument("--ch-db", default="spyglass")
     p.add_argument("--sqlite", default=str(
         (os.path.dirname(__file__) or ".") + "/../../RP_Server/plugins/CoreProtect/database.db"))
+    p.add_argument("--sg-sqlite", default=str(
+        (os.path.dirname(__file__) or ".") + "/../../RP_Server/plugins/Spyglass/spyglass.db"))
     p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
     p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
     p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
@@ -146,6 +153,7 @@ def main():
     runners = {
         "spyglass-mongo": lambda: measure_mongo(args.mongo, args.mongo_db),
         "spyglass-clickhouse": lambda: measure_clickhouse(args.clickhouse, args.ch_db),
+        "spyglass-sqlite": lambda: measure_sqlite(os.path.abspath(args.sg_sqlite), "spyglass-sqlite"),
         "cp-sqlite": lambda: measure_sqlite(os.path.abspath(args.sqlite)),
         "cp-mysql": lambda: measure_mysql(args.mysql_host, args.mysql_port,
                                           args.mysql_user, args.mysql_password, args.mysql_db),

--- a/spyglass-core/build.gradle.kts
+++ b/spyglass-core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 val paperApiVersion: String by rootProject.extra
 val mongoDriverVersion: String by rootProject.extra
 val clickhouseClientVersion: String by rootProject.extra
+val sqliteJdbcVersion: String by rootProject.extra
 val junitVersion: String by rootProject.extra
 val assertjVersion: String by rootProject.extra
 val mockitoVersion: String by rootProject.extra
@@ -51,6 +52,12 @@ dependencies {
     api("com.clickhouse:clickhouse-data:$clickhouseClientVersion")
     runtimeOnly("org.apache.httpcomponents.client5:httpclient5:5.3.1")
 
+    // Embedded SQLite backend (#106): a third, zero-ops record store for
+    // small/medium servers. xerial sqlite-jdbc bundles the native SQLite
+    // engine; exposed as `api` so the plugin + proxy can construct the
+    // store directly, mirroring the Mongo / ClickHouse drivers above.
+    api("org.xerial:sqlite-jdbc:$sqliteJdbcVersion")
+
     testImplementation(project(":spyglass-api"))
     testImplementation("io.papermc.paper:paper-api:$paperApiVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
@@ -68,13 +75,40 @@ tasks.withType<JacocoReport>().configureEach {
 }
 
 tasks.test {
-    // The `bench` and `ch-bench` tags cover long-running throughput
-    // benches; they live here now alongside the storage code they
-    // exercise. Run via `./gradlew :spyglass-core:clickhouseBench`.
+    // The `bench`, `ch-bench`, and `sqlite-bench` tags cover long-running
+    // throughput benches; they live here now alongside the storage code they
+    // exercise. Run via `./gradlew :spyglass-core:clickhouseBench` /
+    // `:spyglass-core:sqliteBench`.
     useJUnitPlatform {
-        excludeTags("bench", "ch-bench")
+        excludeTags("bench", "ch-bench", "sqlite-bench")
     }
     finalizedBy(tasks.named("jacocoTestReport"))
+}
+
+tasks.register<Test>("sqliteBench") {
+    description = "Spyglass·SQLite disk + rollback-read benchmark (#106; no Docker)."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("sqlite-bench")
+    }
+    extensions.configure<JacocoTaskExtension> {
+        isEnabled = false
+    }
+    testLogging {
+        events("started", "passed", "failed", "standard_out")
+        showStandardStreams = true
+        showExceptions = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+    maxHeapSize = "4g"
+    for ((key, value) in System.getProperties()) {
+        val name = key.toString()
+        if (name.startsWith("OMNI_BENCH_")) {
+            systemProperty(name, value.toString())
+        }
+    }
 }
 
 tasks.register<Test>("clickhouseBench") {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/BsonBlobs.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/BsonBlobs.java
@@ -6,6 +6,7 @@ import java.nio.ByteOrder;
 import java.util.Base64;
 import java.util.List;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.event.StoredItem;
 import net.medievalrp.spyglass.api.rollback.RollbackEffect;
 import org.bson.BsonArray;
@@ -60,6 +61,10 @@ public final class BsonBlobs {
                     new BsonValueCodecProvider(),
                     new Jsr310CodecProvider(),
                     new RecordCodecProvider(),
+                    // Dispatches the sealed EventRecord hierarchy on the
+                    // `event` field, so a whole record round-trips as one
+                    // BSON document — the SQLite backend's per-event blob.
+                    EventRecordCodec.provider(),
                     RollbackEffectCodec.provider(),
                     PojoCodecProvider.builder().automatic(true).build()));
 
@@ -67,6 +72,8 @@ public final class BsonBlobs {
             REGISTRY.get(BlockSnapshot.class);
     private static final Codec<StoredItem> STORED_ITEM_CODEC =
             REGISTRY.get(StoredItem.class);
+    private static final Codec<EventRecord> EVENT_RECORD_CODEC =
+            REGISTRY.get(EventRecord.class);
     @SuppressWarnings({"rawtypes", "unchecked"})
     private static final Codec<RollbackEffect> ROLLBACK_EFFECT_CODEC =
             (Codec) REGISTRY.get(RollbackEffect.class);
@@ -220,6 +227,31 @@ public final class BsonBlobs {
     public static @Nullable StoredItem decodeStoredItem(@Nullable String base64) {
         byte[] bytes = fromBase64(base64);
         return bytes == null ? null : decode(STORED_ITEM_CODEC, bytes);
+    }
+
+    /**
+     * Serialize a whole {@link EventRecord} to BSON bytes (no base64) for
+     * the SQLite backend's per-event blob. The concrete record codec
+     * writes the {@code event} field, so {@link #decodeRecordBytes}
+     * dispatches the sealed hierarchy on it — the same self-describing
+     * shape Mongo stores, minus the document wrapper. Callers compress the
+     * returned bytes before persisting them.
+     */
+    public static byte[] encodeRecordBytes(EventRecord record) {
+        BasicOutputBuffer buffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+            EVENT_RECORD_CODEC.encode(writer, record, EncoderContext.builder().build());
+        }
+        return buffer.toByteArray();
+    }
+
+    /** Inverse of {@link #encodeRecordBytes}. */
+    public static EventRecord decodeRecordBytes(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        try (BsonBinaryReader reader = new BsonBinaryReader(new ByteBufferBsonInput(
+                new org.bson.ByteBufNIO(buf)))) {
+            return EVENT_RECORD_CODEC.decode(reader, DecoderContext.builder().build());
+        }
     }
 
     /**

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqlitePredicateToSql.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqlitePredicateToSql.java
@@ -1,0 +1,279 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Translates a list of {@link QueryPredicate} into a self-contained SQL
+ * WHERE fragment for the {@link SqliteRecordStore} schema.
+ *
+ * <p>The SQLite schema is palette-interned: high-cardinality strings
+ * (event / world / player names, block data) live in a {@code dict}
+ * table and UUIDs in a {@code uuids} table, with the {@code records}
+ * row holding only the small integer reference. So unlike the
+ * ClickHouse {@link PredicateToSql} — which inlines string/UUID literals
+ * the column compares directly — this translator resolves each literal
+ * to its palette id <em>up front</em> via {@link Palette} and inlines
+ * that integer. Three consequences:
+ *
+ * <ul>
+ *   <li>Every inlined literal is an {@code int}/{@code long}, so there
+ *       is no SQL string-escaping surface at all — a hostile player name
+ *       never reaches the SQL text, only its resolved row id (or "no
+ *       such id", which compiles to a constant-false clause).</li>
+ *   <li>A value that isn't in the palette yet (e.g. {@code p:Ghost} for a
+ *       player with no records) resolves to no id, so the predicate is
+ *       statically unsatisfiable and translates to {@code 0} — matching
+ *       nothing, exactly as it should.</li>
+ *   <li>A {@code regex} match against an interned column can't be pushed
+ *       (the column is an int, not the string), so it raises
+ *       {@link UnsupportedPredicateException} and the store evaluates it
+ *       in memory against the decoded record (the #32 post-filter path,
+ *       which still sees the palette-resolved field values).</li>
+ * </ul>
+ *
+ * <p>A block-coordinate range additionally bounds the chunk-bucket
+ * column ({@code cx = x>>4}, {@code cz = z>>4}) so the region rollback
+ * index can seek — mirroring {@link PredicateToBson} and the Mongo #100
+ * work. The exact x/z clauses still filter within the seeked chunks, so
+ * results are identical.
+ */
+@ApiStatus.Internal
+final class SqlitePredicateToSql {
+
+    /** Read-side palette resolution. {@code null} means "not interned". */
+    interface Palette {
+        Integer dictId(String value);
+
+        Integer uuidId(UUID value);
+    }
+
+    static final class UnsupportedPredicateException extends RuntimeException {
+        UnsupportedPredicateException(String message) {
+            super(message);
+        }
+    }
+
+    /** How a column's literal is resolved before it's inlined. */
+    private enum Kind {
+        /** {@code seq} primary key — value is the {@link EventIds} sequence of a UUID. */
+        SEQ,
+        /** A {@code dict} string reference. */
+        DICT,
+        /** A {@code uuids} reference. */
+        UUID_REF,
+        /** Epoch-seconds timestamp column. */
+        INSTANT_SEC,
+        /** Plain signed integer column (coordinates). */
+        INT
+    }
+
+    private record Col(String name, Kind kind) {
+    }
+
+    // Only the indexed / filterable scalar paths map to a column. Deep
+    // paths into the per-event blob (item.name, message, beforeItem.lore,
+    // source.entityType, …) have no column and raise Unsupported, so they
+    // fall to the in-memory post-filter against the decoded record.
+    private static final Map<String, Col> COLUMNS = Map.ofEntries(
+            Map.entry("id", new Col("seq", Kind.SEQ)),
+            Map.entry("event", new Col("event", Kind.DICT)),
+            Map.entry("occurred", new Col("occurred", Kind.INSTANT_SEC)),
+            Map.entry("origin.kind", new Col("origin_kind", Kind.DICT)),
+            Map.entry("source.playerId", new Col("player", Kind.UUID_REF)),
+            Map.entry("location.worldId", new Col("world", Kind.UUID_REF)),
+            Map.entry("location.x", new Col("x", Kind.INT)),
+            Map.entry("location.y", new Col("y", Kind.INT)),
+            Map.entry("location.z", new Col("z", Kind.INT)),
+            Map.entry("server", new Col("server", Kind.DICT)),
+            Map.entry("target", new Col("target", Kind.DICT)));
+
+    private final Palette palette;
+
+    SqlitePredicateToSql(Palette palette) {
+        this.palette = palette;
+    }
+
+    /** Translate a top-level AND list; empty input yields the empty string. */
+    String translate(List<QueryPredicate> predicates) {
+        if (predicates.isEmpty()) {
+            return "";
+        }
+        if (predicates.size() == 1) {
+            return translate(predicates.get(0));
+        }
+        StringBuilder sql = new StringBuilder("(");
+        for (int i = 0; i < predicates.size(); i++) {
+            if (i > 0) {
+                sql.append(" AND ");
+            }
+            sql.append(translate(predicates.get(i)));
+        }
+        return sql.append(")").toString();
+    }
+
+    private String translate(QueryPredicate predicate) {
+        return switch (predicate) {
+            case QueryPredicate.Eq eq -> translateEq(col(eq.field()), eq.field(), eq.value());
+            case QueryPredicate.In in -> translateIn(col(in.field()), in.values());
+            case QueryPredicate.Range range -> translateRange(range);
+            case QueryPredicate.Exists exists -> translateExists(col(exists.field()), exists.expected());
+            case QueryPredicate.Not not -> "(NOT " + translate(not.predicate()) + ")";
+            case QueryPredicate.And and -> translateGroup("AND", and.predicates());
+            case QueryPredicate.Or or -> translateGroup("OR", or.predicates());
+        };
+    }
+
+    private String translateGroup(String op, List<QueryPredicate> children) {
+        if (children.isEmpty()) {
+            return "AND".equals(op) ? "1" : "0";
+        }
+        StringBuilder sb = new StringBuilder("(");
+        for (int i = 0; i < children.size(); i++) {
+            if (i > 0) {
+                sb.append(" ").append(op).append(" ");
+            }
+            sb.append(translate(children.get(i)));
+        }
+        return sb.append(")").toString();
+    }
+
+    private String translateEq(Col col, String field, Object value) {
+        if (value instanceof Pattern) {
+            // A regex can't run against an interned int column; evaluate it
+            // in memory against the decoded record instead.
+            throw new UnsupportedPredicateException(
+                    "SQLite backend cannot push a regex match on interned column '" + field + "'.");
+        }
+        Long resolved = resolve(col, value);
+        // A literal absent from the palette can't match any row.
+        return resolved == null ? "0" : col.name() + " = " + resolved;
+    }
+
+    private String translateIn(Col col, List<?> values) {
+        List<Long> ids = new ArrayList<>(values.size());
+        for (Object value : values) {
+            if (value instanceof Pattern) {
+                throw new UnsupportedPredicateException(
+                        "SQLite backend cannot push a regex match in an IN clause on '" + col.name() + "'.");
+            }
+            Long resolved = resolve(col, value);
+            if (resolved != null) {
+                ids.add(resolved);
+            }
+        }
+        if (ids.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder(col.name()).append(" IN (");
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(ids.get(i));
+        }
+        return sb.append(")").toString();
+    }
+
+    private String translateRange(QueryPredicate.Range range) {
+        Col col = col(range.field());
+        if (col.kind() != Kind.INSTANT_SEC && col.kind() != Kind.INT) {
+            // Ranges only make sense on ordered numeric columns; an
+            // interned-string/uuid range is meaningless.
+            throw new UnsupportedPredicateException(
+                    "SQLite backend cannot range over column '" + col.name() + "'.");
+        }
+        List<String> clauses = new ArrayList<>(4);
+        Long lower = scalar(col, range.lowerInclusive());
+        Long upper = scalar(col, range.upperInclusive());
+        if (lower != null) {
+            clauses.add(col.name() + " >= " + lower);
+        }
+        if (upper != null) {
+            clauses.add(col.name() + " <= " + upper);
+        }
+        // Let a block-coordinate range also seek the chunk-bucketed location
+        // index by bounding its chunk EXPRESSION (x>>4 / z>>4) — the exact
+        // expression idx_loc is built on, so the planner can use it. The
+        // chunk isn't a stored column; SQLite computes it. floorDiv(coord,16)
+        // matches the >>4 the index uses, negatives included.
+        String chunkExpr = chunkExpressionFor(col.name());
+        if (chunkExpr != null) {
+            if (range.lowerInclusive() instanceof Number n) {
+                clauses.add(chunkExpr + " >= " + Math.floorDiv(n.longValue(), 16));
+            }
+            if (range.upperInclusive() instanceof Number n) {
+                clauses.add(chunkExpr + " <= " + Math.floorDiv(n.longValue(), 16));
+            }
+        }
+        if (clauses.isEmpty()) {
+            return "1";
+        }
+        if (clauses.size() == 1) {
+            return clauses.get(0);
+        }
+        return "(" + String.join(" AND ", clauses) + ")";
+    }
+
+    private String translateExists(Col col, boolean expected) {
+        return expected ? "(" + col.name() + " IS NOT NULL)" : "(" + col.name() + " IS NULL)";
+    }
+
+    private static String chunkExpressionFor(String column) {
+        if ("x".equals(column)) {
+            return "(x >> 4)";
+        }
+        if ("z".equals(column)) {
+            return "(z >> 4)";
+        }
+        return null;
+    }
+
+    // Resolve an equality/IN literal to the long that the column stores.
+    // Returns null when a palette literal isn't interned (no such row).
+    private Long resolve(Col col, Object value) {
+        return switch (col.kind()) {
+            case SEQ -> value instanceof UUID uuid
+                    ? EventIds.sequenceOf(uuid)
+                    : ((Number) value).longValue();
+            case INT -> ((Number) value).longValue();
+            case INSTANT_SEC -> ((Instant) value).getEpochSecond();
+            case DICT -> {
+                Integer id = palette.dictId(String.valueOf(value));
+                yield id == null ? null : id.longValue();
+            }
+            case UUID_REF -> {
+                Integer id = palette.uuidId((UUID) value);
+                yield id == null ? null : id.longValue();
+            }
+        };
+    }
+
+    // Scalar bound for a range — only INSTANT_MS / INT reach here.
+    private static Long scalar(Col col, Object bound) {
+        if (bound == null) {
+            return null;
+        }
+        return col.kind() == Kind.INSTANT_SEC
+                ? ((Instant) bound).getEpochSecond()
+                : ((Number) bound).longValue();
+    }
+
+    private static Col col(String fieldPath) {
+        Col col = COLUMNS.get(fieldPath);
+        if (col == null) {
+            throw new UnsupportedPredicateException(
+                    "SQLite backend cannot filter on field '" + fieldPath
+                            + "': it lives in the per-event blob and isn't a column "
+                            + "(evaluated in memory against the decoded record instead).");
+        }
+        return col;
+    }
+}

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -1,0 +1,1177 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.EventCatalog;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.Rollbackable;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Embedded-SQLite {@link RecordStore} — the zero-ops third backend (#106).
+ *
+ * <h2>Why it can be small (the design that beats CoreProtect·SQLite)</h2>
+ *
+ * CoreProtect·SQLite is compact because it interns block types into a tiny
+ * id map and stores small int ids per row. Spyglass records are richer, so
+ * this store earns the same density with a stack of levers, every one
+ * measured against the ~160 MiB CP·SQLite footprint at 2M block edits:
+ *
+ * <ol>
+ *   <li><b>Palette interning.</b> The repetitive-but-high-cardinality
+ *       values — block-data strings, event / server names — live once in a
+ *       {@code dict} table; world and player UUIDs (with their display
+ *       names) live once in a {@code uuids} table. Each {@code records} row
+ *       holds small integer references, not the strings/UUIDs.</li>
+ *   <li><b>Hybrid schema.</b> A clean, player-sourced, no-tile-entity block
+ *       edit lives entirely in columns — no blob. Everything else
+ *       (containers, entities, chat, complex/non-player blocks) carries one
+ *       {@code deflate(BSON(record))} blob ({@link BsonBlobs}), decoded only
+ *       when that row is read. The lean rollback never touches it.</li>
+ *   <li><b>seq IS the sort key.</b> The {@link EventIds} sequence is the
+ *       SQLite {@code rowid}, and is co-monotonic with {@code occurred}
+ *       (both stamped at event time), so the store sorts/keysets on
+ *       {@code seq} alone. That removes {@code occurred} from every index
+ *       and drops the standalone time index entirely.</li>
+ *   <li><b>Derived/folded columns.</b> A simple block's {@code material} is
+ *       recovered from its block-data string, player/world names from the
+ *       {@code uuids} palette, {@code source.kind} is always {@code player}
+ *       and {@code expiresAt} is {@code occurred + retention} — so none of
+ *       them costs a column. Coordinates carry a chunk-bucket
+ *       <em>expression</em> index ({@code x>>4, z>>4}), not stored columns.</li>
+ * </ol>
+ *
+ * <h2>Engine</h2>
+ *
+ * WAL + {@code synchronous=NORMAL}: one batched writer (the recorder, off
+ * the main thread) and a small pool of concurrent readers. Retention is a
+ * periodic {@code DELETE … WHERE occurred < now - retention} since SQLite
+ * has no native TTL.
+ */
+@ApiStatus.Internal
+public final class SqliteRecordStore implements RecordStore {
+
+    private static final Logger LOGGER = Logger.getLogger(SqliteRecordStore.class.getName());
+
+    private static final int DEFAULT_READ_POOL = 4;
+    private static final long DEFAULT_RETENTION_SECONDS = 28L * 24 * 3600; // 4 weeks
+    private static final long RETENTION_SWEEP_MINUTES = 60L;
+    private static final int POST_FILTER_SCAN_CAP = 20_000;
+
+    // 14 columns, in bind order. Notably absent (folded/derived, see the
+    // class doc): expires_at, source_kind, player_name, world_name,
+    // origin_detail, cx/cz, and per-side block materials.
+    private static final String INSERT_SQL = "INSERT OR REPLACE INTO records ("
+            + "seq, event, occurred, origin_kind, player, world, x, y, z, "
+            + "server, target, orig_block, new_block, blob) "
+            + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+
+    private static final String DECODE_COLUMNS =
+            "seq, event, occurred, origin_kind, player, world, x, y, z, "
+            + "server, target, orig_block, new_block, blob";
+
+    private final Path dbFile;
+    private final boolean readOnly;
+    private final long retentionSeconds;
+
+    private final Connection writeConn;
+    private final Object writeLock = new Object();
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement dictInsert;
+    private final PreparedStatement uuidInsert;
+
+    private final BlockingQueue<Connection> readPool;
+    private final List<Connection> allConnections = new ArrayList<>();
+    // Dedicated connection for palette reverse-lookups on a cache miss (see
+    // the constructor) — separate from the query read pool so a miss inside
+    // a decode loop that already holds a pooled connection can't deadlock it.
+    private final Connection lookupConn;
+    private final Object lookupLock = new Object();
+
+    // Palette caches — forward (intern) and reverse (resolve). Loaded whole
+    // on open; the single writer keeps them current.
+    private final ConcurrentHashMap<String, Integer> dictForward = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> dictReverse = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Integer> uuidForward = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, UUID> uuidReverse = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> uuidName = new ConcurrentHashMap<>();
+
+    private final Set<String> rollbackableEvents;
+    private final Set<String> chatEvents;
+
+    private final SqlitePredicateToSql.Palette palette = new SqlitePredicateToSql.Palette() {
+        @Override
+        public Integer dictId(String value) {
+            return resolveDictId(value);
+        }
+
+        @Override
+        public Integer uuidId(UUID value) {
+            return resolveUuidId(value);
+        }
+    };
+    private final SqlitePredicateToSql predicateToSql = new SqlitePredicateToSql(palette);
+
+    private final ScheduledExecutorService retention;
+
+    public SqliteRecordStore(Path dbFile) {
+        this(dbFile, false, DEFAULT_READ_POOL, DEFAULT_RETENTION_SECONDS);
+    }
+
+    public SqliteRecordStore(Path dbFile, boolean readOnly) {
+        this(dbFile, readOnly, DEFAULT_READ_POOL, DEFAULT_RETENTION_SECONDS);
+    }
+
+    public SqliteRecordStore(Path dbFile, boolean readOnly, long retentionSeconds) {
+        this(dbFile, readOnly, DEFAULT_READ_POOL, retentionSeconds);
+    }
+
+    public SqliteRecordStore(Path dbFile, boolean readOnly, int readPoolSize, long retentionSeconds) {
+        this.dbFile = dbFile.toAbsolutePath();
+        this.readOnly = readOnly;
+        this.retentionSeconds = retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS;
+        this.rollbackableEvents = rollbackableEventNames();
+        this.chatEvents = EventCatalog.eventsStoredAs(ChatRecord.class);
+        try {
+            if (dbFile.getParent() != null) {
+                java.nio.file.Files.createDirectories(dbFile.getParent());
+            }
+            this.writeConn = open(false);
+            if (readOnly) {
+                this.insertStatement = null;
+                this.dictInsert = null;
+                this.uuidInsert = null;
+            } else {
+                ensureSchema(writeConn);
+                this.insertStatement = writeConn.prepareStatement(INSERT_SQL);
+                this.dictInsert = writeConn.prepareStatement(
+                        "INSERT INTO dict(val) VALUES (?)", Statement.RETURN_GENERATED_KEYS);
+                this.uuidInsert = writeConn.prepareStatement(
+                        "INSERT INTO uuids(hi, lo, name) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
+            }
+
+            int poolSize = Math.max(1, readPoolSize);
+            this.readPool = new ArrayBlockingQueue<>(poolSize);
+            for (int i = 0; i < poolSize; i++) {
+                Connection read = open(true);
+                allConnections.add(read);
+                readPool.add(read);
+            }
+            this.lookupConn = open(true);
+            allConnections.add(lookupConn);
+            loadPalette();
+        } catch (SQLException | IOException ex) {
+            throw new RuntimeException("Failed to open SQLite store at " + this.dbFile
+                    + ": " + ex.getMessage(), ex);
+        }
+
+        if (readOnly) {
+            this.retention = null;
+        } else {
+            this.retention = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "spyglass-sqlite-retention");
+                t.setDaemon(true);
+                return t;
+            });
+            this.retention.scheduleWithFixedDelay(this::pruneExpiredQuietly,
+                    RETENTION_SWEEP_MINUTES, RETENTION_SWEEP_MINUTES, TimeUnit.MINUTES);
+            pruneExpiredQuietly();
+        }
+    }
+
+    // ===== Connection / schema =================================
+
+    private Connection open(boolean asReadOnly) throws SQLException {
+        Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dbFile);
+        try (Statement st = conn.createStatement()) {
+            st.execute("PRAGMA busy_timeout=30000");
+            // 8 KiB pages (set before WAL / first write, a no-op on an existing
+            // db): fewer page headers and tighter b-tree fill across millions
+            // of small rows than the 4 KiB default — a measured few-MiB win on
+            // the 2M footprint at no cost.
+            st.execute("PRAGMA page_size=8192");
+            st.execute("PRAGMA journal_mode=WAL");
+            st.execute("PRAGMA synchronous=NORMAL");
+            st.execute("PRAGMA foreign_keys=OFF");
+            st.execute("PRAGMA temp_store=MEMORY");
+            st.execute("PRAGMA cache_size=-16000");   // 16 MiB page cache / connection
+            st.execute("PRAGMA mmap_size=268435456");  // 256 MiB mmap window
+            if (asReadOnly) {
+                st.execute("PRAGMA query_only=ON");
+            }
+        }
+        return conn;
+    }
+
+    private static void ensureSchema(Connection conn) throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute("CREATE TABLE IF NOT EXISTS dict ("
+                    + "id INTEGER PRIMARY KEY, val TEXT NOT NULL UNIQUE)");
+            // name rides on the uuid palette so a simple block needn't carry
+            // player_name / world_name columns — they fold to the ref.
+            st.execute("CREATE TABLE IF NOT EXISTS uuids ("
+                    + "id INTEGER PRIMARY KEY, hi INTEGER NOT NULL, lo INTEGER NOT NULL, "
+                    + "name TEXT, UNIQUE(hi, lo))");
+            st.execute("CREATE TABLE IF NOT EXISTS records ("
+                    + "seq INTEGER PRIMARY KEY, "       // EventIds sequence == rowid == sort key
+                    + "event INTEGER NOT NULL, "        // dict ref
+                    + "occurred INTEGER NOT NULL, "     // epoch SECONDS
+                    + "origin_kind INTEGER, "           // dict ref
+                    + "player INTEGER, "                // uuids ref (source.playerId)
+                    + "world INTEGER, "                 // uuids ref (location.worldId)
+                    + "x INTEGER, y INTEGER, z INTEGER, "
+                    + "server INTEGER, target INTEGER, "        // dict refs
+                    + "orig_block INTEGER, new_block INTEGER, "  // dict refs (simple-block data)
+                    + "blob BLOB)");                    // deflate(BSON(record)); NULL for simple blocks
+            // Lean, occurred-free indexes (see the class doc). The region
+            // index buckets coordinates with an EXPRESSION (x>>4, z>>4) so the
+            // chunk columns aren't stored on the row at all — the predicate
+            // translator emits the same (x>>4)/(z>>4) expressions to seek it.
+            st.execute("CREATE INDEX IF NOT EXISTS idx_player ON records(player)");
+            st.execute("CREATE INDEX IF NOT EXISTS idx_loc ON records(world, (x >> 4), (z >> 4))");
+        }
+    }
+
+    private void loadPalette() throws SQLException {
+        try (Statement st = writeConn.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SELECT id, val FROM dict")) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    String val = rs.getString(2);
+                    dictForward.put(val, id);
+                    dictReverse.put(id, val);
+                }
+            }
+            try (ResultSet rs = st.executeQuery("SELECT id, hi, lo, name FROM uuids")) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    UUID uuid = new UUID(rs.getLong(2), rs.getLong(3));
+                    uuidForward.put(uuid, id);
+                    uuidReverse.put(id, uuid);
+                    String name = rs.getString(4);
+                    if (name != null) {
+                        uuidName.put(id, name);
+                    }
+                }
+            }
+        }
+    }
+
+    private static Set<String> rollbackableEventNames() {
+        Set<String> names = new HashSet<>();
+        for (String name : EventCatalog.eventNames()) {
+            Class<? extends EventRecord> clazz = EventCatalog.recordClassOf(name);
+            if (clazz != null && Rollbackable.class.isAssignableFrom(clazz)) {
+                names.add(name);
+            }
+        }
+        return names;
+    }
+
+    // ===== Save ================================================
+
+    @Override
+    public void save(List<EventRecord> records) {
+        if (records.isEmpty() || readOnly) {
+            return;
+        }
+        synchronized (writeLock) {
+            Map<String, Integer> pendingDict = new HashMap<>();
+            Map<UUID, Integer> pendingUuid = new HashMap<>();
+            Map<Integer, String> pendingNames = new HashMap<>();
+            try {
+                writeConn.setAutoCommit(false);
+                for (EventRecord record : records) {
+                    bindRecord(record, pendingDict, pendingUuid, pendingNames);
+                    insertStatement.addBatch();
+                }
+                insertStatement.executeBatch();
+                writeConn.commit();
+                // Promote interns to the shared cache only after a durable
+                // commit, so a rolled-back batch never leaves phantom ids.
+                pendingDict.forEach((val, id) -> {
+                    dictForward.put(val, id);
+                    dictReverse.put(id, val);
+                });
+                pendingUuid.forEach((uuid, id) -> {
+                    uuidForward.put(uuid, id);
+                    uuidReverse.put(id, uuid);
+                });
+                uuidName.putAll(pendingNames);
+            } catch (SQLException ex) {
+                rollbackQuietly();
+                throw new RuntimeException("SQLite save failed: " + ex.getMessage(), ex);
+            } finally {
+                restoreAutoCommit();
+            }
+        }
+    }
+
+    private void bindRecord(EventRecord record, Map<String, Integer> pendingDict,
+                            Map<UUID, Integer> pendingUuid, Map<Integer, String> pendingNames)
+            throws SQLException {
+        PreparedStatement ps = insertStatement;
+        ps.setLong(1, EventIds.sequenceOf(record.id()));
+        ps.setInt(2, internDict(record.event(), pendingDict));
+        ps.setLong(3, record.occurred().getEpochSecond());
+
+        Origin origin = record.origin();
+        bindDictRef(ps, 4, origin == null ? null : origin.kind(), pendingDict);
+
+        Source source = record.source();
+        bindUuidRef(ps, 5, source == null ? null : source.playerId(),
+                source == null ? null : source.playerName(), pendingUuid, pendingNames);
+
+        BlockLocation location = record.location();
+        UUID worldId = location == null ? null : location.worldId();
+        bindUuidRef(ps, 6, worldId, location == null ? null : location.worldName(),
+                pendingUuid, pendingNames);
+        if (location == null) {
+            ps.setNull(7, Types.INTEGER);
+            ps.setNull(8, Types.INTEGER);
+            ps.setNull(9, Types.INTEGER);
+        } else {
+            ps.setInt(7, location.x());
+            ps.setInt(8, location.y());
+            ps.setInt(9, location.z());
+        }
+
+        bindDictRef(ps, 10, record.server(), pendingDict);
+        bindDictRef(ps, 11, record.target(), pendingDict);
+
+        if (columnStorable(record)) {
+            BlockSnapshot before = beforeBlock(record);
+            BlockSnapshot after = afterBlock(record);
+            ps.setInt(12, internDict(before.blockData(), pendingDict));
+            ps.setInt(13, internDict(after.blockData(), pendingDict));
+            ps.setNull(14, Types.BLOB);
+        } else {
+            ps.setNull(12, Types.INTEGER);
+            ps.setNull(13, Types.INTEGER);
+            ps.setBytes(14, deflate(BsonBlobs.encodeRecordBytes(record)));
+        }
+    }
+
+    /**
+     * {@code true} when a record reduces, losslessly, to columns alone — no
+     * blob. That's a block break/place whose two snapshots are simple and
+     * whose material is recoverable from the block-data string, with a plain
+     * player source and a default origin. Anything the lean columns can't
+     * carry (a tile entity, an entity/plugin/command-block source, an origin
+     * detail, extension metadata, or a non-vanilla material) forces a blob.
+     */
+    private static boolean columnStorable(EventRecord record) {
+        BlockSnapshot before = beforeBlock(record);
+        BlockSnapshot after = afterBlock(record);
+        if (before == null || after == null || !before.simple() || !after.simple()) {
+            return false;
+        }
+        if (!record.extensions().isEmpty()) {
+            return false;
+        }
+        // material must round-trip from the block-data string alone.
+        if (!materialMatches(before) || !materialMatches(after)) {
+            return false;
+        }
+        Origin origin = record.origin();
+        if (origin != null && origin.detail() != null) {
+            return false;
+        }
+        Source source = record.source();
+        // Columns carry only a plain player source (kind is reconstructed as
+        // "player"); the UUID/name fold to the palette.
+        return source != null
+                && "player".equals(source.kind())
+                && source.entityId() == null && source.entityType() == null
+                && source.pluginName() == null && source.commandBlockLocation() == null
+                && source.description() == null;
+    }
+
+    private static boolean materialMatches(BlockSnapshot snapshot) {
+        Material derived = materialFromBlockData(snapshot.blockData());
+        return derived != null && derived == snapshot.material();
+    }
+
+    private static Material materialFromBlockData(String blockData) {
+        if (blockData == null || !blockData.startsWith("minecraft:")) {
+            return null;
+        }
+        String key = blockData.substring("minecraft:".length());
+        int bracket = key.indexOf('[');
+        if (bracket >= 0) {
+            key = key.substring(0, bracket);
+        }
+        try {
+            return Material.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private static BlockSnapshot beforeBlock(EventRecord record) {
+        if (record instanceof BlockBreakRecord b) {
+            return b.originalBlock();
+        }
+        if (record instanceof BlockPlaceRecord p) {
+            return p.originalBlock();
+        }
+        return null;
+    }
+
+    private static BlockSnapshot afterBlock(EventRecord record) {
+        if (record instanceof BlockBreakRecord b) {
+            return b.newBlock();
+        }
+        if (record instanceof BlockPlaceRecord p) {
+            return p.newBlock();
+        }
+        return null;
+    }
+
+    // ===== Query ===============================================
+
+    @Override
+    public QueryResult query(QueryRequest request) {
+        return runQuery(request, true);
+    }
+
+    @Override
+    public QueryResult querySummary(QueryRequest request) {
+        return runQuery(request, false);
+    }
+
+    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
+        List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
+        String where;
+        List<QueryPredicate> residual = List.of();
+        try {
+            where = predicateToSql.translate(predicates);
+        } catch (SqlitePredicateToSql.UnsupportedPredicateException unsupported) {
+            List<QueryPredicate> pushable = new ArrayList<>();
+            List<QueryPredicate> inMemory = new ArrayList<>();
+            for (QueryPredicate predicate : predicates) {
+                try {
+                    predicateToSql.translate(List.of(predicate));
+                    pushable.add(predicate);
+                } catch (SqlitePredicateToSql.UnsupportedPredicateException ex) {
+                    inMemory.add(predicate);
+                }
+            }
+            residual = inMemory;
+            where = predicateToSql.translate(pushable);
+        }
+        boolean postFilter = !residual.isEmpty();
+        boolean hydrate = includeHeavy || postFilter;
+        where = appendNoChat(where, request);
+
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + (postFilter ? POST_FILTER_SCAN_CAP : request.limit());
+
+        List<EventRecord> records = new ArrayList<>(postFilter ? 64 : Math.min(request.limit(), 4096));
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                EventRecord record = decodeRow(rs, hydrate);
+                if (record == null) {
+                    continue;
+                }
+                if (postFilter && !PredicateEvaluator.matchesAll(residual, record)) {
+                    continue;
+                }
+                records.add(record);
+                if (postFilter && records.size() >= request.limit()) {
+                    break;
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite query failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+
+        List<QueryResult.RecordAggregation> aggregations =
+                request.grouping() && !request.flags().contains(Flag.NO_GROUP)
+                        ? aggregate(records)
+                        : List.of();
+        return new QueryResult(records, aggregations);
+    }
+
+    @Override
+    public QueryPage queryPage(QueryRequest request, QueryPage.Cursor cursor, int pageSize) {
+        // Generic keyset page over seq — all event types, full decode. The
+        // lean, rollbackable-filtered path is streamRollbackEffects below.
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String where = appendNoChat(predicateToSql.translate(new ArrayList<>(request.predicates())), request);
+        where = appendKeyset(where, cursor, newestFirst);
+
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + pageSize;
+
+        List<EventRecord> records = new ArrayList<>(Math.min(pageSize, 4096));
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                EventRecord record = decodeRow(rs, true);
+                if (record != null) {
+                    records.add(record);
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite paged query failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        QueryPage.Cursor next = null;
+        if (records.size() == pageSize) {
+            EventRecord last = records.get(records.size() - 1);
+            if (last.occurred() != null && last.id() != null) {
+                next = new QueryPage.Cursor(last.occurred(), last.id());
+            }
+        }
+        return new QueryPage(records, next);
+    }
+
+    @Override
+    public QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                  int windowLimit, boolean rollback,
+                                                  RollbackEffectSink sink) {
+        // Allocation-lean rollback read (#67/#83 mirror): a direction-specific,
+        // rollbackable-only keyset scan that resolves the one block-data side
+        // the apply engine writes straight from the in-memory palette — the
+        // cached String is the SAME reference for every stone/air row, so the
+        // simple-block hot path allocates nothing per row. Only a blob row
+        // (container / entity / complex block) decodes.
+        String blockColumn = rollback ? "orig_block" : "new_block";
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String where = predicateToSql.translate(new ArrayList<>(request.predicates()));
+        where = appendAnd(where, rollbackableFilter());
+        where = appendKeyset(where, cursor, newestFirst);
+
+        String sql = "SELECT seq, occurred, world, x, y, z, "
+                + blockColumn + " AS blk, blob, event FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + windowLimit;
+
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int count = 0;
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                count++;
+                long seq = rs.getLong("seq");
+                UUID id = EventIds.uuidOf(seq);
+                Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+                lastOccurred = occurred;
+                lastId = id;
+                emitEffect(rs, rollback, occurred, id, sink);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite rollback stream failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        return (count == windowLimit && lastOccurred != null && lastId != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
+    private void emitEffect(ResultSet rs, boolean rollback, Instant occurred, UUID id,
+                            RollbackEffectSink sink) throws SQLException {
+        byte[] blob = rs.getBytes("blob");
+        if (blob == null) {
+            // Simple-block fast path: resolve the one side's block-data from
+            // the palette and hand primitives straight to the sink — no
+            // record, snapshot, or effect object. expectedCurrent is unused
+            // under force-overwrite (#69), so pass null.
+            int blockRef = rs.getInt("blk");
+            if (rs.wasNull()) {
+                sink.skip(occurred, id);
+                return;
+            }
+            UUID world = uuidValue(rs.getInt("world"));
+            sink.block(world, rs.getInt("x"), rs.getInt("y"), rs.getInt("z"),
+                    dictValue(blockRef), null, occurred, id);
+            return;
+        }
+        EventRecord record = decodeBlob(blob);
+        if (!(record instanceof Rollbackable rollbackable)) {
+            sink.skip(occurred, id);
+            return;
+        }
+        RollbackEffect effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+        if (effect instanceof RollbackEffect.BlockReplace br
+                && br.replacement() != null && br.replacement().simple()) {
+            BlockLocation loc = br.location();
+            sink.block(loc.worldId(), loc.x(), loc.y(), loc.z(),
+                    br.replacement().blockData(), null, occurred, id);
+        } else {
+            sink.complex(effect, occurred, id);
+        }
+    }
+
+    // ===== Row decode ==========================================
+
+    private EventRecord decodeRow(ResultSet rs, boolean includeHeavy) throws SQLException {
+        byte[] blob = rs.getBytes("blob");
+        if (blob != null) {
+            return decodeBlob(blob); // authoritative; columns were only for pushdown
+        }
+        // Column-stored: a clean player-sourced simple block.
+        String event = dictValue(rs.getInt("event"));
+        Class<? extends EventRecord> clazz = EventCatalog.recordClassOf(event);
+        if (clazz == null) {
+            return null;
+        }
+        UUID id = EventIds.uuidOf(rs.getLong("seq"));
+        Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+        Instant expiresAt = occurred.plusSeconds(retentionSeconds);
+        Origin origin = new Origin(dictValueOrNull(rs, "origin_kind"), null);
+        int playerRef = rs.getInt("player");
+        boolean hasPlayer = !rs.wasNull();
+        Source source = new Source("player",
+                hasPlayer ? uuidValue(playerRef) : null,
+                hasPlayer ? uuidName.get(playerRef) : null,
+                null, null, null, null, null);
+        int worldRef = rs.getInt("world");
+        boolean hasWorld = !rs.wasNull();
+        BlockLocation location = new BlockLocation(
+                hasWorld ? uuidValue(worldRef) : null,
+                hasWorld ? uuidName.get(worldRef) : null,
+                rs.getInt("x"), rs.getInt("y"), rs.getInt("z"));
+        String server = dictValueOrNull(rs, "server");
+        String target = dictValueOrNull(rs, "target");
+        BlockSnapshot before = includeHeavy ? snapshot(rs, "orig_block") : null;
+        BlockSnapshot after = includeHeavy ? snapshot(rs, "new_block") : null;
+
+        if (clazz == BlockBreakRecord.class) {
+            return new BlockBreakRecord(id, event, occurred, expiresAt,
+                    origin, source, location, server, target, before, after);
+        }
+        if (clazz == BlockPlaceRecord.class) {
+            return new BlockPlaceRecord(id, event, occurred, expiresAt,
+                    origin, source, location, server, target, before, after);
+        }
+        return null; // only block break/place are ever column-stored
+    }
+
+    private BlockSnapshot snapshot(ResultSet rs, String blockColumn) throws SQLException {
+        String blockData = dictValueOrNull(rs, blockColumn);
+        if (blockData == null) {
+            return null;
+        }
+        Material material = materialFromBlockData(blockData);
+        if (material == null) {
+            return null; // column storage guaranteed derivability, but stay defensive
+        }
+        return new BlockSnapshot(material, blockData,
+                List.of(), List.of(), List.of(), List.of(), null, List.of());
+    }
+
+    private EventRecord decodeBlob(byte[] blob) {
+        return BsonBlobs.decodeRecordBytes(inflate(blob));
+    }
+
+    // ===== Predicate / SQL helpers =============================
+
+    private String appendNoChat(String where, QueryRequest request) {
+        if (!request.flags().contains(Flag.NO_CHAT)) {
+            return where;
+        }
+        List<Integer> ids = new ArrayList<>(chatEvents.size());
+        for (String name : chatEvents) {
+            Integer id = dictForward.get(name);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        if (ids.isEmpty()) {
+            return where;
+        }
+        return appendAnd(where, "event NOT IN (" + joinInts(ids) + ")");
+    }
+
+    private static String appendAnd(String where, String clause) {
+        if (clause == null || clause.isEmpty()) {
+            return where;
+        }
+        return where.isEmpty() ? clause : where + " AND " + clause;
+    }
+
+    private static String appendKeyset(String where, QueryPage.Cursor cursor, boolean newestFirst) {
+        if (cursor == null) {
+            return where;
+        }
+        // Sort/keyset is on seq alone (co-monotonic with occurred), so the
+        // cursor is a single-column compare on the primary key.
+        String op = newestFirst ? "<" : ">";
+        return appendAnd(where, "seq " + op + " " + EventIds.sequenceOf(cursor.id()));
+    }
+
+    private String rollbackableFilter() {
+        List<Integer> ids = new ArrayList<>(rollbackableEvents.size());
+        for (String name : rollbackableEvents) {
+            Integer id = dictForward.get(name);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids.isEmpty() ? "0" : "event IN (" + joinInts(ids) + ")";
+    }
+
+    private static String joinInts(List<Integer> ids) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(ids.get(i));
+        }
+        return sb.toString();
+    }
+
+    // ===== Palette resolution ==================================
+
+    private int internDict(String value, Map<String, Integer> pending) throws SQLException {
+        Integer id = dictForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        id = pending.get(value);
+        if (id != null) {
+            return id;
+        }
+        dictInsert.setString(1, value);
+        dictInsert.executeUpdate();
+        int newId = generatedKey(dictInsert);
+        pending.put(value, newId);
+        return newId;
+    }
+
+    private int internUuid(UUID value, String name, Map<UUID, Integer> pending,
+                           Map<Integer, String> pendingNames) throws SQLException {
+        Integer id = uuidForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        id = pending.get(value);
+        if (id != null) {
+            return id;
+        }
+        uuidInsert.setLong(1, value.getMostSignificantBits());
+        uuidInsert.setLong(2, value.getLeastSignificantBits());
+        if (name == null) {
+            uuidInsert.setNull(3, Types.VARCHAR);
+        } else {
+            uuidInsert.setString(3, name);
+        }
+        uuidInsert.executeUpdate();
+        int newId = generatedKey(uuidInsert);
+        pending.put(value, newId);
+        if (name != null) {
+            pendingNames.put(newId, name);
+        }
+        return newId;
+    }
+
+    private void bindDictRef(PreparedStatement ps, int index, String value,
+                             Map<String, Integer> pending) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+        } else {
+            ps.setInt(index, internDict(value, pending));
+        }
+    }
+
+    private void bindUuidRef(PreparedStatement ps, int index, UUID value, String name,
+                             Map<UUID, Integer> pending, Map<Integer, String> pendingNames)
+            throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+        } else {
+            ps.setInt(index, internUuid(value, name, pending, pendingNames));
+        }
+    }
+
+    private static int generatedKey(PreparedStatement ps) throws SQLException {
+        try (ResultSet keys = ps.getGeneratedKeys()) {
+            if (keys.next()) {
+                return keys.getInt(1);
+            }
+        }
+        throw new SQLException("INSERT returned no generated key");
+    }
+
+    private String dictValue(int id) {
+        String val = dictReverse.get(id);
+        if (val != null) {
+            return val;
+        }
+        val = lookupDict(id);
+        if (val != null) {
+            dictReverse.put(id, val);
+            dictForward.putIfAbsent(val, id);
+        }
+        return val;
+    }
+
+    private UUID uuidValue(int id) {
+        UUID val = uuidReverse.get(id);
+        if (val != null) {
+            return val;
+        }
+        val = lookupUuid(id);
+        if (val != null) {
+            uuidReverse.put(id, val);
+            uuidForward.putIfAbsent(val, id);
+        }
+        return val;
+    }
+
+    private String dictValueOrNull(ResultSet rs, String column) throws SQLException {
+        int id = rs.getInt(column);
+        return rs.wasNull() ? null : dictValue(id);
+    }
+
+    private Integer resolveDictId(String value) {
+        Integer id = dictForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement("SELECT id FROM dict WHERE val = ?")) {
+                ps.setString(1, value);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        int found = rs.getInt(1);
+                        dictForward.putIfAbsent(value, found);
+                        dictReverse.putIfAbsent(found, value);
+                        return found;
+                    }
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite dict lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+        return null;
+    }
+
+    private Integer resolveUuidId(UUID value) {
+        Integer id = uuidForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement(
+                    "SELECT id FROM uuids WHERE hi = ? AND lo = ?")) {
+                ps.setLong(1, value.getMostSignificantBits());
+                ps.setLong(2, value.getLeastSignificantBits());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        int found = rs.getInt(1);
+                        uuidForward.putIfAbsent(value, found);
+                        uuidReverse.putIfAbsent(found, value);
+                        return found;
+                    }
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite uuid lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+        return null;
+    }
+
+    private String lookupDict(int id) {
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement("SELECT val FROM dict WHERE id = ?")) {
+                ps.setInt(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? rs.getString(1) : null;
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite dict reverse lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private UUID lookupUuid(int id) {
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement(
+                    "SELECT hi, lo, name FROM uuids WHERE id = ?")) {
+                ps.setInt(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    UUID uuid = new UUID(rs.getLong(1), rs.getLong(2));
+                    String name = rs.getString(3);
+                    if (name != null) {
+                        uuidName.putIfAbsent(id, name);
+                    }
+                    return uuid;
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite uuid reverse lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    // ===== Read pool ===========================================
+
+    private Connection borrow() {
+        try {
+            return readPool.take();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted borrowing a SQLite read connection", ex);
+        }
+    }
+
+    private void giveBack(Connection conn) {
+        readPool.offer(conn);
+    }
+
+    /** Work that runs against a borrowed connection and may throw {@link SQLException}. */
+    @FunctionalInterface
+    public interface ConnectionWork<T> {
+        T apply(Connection connection) throws SQLException;
+    }
+
+    /**
+     * Run {@code work} on a pooled read connection. The auxiliary SQLite
+     * stores (undo / tool-state / salvage) share this store's read pool
+     * rather than opening their own, so connection count stays bounded.
+     */
+    public <T> T withReadConnection(ConnectionWork<T> work) {
+        Connection conn = borrow();
+        try {
+            return work.apply(conn);
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite read failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+    }
+
+    /**
+     * Run {@code work} on the single write connection under the write lock,
+     * so every writer (records + aux) serialises on one connection.
+     */
+    public <T> T withWriteConnection(ConnectionWork<T> work) {
+        synchronized (writeLock) {
+            try {
+                return work.apply(writeConn);
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite write failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    // ===== Retention / maintenance =============================
+
+    private void pruneExpiredQuietly() {
+        try {
+            pruneExpired();
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.WARNING, "SQLite retention sweep failed", ex);
+        }
+    }
+
+    /** Drop records past the retention horizon; the SQLite TTL analogue. */
+    public long pruneExpired() {
+        if (readOnly) {
+            return 0L;
+        }
+        long thresholdSec = (System.currentTimeMillis() / 1000L) - retentionSeconds;
+        synchronized (writeLock) {
+            try (PreparedStatement ps = writeConn.prepareStatement(
+                    "DELETE FROM records WHERE occurred < ?")) {
+                ps.setLong(1, thresholdSec);
+                return ps.executeUpdate();
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite retention prune failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    /** Fold the WAL back into the main db file (bounds the -wal sidecar). */
+    public void checkpoint() {
+        synchronized (writeLock) {
+            try (Statement st = writeConn.createStatement()) {
+                st.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+            } catch (SQLException ex) {
+                throw new RuntimeException("SQLite checkpoint failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    /** Total record rows — test / benchmark helper. */
+    public long count() {
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT count(*) FROM records")) {
+            return rs.next() ? rs.getLong(1) : 0L;
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite count failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+    }
+
+    public Path databaseFile() {
+        return dbFile;
+    }
+
+    // ===== Aggregate (mirrors Mongo / ClickHouse) ==============
+
+    private List<QueryResult.RecordAggregation> aggregate(List<EventRecord> records) {
+        Map<String, Long> counts = new HashMap<>();
+        Map<String, EventRecord> sample = new HashMap<>();
+        for (EventRecord record : records) {
+            String key = record.event() + "|" + record.sourceName() + "|" + record.target() + "|"
+                    + record.occurred().atZone(java.time.ZoneOffset.UTC).toLocalDate();
+            counts.merge(key, 1L, Long::sum);
+            sample.putIfAbsent(key, record);
+        }
+        return counts.entrySet().stream()
+                .map(entry -> new QueryResult.RecordAggregation(sample.get(entry.getKey()), entry.getValue()))
+                .sorted(Comparator.comparing((QueryResult.RecordAggregation aggregation)
+                        -> aggregation.sample().occurred()).reversed())
+                .toList();
+    }
+
+    // ===== Compression (per-event blob) ========================
+
+    private static byte[] deflate(byte[] input) {
+        Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION);
+        deflater.setInput(input);
+        deflater.finish();
+        ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(32, input.length / 2));
+        byte[] buffer = new byte[8192];
+        while (!deflater.finished()) {
+            out.write(buffer, 0, deflater.deflate(buffer));
+        }
+        deflater.end();
+        return out.toByteArray();
+    }
+
+    private static byte[] inflate(byte[] input) {
+        Inflater inflater = new Inflater();
+        inflater.setInput(input);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(32, input.length * 2));
+        byte[] buffer = new byte[8192];
+        try {
+            while (!inflater.finished()) {
+                int n = inflater.inflate(buffer);
+                if (n == 0 && inflater.needsInput()) {
+                    break;
+                }
+                out.write(buffer, 0, n);
+            }
+        } catch (java.util.zip.DataFormatException ex) {
+            throw new RuntimeException("SQLite blob inflate failed: " + ex.getMessage(), ex);
+        } finally {
+            inflater.end();
+        }
+        return out.toByteArray();
+    }
+
+    // ===== Lifecycle ===========================================
+
+    private void rollbackQuietly() {
+        try {
+            writeConn.rollback();
+        } catch (SQLException ignored) {
+            // best-effort; the original failure is what we surface
+        }
+    }
+
+    private void restoreAutoCommit() {
+        try {
+            writeConn.setAutoCommit(true);
+        } catch (SQLException ignored) {
+            // best-effort
+        }
+    }
+
+    @Override
+    public void close() {
+        if (retention != null) {
+            retention.shutdownNow();
+        }
+        if (!readOnly) {
+            try {
+                checkpoint();
+            } catch (RuntimeException ex) {
+                LOGGER.log(Level.WARNING, "SQLite checkpoint on close failed", ex);
+            }
+        }
+        closeQuietly(insertStatement);
+        closeQuietly(dictInsert);
+        closeQuietly(uuidInsert);
+        closeQuietly(writeConn);
+        for (Connection conn : allConnections) {
+            closeQuietly(conn);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception ignored) {
+            // shutdown best-effort
+        }
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteBench.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteBench.java
@@ -1,0 +1,266 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * On-disk footprint + rollback-read throughput for {@link SqliteRecordStore}
+ * (#106), measured directly in-JVM — no server, no Docker, repeatable.
+ *
+ * <p>Seeds a realistic 2M block-edit stream (the same shape CoreProtect's
+ * {@code co_block} holds, so the disk numbers are apples-to-apples with
+ * the ~160 MiB CP·SQLite footprint the issue targets), checkpoints, and
+ * reports:
+ *
+ * <ul>
+ *   <li>total on-disk bytes (db file + WAL), and per-table/index bytes via
+ *       {@code dbstat};</li>
+ *   <li>a full keyset rollback read over every row, in effects/sec — the
+ *       lean {@code streamRollbackEffects} path the engine drives.</li>
+ * </ul>
+ *
+ * <p>Default 2,000,000 records; override with {@code -DOMNI_BENCH_RECORDS=N}.
+ * Run with {@code ./gradlew :spyglass-core:sqliteBench}.
+ */
+@Tag("sqlite-bench")
+class SqliteBench {
+
+    private static final int RECORDS =
+            Integer.getInteger("OMNI_BENCH_RECORDS", 2_000_000);
+    private static final int BATCH = 10_000;
+    private static final int ROLLBACK_WINDOW = 4_000;
+    private static final long CP_SQLITE_MIB = 160; // the figure to beat (#106)
+
+    // The dataset mirrors regression/bot/compare.js exactly — the scenario
+    // CoreProtect's ~160 MiB was measured on — so the disk comparison is
+    // apples-to-apples: a `/fill stone` then `//replace stone air` over a
+    // contiguous cube. One player, one world, one block transition
+    // (stone -> air), sequential coordinates. This is what a WorldEdit
+    // rollback set actually looks like; a random scatter would be a
+    // worst case neither store sees in the benchmark.
+    private static final UUID WORLD = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+    private static final UUID PLAYER = UUID.fromString("99999999-0000-0000-0000-000000001000");
+    private static final int X0 = 10_000;
+    private static final int Y0 = -32;
+    private static final int Z0 = 10_000;
+    private static final int SIDE = (int) Math.round(Math.cbrt(RECORDS));
+
+    @Test
+    void footprintAndRollbackAt2M() throws Exception {
+        Path dir = Files.createTempDirectory("sg-sqlite-bench");
+        Path db = dir.resolve("spyglass.db");
+        SqliteRecordStore store = new SqliteRecordStore(db);
+        try {
+            long t0 = System.nanoTime();
+            seed(store);
+            store.checkpoint();
+            double seedSec = (System.nanoTime() - t0) / 1e9;
+
+            long total = fileBytes(db);
+            System.out.printf(Locale.ROOT,
+                    "%n=== SQLite footprint @ %,d block records ===%n", RECORDS);
+            System.out.printf(Locale.ROOT, "seed: %.1fs (%,.0f rec/s)%n",
+                    seedSec, RECORDS / seedSec);
+            System.out.printf(Locale.ROOT, "rows in records table: %,d%n", store.count());
+            printDbStat(db);
+            double mib = total / (1024.0 * 1024.0);
+            System.out.printf(Locale.ROOT, "TOTAL on disk (db + wal + shm): %.1f MiB  (%.1f MiB / million)%n",
+                    mib, mib / (RECORDS / 1_000_000.0));
+            System.out.printf(Locale.ROOT, "CoreProtect·SQLite target: ~%d MiB  ->  Spyglass·SQLite is %s%n",
+                    CP_SQLITE_MIB, mib < CP_SQLITE_MIB ? String.format(Locale.ROOT,
+                            "SMALLER by %.0f%%", 100 * (CP_SQLITE_MIB - mib) / CP_SQLITE_MIB)
+                            : "LARGER (over target!)");
+
+            // Full rollback read over every row, lean path, in windows like
+            // the engine. Counts emitted effects, times the whole sweep.
+            AtomicLong effects = new AtomicLong();
+            RecordStore.RollbackEffectSink sink = new RecordStore.RollbackEffectSink() {
+                @Override
+                public void block(UUID world, int x, int y, int z, String data,
+                                  String expected, Instant occurred, UUID id) {
+                    effects.incrementAndGet();
+                }
+
+                @Override
+                public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                                    Instant occurred, UUID id) {
+                    effects.incrementAndGet();
+                }
+
+                @Override
+                public void skip(Instant occurred, UUID id) {
+                }
+            };
+            QueryRequest all = new QueryRequest(List.of(), Sort.NEWEST_FIRST, RECORDS,
+                    java.util.EnumSet.noneOf(Flag.class), false);
+            long r0 = System.nanoTime();
+            QueryPage.Cursor cursor = null;
+            do {
+                cursor = store.streamRollbackEffects(all, cursor, ROLLBACK_WINDOW, true, sink);
+            } while (cursor != null);
+            double rbSec = (System.nanoTime() - r0) / 1e9;
+            System.out.printf(Locale.ROOT,
+                    "%nrollback read: %,d effects in %.2fs  (%,.0f effects/s)%n",
+                    effects.get(), rbSec, effects.get() / rbSec);
+
+            // A scoped (single-player) rollback — the common operator action —
+            // to show the by-player index seek.
+            UUID victim = PLAYER;
+            AtomicLong scoped = new AtomicLong();
+            RecordStore.RollbackEffectSink countSink = countingSink(scoped);
+            long s0 = System.nanoTime();
+            cursor = null;
+            do {
+                cursor = store.streamRollbackEffects(
+                        new QueryRequest(List.of(new QueryPredicate.Eq("source.playerId", victim)),
+                                Sort.NEWEST_FIRST, RECORDS, java.util.EnumSet.noneOf(Flag.class), false),
+                        cursor, ROLLBACK_WINDOW, true, countSink);
+            } while (cursor != null);
+            double scopedSec = (System.nanoTime() - s0) / 1e9;
+            System.out.printf(Locale.ROOT,
+                    "by-player rollback: %,d effects in %.3fs  (%,.0f effects/s)%n",
+                    scoped.get(), scopedSec, scoped.get() / scopedSec);
+        } finally {
+            store.close();
+            deleteTree(dir);
+        }
+    }
+
+    private void seed(SqliteRecordStore store) {
+        Instant base = Instant.now().minus(7, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+        List<EventRecord> batch = new ArrayList<>(BATCH);
+        for (int i = 0; i < RECORDS; i++) {
+            batch.add(record(i, base.plusMillis(i)));
+            if (batch.size() == BATCH) {
+                store.save(batch);
+                batch.clear();
+            }
+        }
+        if (!batch.isEmpty()) {
+            store.save(batch);
+        }
+    }
+
+    private EventRecord record(int i, Instant occurred) {
+        // Walk the cube in (x, then z, then y) order, the way a WorldEdit
+        // //replace iterates a region — contiguous coordinates.
+        int dx = i % SIDE;
+        int dz = (i / SIDE) % SIDE;
+        int dy = i / (SIDE * SIDE);
+        BlockLocation loc = new BlockLocation(WORLD, "world", X0 + dx, Y0 + dy, Z0 + dz);
+        // //replace stone air is logged as a break: stone -> air.
+        return new BlockBreakRecord(EventIds.newId(), "break", occurred,
+                occurred.plus(28, ChronoUnit.DAYS), Origin.player(),
+                Source.player(PLAYER, "Builder"), loc, "world", "STONE",
+                snap("minecraft:stone"), snap("minecraft:air"));
+    }
+
+    private static RecordStore.RollbackEffectSink countingSink(AtomicLong counter) {
+        return new RecordStore.RollbackEffectSink() {
+            @Override
+            public void block(UUID world, int x, int y, int z, String data, String expected,
+                              Instant occurred, UUID id) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                                Instant occurred, UUID id) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void skip(Instant occurred, UUID id) {
+            }
+        };
+    }
+
+    private static BlockSnapshot snap(String blockData) {
+        return new BlockSnapshot(material(blockData), blockData,
+                List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    // Derive a plausible Material enum constant from the block-data string.
+    private static Material material(String blockData) {
+        String key = blockData.substring("minecraft:".length());
+        int bracket = key.indexOf('[');
+        if (bracket >= 0) {
+            key = key.substring(0, bracket);
+        }
+        try {
+            return Material.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return Material.STONE;
+        }
+    }
+
+    private static long fileBytes(Path db) {
+        long total = 0;
+        for (String suffix : new String[]{"", "-wal", "-shm"}) {
+            Path p = Path.of(db + suffix);
+            if (Files.exists(p)) {
+                try {
+                    total += Files.size(p);
+                } catch (java.io.IOException ignored) {
+                    // best effort
+                }
+            }
+        }
+        return total;
+    }
+
+    private static void printDbStat(Path db) {
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db);
+             Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT name, sum(pgsize) AS bytes FROM dbstat GROUP BY name ORDER BY bytes DESC")) {
+            System.out.println("per-object bytes (dbstat):");
+            while (rs.next()) {
+                System.out.printf(Locale.ROOT, "  %-16s %8.1f MiB%n",
+                        rs.getString("name"), rs.getLong("bytes") / (1024.0 * 1024.0));
+            }
+        } catch (Exception ex) {
+            System.out.println("  (dbstat unavailable: " + ex.getMessage() + ")");
+        }
+    }
+
+    private static void deleteTree(Path dir) {
+        try (var walk = Files.walk(dir)) {
+            walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (java.io.IOException ignored) {
+                    // best effort cleanup
+                }
+            });
+        } catch (java.io.IOException ignored) {
+            // best effort cleanup
+        }
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqlitePredicateToSqlTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqlitePredicateToSqlTest.java
@@ -1,0 +1,143 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the palette-resolving SQLite predicate translator.
+ * The crux: user-supplied strings/UUIDs are resolved to integer palette
+ * ids up front, so the emitted SQL is integers + fixed identifiers only —
+ * there is no string-escaping surface, and an unknown value compiles to a
+ * constant-false clause.
+ */
+class SqlitePredicateToSqlTest {
+
+    private static final UUID PLAYER = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    // Fake palette: "break"->7, "Alice"->9; PLAYER->3. Everything else absent.
+    private final SqlitePredicateToSql translator = new SqlitePredicateToSql(
+            new SqlitePredicateToSql.Palette() {
+                @Override
+                public Integer dictId(String value) {
+                    return switch (value) {
+                        case "break" -> 7;
+                        case "Alice" -> 9;
+                        default -> null;
+                    };
+                }
+
+                @Override
+                public Integer uuidId(UUID value) {
+                    return PLAYER.equals(value) ? 3 : null;
+                }
+            });
+
+    private String translate(QueryPredicate predicate) {
+        return translator.translate(List.of(predicate));
+    }
+
+    @Test
+    void resolvesStringEqualityToPaletteId() {
+        assertThat(translate(new QueryPredicate.Eq("event", "break"))).isEqualTo("event = 7");
+    }
+
+    @Test
+    void resolvesUuidEqualityToPaletteId() {
+        assertThat(translate(new QueryPredicate.Eq("source.playerId", PLAYER))).isEqualTo("player = 3");
+    }
+
+    @Test
+    void unknownValueCompilesToConstantFalse() {
+        assertThat(translate(new QueryPredicate.Eq("event", "never-seen"))).isEqualTo("0");
+    }
+
+    @Test
+    void inDropsAbsentValuesAndKeepsPresentOnes() {
+        assertThat(translate(new QueryPredicate.In("event", List.of("break", "ghost"))))
+                .isEqualTo("event IN (7)");
+        assertThat(translate(new QueryPredicate.In("event", List.of("ghost"))))
+                .isEqualTo("0");
+    }
+
+    @Test
+    void timeRangeInlinesEpochSeconds() {
+        Instant lo = Instant.ofEpochSecond(1000);
+        Instant hi = Instant.ofEpochSecond(2000);
+        assertThat(translate(new QueryPredicate.Range("occurred", lo, hi)))
+                .isEqualTo("(occurred >= 1000 AND occurred <= 2000)");
+    }
+
+    @Test
+    void coordinateRangeAlsoBoundsChunkExpressionForTheIndex() {
+        // x in [10, 40] => (x>>4) in [floorDiv(10,16), floorDiv(40,16)] = [0, 2].
+        assertThat(translate(new QueryPredicate.Range("location.x", 10, 40)))
+                .isEqualTo("(x >= 10 AND x <= 40 AND (x >> 4) >= 0 AND (x >> 4) <= 2)");
+        // Negative coordinates floor toward -inf, matching x>>4 at write time.
+        assertThat(translate(new QueryPredicate.Range("location.z", -20, -1)))
+                .isEqualTo("(z >= -20 AND z <= -1 AND (z >> 4) >= -2 AND (z >> 4) <= -1)");
+    }
+
+    @Test
+    void idEqualityMapsUuidThroughEventIdsSequence() {
+        UUID id = EventIds.newId();
+        assertThat(translate(new QueryPredicate.Eq("id", id)))
+                .isEqualTo("seq = " + EventIds.sequenceOf(id));
+    }
+
+    @Test
+    void regexOnInternedColumnIsUnsupported() {
+        // server is an interned dict column; a regex can't run against the int.
+        assertThatThrownBy(() -> translate(new QueryPredicate.Eq(
+                "server", Pattern.compile("survi.*"))))
+                .isInstanceOf(SqlitePredicateToSql.UnsupportedPredicateException.class);
+    }
+
+    @Test
+    void blobOnlyFieldIsUnsupported() {
+        assertThatThrownBy(() -> translate(new QueryPredicate.Eq("message", "hi")))
+                .isInstanceOf(SqlitePredicateToSql.UnsupportedPredicateException.class);
+    }
+
+    @Test
+    void hostileStringNeverReachesSqlOnlyItsResolvedId() {
+        // A SQL-injection attempt as an interned value resolves to "no such id"
+        // (the fake palette doesn't know it) and compiles to a constant — the
+        // raw string is never inlined into the SQL text.
+        String sql = translate(new QueryPredicate.Eq("server", "'; DROP TABLE records;--"));
+        assertThat(sql).isEqualTo("0");
+        assertThat(sql).doesNotContain("DROP");
+    }
+
+    @Test
+    void andOrNotCompose() {
+        QueryPredicate and = new QueryPredicate.And(List.of(
+                new QueryPredicate.Eq("event", "break"),
+                new QueryPredicate.Eq("source.playerId", PLAYER)));
+        assertThat(translate(and)).isEqualTo("(event = 7 AND player = 3)");
+
+        QueryPredicate not = new QueryPredicate.Not(new QueryPredicate.Eq("event", "break"));
+        assertThat(translate(not)).isEqualTo("(NOT event = 7)");
+
+        // Existence on an interned column.
+        assertThat(translate(new QueryPredicate.Exists("target", true)))
+                .isEqualTo("(target IS NOT NULL)");
+    }
+
+    @Test
+    void multipleTopLevelPredicatesJoinWithAnd() {
+        String sql = translator.translate(List.of(
+                new QueryPredicate.Eq("event", "break"),
+                new QueryPredicate.Eq("origin.kind", "Alice")));
+        assertThat(sql).isEqualTo("(event = 7 AND origin_kind = 9)");
+        assertThat(translator.translate(List.of())).isEmpty();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -1,0 +1,371 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.EntityDeathRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.event.TeleportRecord;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Embedded-SQLite store coverage (#106) — runs with no Docker, a CI win
+ * over the Testcontainers Mongo / ClickHouse ITs. Exercises the hybrid
+ * schema (simple block → columns, everything else → blob), the keyset
+ * page, the lean rollback stream in both directions, predicate pushdown +
+ * post-filter, palette interning, and retention.
+ */
+class SqliteRecordStoreTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+    // occurred is stored at second precision, so truncate fixtures to match
+    // for exact round-trip equality.
+    private static final Instant BASE = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    // Column-stored rows reconstruct expiresAt as occurred + retention, so
+    // the fixtures use occurred + RETENTION (3600s) as their expiry.
+    private static final long RETENTION = 3600L;
+
+    @TempDir
+    Path dir;
+    private SqliteRecordStore store;
+
+    @BeforeEach
+    void open() {
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"), false, RETENTION);
+    }
+
+    @AfterEach
+    void close() {
+        store.close();
+    }
+
+    // ===== Builders ============================================
+
+    private static BlockSnapshot simple(Material material, String data) {
+        return new BlockSnapshot(material, data, List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    private static BlockSnapshot sign() {
+        // A non-empty sign line => not simple => the blob path.
+        return new BlockSnapshot(Material.OAK_SIGN, "minecraft:oak_sign",
+                List.of(), List.of("line"), List.of(), List.of(), null);
+    }
+
+    private BlockBreakRecord breakAt(UUID player, String name, int x, long secondsAgo,
+                                     BlockSnapshot before, BlockSnapshot after) {
+        Instant occurred = BASE.minusSeconds(secondsAgo);
+        return new BlockBreakRecord(EventIds.newId(), "break", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(player, name),
+                new BlockLocation(WORLD, "world", x, 64, x), "srv", "STONE", before, after);
+    }
+
+    private BlockBreakRecord simpleBreak(int x) {
+        return breakAt(UUID.randomUUID(), "Alice", x, x,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+    }
+
+    private ContainerDepositRecord deposit(int slot) {
+        Instant occurred = BASE.minusSeconds(slot);
+        return new ContainerDepositRecord(EventIds.newId(), "deposit", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Bob"),
+                new BlockLocation(WORLD, "world", slot, 70, slot), "srv", "CHEST",
+                "CHEST", slot, 1,
+                new StoredItem(slot, "DIAMOND", "minecraft:diamond"), null);
+    }
+
+    private EntityDeathRecord death(String type) {
+        return new EntityDeathRecord(EventIds.newId(), "death", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Cara"),
+                new BlockLocation(WORLD, "world", 5, 64, 5), "srv", type,
+                type, UUID.randomUUID(), "PLAYER", "ENTITY_ATTACK", null);
+    }
+
+    private ChatRecord chat(String message) {
+        // "say" is the catalog event name for ChatRecord (not "chat").
+        return new ChatRecord(EventIds.newId(), "say", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Dan"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv", null,
+                message, List.of(), Map.of());
+    }
+
+    private static QueryRequest request(List<QueryPredicate> predicates) {
+        return new QueryRequest(predicates, Sort.NEWEST_FIRST, 1000,
+                EnumSet.noneOf(Flag.class), false);
+    }
+
+    private byte[] rawBlob(long seq) throws SQLException {
+        store.checkpoint();
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + store.databaseFile());
+             var ps = conn.prepareStatement("SELECT blob FROM records WHERE seq = ?")) {
+            ps.setLong(1, seq);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getBytes(1) : new byte[0];
+            }
+        }
+    }
+
+    private long rawCount(String table) throws SQLException {
+        store.checkpoint();
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + store.databaseFile());
+             var st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT count(*) FROM " + table)) {
+            return rs.next() ? rs.getLong(1) : 0L;
+        }
+    }
+
+    // ===== Tests ===============================================
+
+    @Test
+    void simpleBlockRoundTripsThroughColumnsWithNoBlob() throws SQLException {
+        BlockBreakRecord record = simpleBreak(10);
+        store.save(List.of(record));
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactly(record);
+        // The whole record reduced to columns — no per-event blob row.
+        assertThat(rawBlob(EventIds.sequenceOf(record.id()))).isNull();
+    }
+
+    @Test
+    void tileEntityBlockRoundTripsThroughBlob() throws SQLException {
+        BlockBreakRecord record = breakAt(UUID.randomUUID(), "Alice", 1, 1,
+                sign(), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(record));
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactly(record);
+        // A tile-entity block can't reduce to columns; it carries a blob.
+        assertThat(rawBlob(EventIds.sequenceOf(record.id()))).isNotEmpty();
+    }
+
+    @Test
+    void nonBlockEventsRoundTripThroughBlob() {
+        BlockPlaceRecord place = new BlockPlaceRecord(EventIds.newId(), "place", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Eve"),
+                new BlockLocation(WORLD, "world", 2, 65, 2), "srv", "DIRT",
+                simple(Material.AIR, "minecraft:air"), simple(Material.DIRT, "minecraft:dirt"));
+        TeleportRecord teleport = new TeleportRecord(EventIds.newId(), "teleport", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Finn"),
+                new BlockLocation(WORLD, "world", 3, 64, 3), "srv", null,
+                new BlockLocation(WORLD, "world", 3, 64, 3),
+                new BlockLocation(WORLD, "world", 99, 64, 99), "COMMAND");
+        List<EventRecord> records = List.of(place, deposit(4), death("ZOMBIE"), chat("hi"), teleport);
+        store.save(records);
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactlyInAnyOrderElementsOf(records);
+    }
+
+    @Test
+    void streamRollbackEffectsEmitsSimpleBlockAsPrimitives() {
+        BlockBreakRecord record = breakAt(UUID.randomUUID(), "Alice", 7, 1,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(record));
+
+        CapturingSink rollback = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, true, rollback);
+        assertThat(rollback.complex).isEmpty();
+        assertThat(rollback.blocks).singleElement().satisfies(b -> {
+            assertThat(b.data()).isEqualTo("minecraft:stone"); // rollback writes the before-state
+            assertThat(b.x()).isEqualTo(7);
+            assertThat(b.world()).isEqualTo(WORLD);
+        });
+
+        CapturingSink restore = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, false, restore);
+        assertThat(restore.blocks).singleElement().satisfies(
+                b -> assertThat(b.data()).isEqualTo("minecraft:air")); // restore writes the after-state
+    }
+
+    @Test
+    void streamRollbackEffectsEmitsContainerAndEntityAsComplexAndSkipsChat() {
+        store.save(List.of(deposit(1), death("ZOMBIE"), chat("noise")));
+
+        CapturingSink sink = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, true, sink);
+
+        // chat is filtered out at the SQL level (not rollbackable), so it
+        // never reaches the sink at all.
+        assertThat(sink.skips).isZero();
+        assertThat(sink.blocks).isEmpty();
+        assertThat(sink.complex).hasSize(2);
+        assertThat(sink.complex).anySatisfy(e ->
+                assertThat(e).isInstanceOf(RollbackEffect.ContainerSlotWrite.class));
+        assertThat(sink.complex).anySatisfy(e ->
+                assertThat(e).isInstanceOf(RollbackEffect.EntitySpawn.class));
+    }
+
+    @Test
+    void keysetPageReturnsEveryRowOnceInOrder() {
+        List<EventRecord> saved = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            saved.add(simpleBreak(i));
+        }
+        store.save(saved);
+
+        List<UUID> seen = new ArrayList<>();
+        QueryPage.Cursor cursor = null;
+        do {
+            QueryPage page = store.queryPage(request(List.of()), cursor, 7);
+            page.records().forEach(r -> seen.add(r.id()));
+            cursor = page.next();
+        } while (cursor != null);
+
+        // Newest-first is by seq (the mint sequence == rowid), so paging
+        // walks every row exactly once in reverse save order — last-minted
+        // first. seq is co-monotonic with occurred for real records.
+        List<UUID> newestFirst = new ArrayList<>(saved.stream().map(EventRecord::id).toList());
+        java.util.Collections.reverse(newestFirst);
+        assertThat(seen).containsExactlyElementsOf(newestFirst);
+    }
+
+    @Test
+    void predicatePushdownFiltersByPlayerEventAndTime() {
+        UUID alice = UUID.randomUUID();
+        BlockBreakRecord aliceBreak = breakAt(alice, "Alice", 1, 10,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        BlockBreakRecord bobBreak = breakAt(UUID.randomUUID(), "Bob", 2, 10,
+                simple(Material.DIRT, "minecraft:dirt"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(aliceBreak, bobBreak, chat("hi")));
+
+        QueryResult byPlayer = store.query(request(List.of(
+                new QueryPredicate.Eq("source.playerId", alice))));
+        assertThat(byPlayer.records()).containsExactly(aliceBreak);
+
+        QueryResult byEvent = store.query(request(List.of(
+                new QueryPredicate.Eq("event", "break"))));
+        assertThat(byEvent.records()).containsExactlyInAnyOrder(aliceBreak, bobBreak);
+
+        QueryResult byTime = store.query(request(List.of(
+                new QueryPredicate.Range("occurred", BASE.minusSeconds(20), BASE.minusSeconds(5)))));
+        assertThat(byTime.records()).containsExactlyInAnyOrder(aliceBreak, bobBreak);
+    }
+
+    @Test
+    void absentPaletteValueMatchesNothing() {
+        store.save(List.of(simpleBreak(1)));
+        QueryResult result = store.query(request(List.of(
+                new QueryPredicate.Eq("source.playerId", UUID.randomUUID())))); // never recorded
+        assertThat(result.records()).isEmpty();
+    }
+
+    @Test
+    void coordinateRangeReturnsBlocksInBox() {
+        store.save(List.of(simpleBreak(5), simpleBreak(50), simpleBreak(500)));
+        QueryResult inBox = store.query(request(List.of(
+                new QueryPredicate.Range("location.x", 0, 100),
+                new QueryPredicate.Range("location.z", 0, 100))));
+        // x and z are equal in simpleBreak(n); only n in [0,100] qualifies.
+        assertThat(inBox.records()).hasSize(2);
+    }
+
+    @Test
+    void regexPredicateFallsToPostFilter() {
+        store.save(List.of(
+                breakAt(UUID.randomUUID(), "Alice", 1, 1,
+                        simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air")),
+                breakAt(UUID.randomUUID(), "Bartholomew", 2, 1,
+                        simple(Material.DIRT, "minecraft:dirt"), simple(Material.AIR, "minecraft:air"))));
+
+        QueryResult result = store.query(request(List.of(new QueryPredicate.Eq(
+                "source.playerName", Pattern.compile("Alic.*")))));
+        assertThat(result.records()).singleElement().satisfies(
+                r -> assertThat(r.sourceName()).isEqualTo("Alice"));
+    }
+
+    @Test
+    void paletteInternsRepeatedValuesOnce() throws SQLException {
+        UUID player = UUID.randomUUID();
+        // Three breaks by one player in one world: world + player UUIDs and
+        // the "break"/"world"/"minecraft:stone"/… strings intern once each.
+        store.save(List.of(
+                breakAt(player, "Zed", 1, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air")),
+                breakAt(player, "Zed", 2, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air")),
+                breakAt(player, "Zed", 3, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air"))));
+        // Exactly two UUIDs (world + player) despite three rows.
+        assertThat(rawCount("uuids")).isEqualTo(2L);
+        // event, world-name, target(STONE), player-name, STONE/AIR materials,
+        // stone/air block-data, server, origin/source kinds — a small fixed
+        // set, NOT three-per-row.
+        assertThat(rawCount("dict")).isLessThan(12L);
+    }
+
+    @Test
+    void retentionPrunesExpiredRows() throws SQLException {
+        BlockBreakRecord fresh = simpleBreak(1);
+        // occurred is older than the retention window (3600s), so the sweep
+        // (DELETE WHERE occurred < now - retention) drops it.
+        Instant old = BASE.minusSeconds(2 * RETENTION);
+        BlockBreakRecord stale = new BlockBreakRecord(EventIds.newId(), "break",
+                old, old.plusSeconds(RETENTION),
+                Origin.player(), Source.player(UUID.randomUUID(), "Old"),
+                new BlockLocation(WORLD, "world", 9, 64, 9), "srv", "STONE",
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(fresh, stale));
+        assertThat(rawCount("records")).isEqualTo(2L);
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned).isEqualTo(1L);
+        assertThat(store.query(request(List.of())).records()).containsExactly(fresh);
+    }
+
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        record Block(UUID world, int x, int y, int z, String data) {
+        }
+
+        final List<Block> blocks = new ArrayList<>();
+        final List<RollbackEffect> complex = new ArrayList<>();
+        int skips;
+
+        @Override
+        public void block(UUID world, int x, int y, int z, String data, String expected,
+                          Instant occurred, UUID id) {
+            blocks.add(new Block(world, x, y, z, data));
+        }
+
+        @Override
+        public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+            complex.add(effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skips++;
+        }
+    }
+}

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
@@ -15,6 +15,7 @@ import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
 import net.medievalrp.spyglass.plugin.storage.IndexManager;
 import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
 import net.medievalrp.spyglass.proxy.command.SpyglassCommand;
 import net.medievalrp.spyglass.proxy.config.SpyglassProxyConfig;
 import org.slf4j.Logger;
@@ -60,7 +61,7 @@ public final class SpyglassProxy {
         }
 
         try {
-            this.recordStore = openStore(config);
+            this.recordStore = openStore(config, dataDirectory);
         } catch (RuntimeException ex) {
             logger.error("Failed to open Spyglass record store; plugin disabled.", ex);
             return;
@@ -91,7 +92,7 @@ public final class SpyglassProxy {
         }
     }
 
-    private static RecordStore openStore(SpyglassProxyConfig cfg) {
+    private static RecordStore openStore(SpyglassProxyConfig cfg, Path dataDirectory) {
         SpyglassProxyConfig.Database db = cfg.database();
         return switch (db.backend()) {
             case MONGO -> new MongoRecordStore(
@@ -103,6 +104,16 @@ public final class SpyglassProxy {
                 yield new ClickHouseRecordStore(
                         ch.host(), ch.port(), ch.database(), ch.table(),
                         ch.user(), ch.password(), ch.ssl());
+            }
+            case SQLITE -> {
+                // Read-only: the embedded file must be reachable on the
+                // proxy host (same machine / shared mount). A relative path
+                // resolves under the proxy's data directory.
+                Path configured = Path.of(db.sqlite().path());
+                Path dbPath = configured.isAbsolute()
+                        ? configured
+                        : dataDirectory.resolve(configured);
+                yield new SqliteRecordStore(dbPath, true);
             }
         };
     }

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
@@ -35,9 +35,10 @@ public record SpyglassProxyConfig(
         String backendName = root.node("database", "backend").getString("mongo").trim().toLowerCase(java.util.Locale.ROOT);
         Backend backend = switch (backendName) {
             case "clickhouse" -> Backend.CLICKHOUSE;
+            case "sqlite" -> Backend.SQLITE;
             case "mongo", "mongodb" -> Backend.MONGO;
             default -> throw new IOException("Unknown database.backend: " + backendName
-                    + " (expected 'mongo' or 'clickhouse')");
+                    + " (expected 'mongo', 'clickhouse', or 'sqlite')");
         };
 
         return new SpyglassProxyConfig(
@@ -53,7 +54,9 @@ public record SpyglassProxyConfig(
                                 root.node("database", "clickhouse", "table").getString("event_records"),
                                 root.node("database", "clickhouse", "user").getString("default"),
                                 root.node("database", "clickhouse", "password").getString(""),
-                                root.node("database", "clickhouse", "ssl").getBoolean(false))),
+                                root.node("database", "clickhouse", "ssl").getBoolean(false)),
+                        new Sqlite(
+                                root.node("database", "sqlite", "path").getString("spyglass.db"))),
                 new Defaults(
                         Duration.parse(root.node("defaults", "time").getString("4h"))),
                 new Limits(
@@ -63,7 +66,8 @@ public record SpyglassProxyConfig(
 
     public enum Backend {
         MONGO,
-        CLICKHOUSE
+        CLICKHOUSE,
+        SQLITE
     }
 
     public record Database(
@@ -71,7 +75,21 @@ public record SpyglassProxyConfig(
             String uri,
             String name,
             String collection,
-            ClickHouse clickhouse) {
+            ClickHouse clickhouse,
+            Sqlite sqlite) {
+    }
+
+    /**
+     * Embedded-SQLite location (used when {@code backend = "sqlite"}). The
+     * proxy opens this file <b>read-only</b>; it must be reachable on the
+     * proxy host's filesystem (same machine or a shared mount), since
+     * unlike Mongo / ClickHouse an embedded SQLite file is not served over
+     * the network.
+     */
+    public record Sqlite(String path) {
+        public Sqlite {
+            path = path == null || path.isBlank() ? "spyglass.db" : path.trim();
+        }
     }
 
     public record ClickHouse(
@@ -106,7 +124,8 @@ public record SpyglassProxyConfig(
                 # Spyglass plugin. Copy the database block from your Paper
                 # config.conf so this proxy reads the same backend.
                 database {
-                  # "mongo" or "clickhouse" - must match the Paper-side backend.
+                  # "mongo", "clickhouse", or "sqlite" - must match the
+                  # Paper-side backend.
                   backend = "mongo"
 
                   # Mongo (used when backend = "mongo")
@@ -123,6 +142,15 @@ public record SpyglassProxyConfig(
                     user = "default"
                     password = ""
                     ssl = false
+                  }
+
+                  # SQLite (used when backend = "sqlite"). The proxy opens
+                  # this file READ-ONLY, so it must sit on the proxy host's
+                  # filesystem (same machine as the Paper server, or a shared
+                  # mount) - an embedded SQLite file is not served over the
+                  # network the way Mongo / ClickHouse are.
+                  sqlite {
+                    path = "spyglass.db"
                   }
                 }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -97,14 +97,17 @@ import net.medievalrp.spyglass.plugin.rollback.ClickHouseUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.MongoUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.RollbackPhysicsBlocker;
+import net.medievalrp.spyglass.plugin.rollback.SqliteUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
 import net.medievalrp.spyglass.plugin.storage.IndexManager;
 import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
 import net.medievalrp.spyglass.plugin.storage.SynthesizingRecordStore;
 import net.medievalrp.spyglass.plugin.salvage.ClickHouseSalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.MongoSalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.SqliteSalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.SalvageCapturer;
 import net.medievalrp.spyglass.plugin.salvage.SalvageGui;
 import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
@@ -112,6 +115,7 @@ import net.medievalrp.spyglass.plugin.salvage.SalvageWithdrawLogger;
 import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.tool.ClickHouseToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.MongoToolStateStore;
+import net.medievalrp.spyglass.plugin.command.service.tool.SqliteToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.ToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.WandInteractListener;
 import net.medievalrp.spyglass.plugin.worldedit.WorldEditLifecycleListener;
@@ -185,6 +189,24 @@ public final class SpyglassPlugin extends JavaPlugin {
                             chStore.client(), ch.database());
                     salvageStore = new ClickHouseSalvageStore(
                             chStore.client(), ch.database(), 30L);
+                }
+                case SQLITE -> {
+                    // One embedded file holds every store. A relative path
+                    // resolves under the plugin data folder.
+                    java.nio.file.Path configured =
+                            java.nio.file.Path.of(config.database().sqlite().path());
+                    java.nio.file.Path dbPath = configured.isAbsolute()
+                            ? configured
+                            : getDataFolder().toPath().resolve(configured);
+                    // Retention drives the SQLite TTL sweep and the reconstructed
+                    // expiry on column-stored rows (which don't carry an
+                    // expires_at column).
+                    SqliteRecordStore sqliteStore = new SqliteRecordStore(
+                            dbPath, false, config.storage().retention().seconds());
+                    recordStore = sqliteStore;
+                    undoStack = new SqliteUndoStack(sqliteStore);
+                    toolStateStore = new SqliteToolStateStore(sqliteStore);
+                    salvageStore = new SqliteSalvageStore(sqliteStore, 30L);
                 }
             }
             if (config.storage().rolledAuditSynthesized()) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/SqliteToolStateStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/SqliteToolStateStore.java
@@ -1,0 +1,70 @@
+package net.medievalrp.spyglass.plugin.command.service.tool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * SQLite-backed {@link ToolStateStore} — a small {@code (player_id,
+ * enabled_at)} table in the shared Spyglass database. Point operations on
+ * a {@code TEXT PRIMARY KEY}, so {@link #enable} / {@link #disable} are
+ * O(log N) with no scan, the same role the EmbeddedRocksDB table plays on
+ * the ClickHouse backend.
+ */
+@ApiStatus.Internal
+public final class SqliteToolStateStore implements ToolStateStore {
+
+    private final SqliteRecordStore store;
+
+    public SqliteToolStateStore(SqliteRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS tool_states ("
+                        + "player_id TEXT PRIMARY KEY, enabled_at INTEGER)");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Collection<UUID> loadActive() {
+        return store.withReadConnection(conn -> {
+            List<UUID> out = new ArrayList<>();
+            try (var st = conn.createStatement();
+                 var rs = st.executeQuery("SELECT player_id FROM tool_states")) {
+                while (rs.next()) {
+                    out.add(UUID.fromString(rs.getString("player_id")));
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public void enable(UUID playerId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement(
+                    "INSERT OR REPLACE INTO tool_states (player_id, enabled_at) VALUES (?, ?)")) {
+                ps.setString(1, playerId.toString());
+                ps.setLong(2, System.currentTimeMillis());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void disable(UUID playerId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM tool_states WHERE player_id = ?")) {
+                ps.setString(1, playerId.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -65,9 +65,10 @@ public record SpyglassConfig(
         String backendName = root.node("database", "backend").getString("mongo").trim().toLowerCase(java.util.Locale.ROOT);
         Backend backend = switch (backendName) {
             case "clickhouse" -> Backend.CLICKHOUSE;
+            case "sqlite" -> Backend.SQLITE;
             case "mongo", "mongodb" -> Backend.MONGO;
             default -> throw new IOException("Unknown database.backend: " + backendName
-                    + " (expected 'mongo' or 'clickhouse')");
+                    + " (expected 'mongo', 'clickhouse', or 'sqlite')");
         };
         return new SpyglassConfig(
                 new Database(
@@ -82,7 +83,9 @@ public record SpyglassConfig(
                                 root.node("database", "clickhouse", "table").getString("event_records"),
                                 root.node("database", "clickhouse", "user").getString("default"),
                                 root.node("database", "clickhouse", "password").getString(""),
-                                root.node("database", "clickhouse", "ssl").getBoolean(false))),
+                                root.node("database", "clickhouse", "ssl").getBoolean(false)),
+                        new Sqlite(
+                                root.node("database", "sqlite", "path").getString("spyglass.db"))),
                 new Storage(
                         Duration.parse(root.node("storage", "retention").getString("4w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
@@ -150,10 +153,17 @@ public record SpyglassConfig(
      * undo ledger and the wand-state ledger. Mongo is not required at
      * all when this backend is selected. Operators run one or the
      * other, never both.
+     *
+     * <p>{@link #SQLITE} is the zero-ops option: every store the plugin
+     * needs (records, undo ledger, wand state, salvage) lives in one
+     * embedded SQLite file ({@code database.sqlite.path}), so a small or
+     * medium server runs Spyglass with no external database process at
+     * all.
      */
     public enum Backend {
         MONGO,
-        CLICKHOUSE
+        CLICKHOUSE,
+        SQLITE
     }
 
     public record Database(
@@ -161,7 +171,23 @@ public record SpyglassConfig(
             String uri,
             String name,
             String collection,
-            ClickHouse clickhouse) {
+            ClickHouse clickhouse,
+            Sqlite sqlite) {
+    }
+
+    /**
+     * Embedded-SQLite settings (used when {@code backend = "sqlite"}).
+     *
+     * @param path location of the SQLite database file. A relative path
+     *     is resolved against the plugin data folder, so the default
+     *     {@code "spyglass.db"} lands at {@code plugins/Spyglass/spyglass.db}.
+     *     The {@code -wal} / {@code -shm} sidecar files SQLite creates in
+     *     WAL mode live alongside it.
+     */
+    public record Sqlite(String path) {
+        public Sqlite {
+            path = path == null || path.isBlank() ? "spyglass.db" : path.trim();
+        }
     }
 
     public record ClickHouse(

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/SqliteUndoStack.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/SqliteUndoStack.java
@@ -1,0 +1,151 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * SQLite-backed {@link UndoStack}. One small row per undo operation,
+ * stored <b>by reference</b> (the resolved query that replays the
+ * original op in the opposite direction — see {@code UndoReferenceBson}),
+ * mirroring the reference-only contract the Mongo / ClickHouse stacks
+ * settled on (#17).
+ *
+ * <p>The SQLite backend is new, so there is no legacy chunked-row shape
+ * to read — every row is a reference, surfaced as {@link ReplayReference}.
+ * A 24h horizon is enforced with an opportunistic delete on each push
+ * (SQLite has no native TTL), matching the 1-day window the other
+ * backends TTL.
+ */
+@ApiStatus.Internal
+public final class SqliteUndoStack implements UndoStack {
+
+    private static final long TTL_MS = java.util.concurrent.TimeUnit.DAYS.toMillis(1);
+
+    private final SqliteRecordStore store;
+
+    public SqliteUndoStack(SqliteRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS undo_history ("
+                        + "operation_id TEXT PRIMARY KEY, "
+                        + "player_id TEXT NOT NULL, "
+                        + "created_at INTEGER NOT NULL, "
+                        + "operation_type TEXT NOT NULL, "
+                        + "reference TEXT NOT NULL)");
+                st.execute("CREATE INDEX IF NOT EXISTS idx_undo_player "
+                        + "ON undo_history(player_id, created_at)");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void pushReference(UUID playerId, String operationType, String referenceBase64) {
+        UUID operationId = UUID.randomUUID();
+        long now = System.currentTimeMillis();
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("INSERT INTO undo_history "
+                    + "(operation_id, player_id, created_at, operation_type, reference) "
+                    + "VALUES (?, ?, ?, ?, ?)")) {
+                ps.setString(1, operationId.toString());
+                ps.setString(2, playerId.toString());
+                ps.setLong(3, now);
+                ps.setString(4, operationType + REF_MARKER);
+                ps.setString(5, referenceBase64);
+                ps.executeUpdate();
+            }
+            // Opportunistic TTL: drop anything past the 24h window.
+            try (var ps = conn.prepareStatement("DELETE FROM undo_history WHERE created_at < ?")) {
+                ps.setLong(1, now - TTL_MS);
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Optional<Popped> openLatest(UUID playerId) {
+        return store.withReadConnection(conn -> {
+            try (var ps = conn.prepareStatement("SELECT operation_id, created_at, "
+                    + "operation_type, reference FROM undo_history "
+                    + "WHERE player_id = ? AND created_at >= ? "
+                    + "ORDER BY created_at DESC LIMIT 1")) {
+                ps.setString(1, playerId.toString());
+                ps.setLong(2, System.currentTimeMillis() - TTL_MS);
+                try (var rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return Optional.empty();
+                    }
+                    UUID operationId = UUID.fromString(rs.getString("operation_id"));
+                    Instant createdAt = Instant.ofEpochMilli(rs.getLong("created_at"));
+                    String storedType = rs.getString("operation_type");
+                    String reference = rs.getString("reference");
+                    String type = storedType.endsWith(REF_MARKER)
+                            ? storedType.substring(0, storedType.length() - REF_MARKER.length())
+                            : storedType;
+                    return Optional.of(new Reference(operationId, createdAt, type, reference));
+                }
+            }
+        });
+    }
+
+    private void tombstone(UUID operationId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM undo_history WHERE operation_id = ?")) {
+                ps.setString(1, operationId.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    private final class Reference implements ReplayReference {
+
+        private final UUID operationId;
+        private final Instant createdAt;
+        private final String operationType;
+        private String reference;
+
+        private Reference(UUID operationId, Instant createdAt,
+                          String operationType, String reference) {
+            this.operationId = operationId;
+            this.createdAt = createdAt;
+            this.operationType = operationType;
+            this.reference = reference;
+        }
+
+        @Override
+        public UUID operationId() {
+            return operationId;
+        }
+
+        @Override
+        public Instant createdAt() {
+            return createdAt;
+        }
+
+        @Override
+        public String operationType() {
+            return operationType;
+        }
+
+        @Override
+        public String referenceBase64() {
+            return reference;
+        }
+
+        @Override
+        public void tombstone() {
+            SqliteUndoStack.this.tombstone(operationId);
+        }
+
+        @Override
+        public void close() {
+            reference = null;
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SqliteSalvageStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SqliteSalvageStore.java
@@ -1,0 +1,219 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.BsonBlobs;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * SQLite-backed {@link SalvageStore}. A row per captured container
+ * inventory in the shared Spyglass database, keyed on {@code id} so an
+ * extraction's {@link #replaceItems} overwrites in place and
+ * {@link #delete} removes the emptied snapshot. Items are a {@code |}-
+ * joined list of {@link BsonBlobs#encodeStoredItem} blobs — the base64
+ * alphabet never contains {@code |}, so the split is unambiguous.
+ * Modeled on {@code ClickHouseSalvageStore}; self-creates its table.
+ */
+@ApiStatus.Internal
+public final class SqliteSalvageStore implements SalvageStore {
+
+    private final SqliteRecordStore store;
+    private final long ttlMs;
+
+    public SqliteSalvageStore(SqliteRecordStore store, long ttlDays) {
+        this.store = store;
+        this.ttlMs = ttlDays > 0 ? java.util.concurrent.TimeUnit.DAYS.toMillis(ttlDays) : 0L;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS salvage ("
+                        + "id TEXT PRIMARY KEY, "
+                        + "rollback_op_id TEXT, "
+                        + "world_id TEXT, world_name TEXT, "
+                        + "x INTEGER, y INTEGER, z INTEGER, "
+                        + "container_type TEXT, operator_name TEXT, "
+                        + "captured_at INTEGER, items TEXT)");
+                st.execute("CREATE INDEX IF NOT EXISTS idx_salvage_captured ON salvage(captured_at)");
+                st.execute("CREATE INDEX IF NOT EXISTS idx_salvage_rollback ON salvage(rollback_op_id)");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void save(SalvageSnapshot snapshot) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("INSERT OR REPLACE INTO salvage "
+                    + "(id, rollback_op_id, world_id, world_name, x, y, z, "
+                    + "container_type, operator_name, captured_at, items) "
+                    + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                ps.setString(1, snapshot.id().toString());
+                ps.setString(2, snapshot.rollbackOpId() == null ? null : snapshot.rollbackOpId().toString());
+                ps.setString(3, snapshot.worldId() == null ? null : snapshot.worldId().toString());
+                ps.setString(4, snapshot.worldName());
+                ps.setInt(5, snapshot.x());
+                ps.setInt(6, snapshot.y());
+                ps.setInt(7, snapshot.z());
+                ps.setString(8, snapshot.containerType());
+                ps.setString(9, snapshot.operatorName());
+                ps.setLong(10, snapshot.capturedAt().toEpochMilli());
+                ps.setString(11, encodeItems(snapshot.items()));
+                ps.executeUpdate();
+            }
+            pruneExpired(conn);
+            return null;
+        });
+    }
+
+    @Override
+    public List<SalvageSnapshot> list(int limit) {
+        return store.withReadConnection(conn -> {
+            List<SalvageSnapshot> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement(selectColumns()
+                    + " FROM salvage ORDER BY captured_at DESC LIMIT ?")) {
+                ps.setInt(1, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        out.add(fromRow(rs));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public List<RollbackGroup> listRollbacks(int limit) {
+        return store.withReadConnection(conn -> {
+            List<RollbackGroup> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement("SELECT rollback_op_id, count(*) AS c, "
+                    + "max(operator_name) AS op, max(captured_at) AS latest FROM salvage "
+                    + "WHERE rollback_op_id IS NOT NULL "
+                    + "GROUP BY rollback_op_id ORDER BY latest DESC LIMIT ?")) {
+                ps.setInt(1, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        String rollbackId = rs.getString("rollback_op_id");
+                        out.add(new RollbackGroup(UUID.fromString(rollbackId), rs.getInt("c"),
+                                rs.getString("op"), Instant.ofEpochMilli(rs.getLong("latest"))));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public List<SalvageSnapshot> listByRollback(UUID rollbackId, int limit) {
+        return store.withReadConnection(conn -> {
+            List<SalvageSnapshot> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement(selectColumns()
+                    + " FROM salvage WHERE rollback_op_id = ? ORDER BY captured_at DESC LIMIT ?")) {
+                ps.setString(1, rollbackId.toString());
+                ps.setInt(2, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        out.add(fromRow(rs));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public Optional<SalvageSnapshot> get(UUID id) {
+        return store.withReadConnection(conn -> {
+            try (var ps = conn.prepareStatement(selectColumns() + " FROM salvage WHERE id = ? LIMIT 1")) {
+                ps.setString(1, id.toString());
+                try (var rs = ps.executeQuery()) {
+                    return rs.next() ? Optional.of(fromRow(rs)) : Optional.<SalvageSnapshot>empty();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void replaceItems(UUID id, List<StoredItem> remaining) {
+        get(id).ifPresent(current -> save(current.withItems(remaining)));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM salvage WHERE id = ?")) {
+                ps.setString(1, id.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    private void pruneExpired(java.sql.Connection conn) throws SQLException {
+        if (ttlMs <= 0) {
+            return;
+        }
+        try (var ps = conn.prepareStatement("DELETE FROM salvage WHERE captured_at < ?")) {
+            ps.setLong(1, System.currentTimeMillis() - ttlMs);
+            ps.executeUpdate();
+        }
+    }
+
+    private static String selectColumns() {
+        return "SELECT id, rollback_op_id, world_id, world_name, x, y, z, "
+                + "container_type, operator_name, captured_at, items";
+    }
+
+    private static SalvageSnapshot fromRow(ResultSet rs) throws SQLException {
+        String rollbackId = rs.getString("rollback_op_id");
+        String worldId = rs.getString("world_id");
+        return new SalvageSnapshot(
+                UUID.fromString(rs.getString("id")),
+                rollbackId == null ? null : UUID.fromString(rollbackId),
+                worldId == null ? null : UUID.fromString(worldId),
+                rs.getString("world_name"),
+                rs.getInt("x"), rs.getInt("y"), rs.getInt("z"),
+                rs.getString("container_type"),
+                rs.getString("operator_name"),
+                Instant.ofEpochMilli(rs.getLong("captured_at")),
+                decodeItems(rs.getString("items")));
+    }
+
+    // Items as a '|'-joined list of base64 blobs; the base64 alphabet never
+    // contains '|', so the split is unambiguous.
+    static String encodeItems(List<StoredItem> items) {
+        StringBuilder sb = new StringBuilder();
+        for (StoredItem item : items) {
+            String enc = BsonBlobs.encodeStoredItem(item);
+            if (enc != null) {
+                if (sb.length() > 0) {
+                    sb.append('|');
+                }
+                sb.append(enc);
+            }
+        }
+        return sb.toString();
+    }
+
+    static List<StoredItem> decodeItems(String blob) {
+        List<StoredItem> items = new ArrayList<>();
+        if (blob == null || blob.isEmpty()) {
+            return items;
+        }
+        for (String part : blob.split("\\|")) {
+            if (!part.isEmpty()) {
+                StoredItem item = BsonBlobs.decodeStoredItem(part);
+                if (item != null) {
+                    items.add(item);
+                }
+            }
+        }
+        return items;
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -1,14 +1,21 @@
 database {
   # Which backend stores Spyglass data. Pick one — operators run
-  # either MongoDB or ClickHouse, not both. The chosen backend stores
-  # the primary EventRecord stream AND the auxiliary UndoHistory /
-  # Tools collections; the unused backend block is ignored.
+  # exactly one of MongoDB, ClickHouse, or SQLite, never several. The
+  # chosen backend stores the primary EventRecord stream AND the
+  # auxiliary UndoHistory / Tools / Salvage collections; the unused
+  # backend blocks are ignored.
   #
   # "mongo"      — MongoDB; production-tested default.
   # "clickhouse" — ClickHouse; columnar, ~3-4x storage compression,
   #                ~10x faster on full-table analytics, ~5-15x slower
   #                on per-player /spyglass search lookups (architectural
   #                trade-off — sparse primary index vs. B-tree).
+  # "sqlite"     — embedded SQLite file; zero external database to run.
+  #                The zero-ops option for small/medium servers: every
+  #                store lives in one file (database.sqlite.path).
+  #                Palette-interned + chunk-bucketed, so it stays smaller
+  #                on disk than CoreProtect's SQLite while holding 20 TPS
+  #                on rollback.
   backend = "mongo"
 
   # The defaults below assume the database lives on THIS host. Before
@@ -30,6 +37,16 @@ database {
     user = "default"         # ClickHouse user
     password = ""            # password for that user ("" = none)
     ssl = false              # true to connect over HTTPS/TLS instead of plain HTTP
+  }
+
+  # SQLite location (used when backend = "sqlite").
+  sqlite {
+    # Database file. A relative path is resolved against the plugin data
+    # folder, so the default lands at plugins/Spyglass/spyglass.db. WAL
+    # mode means two sidecar files (spyglass.db-wal, spyglass.db-shm) sit
+    # next to it. Put it on a local disk (not a network mount) for the
+    # WAL locking to behave.
+    path = "spyglass.db"
   }
 }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/sqlite/SqliteAuxStoresTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/sqlite/SqliteAuxStoresTest.java
@@ -1,0 +1,120 @@
+package net.medievalrp.spyglass.plugin.sqlite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.command.service.tool.SqliteToolStateStore;
+import net.medievalrp.spyglass.plugin.rollback.SqliteUndoStack;
+import net.medievalrp.spyglass.plugin.rollback.UndoStack;
+import net.medievalrp.spyglass.plugin.salvage.SalvageSnapshot;
+import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.SqliteSalvageStore;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the three SQLite auxiliary stores (#106) — undo ledger, wand
+ * state, salvage — sharing the record store's connection. No Docker.
+ */
+class SqliteAuxStoresTest {
+
+    @TempDir
+    Path dir;
+    private SqliteRecordStore store;
+
+    @BeforeEach
+    void open() {
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"));
+    }
+
+    @AfterEach
+    void close() {
+        store.close();
+    }
+
+    @Test
+    void undoPushOpenAndTombstone() {
+        SqliteUndoStack undo = new SqliteUndoStack(store);
+        UUID player = UUID.randomUUID();
+        assertThat(undo.openLatest(player)).isEmpty();
+
+        undo.pushReference(player, "ROLLBACK", "ref-blob-base64");
+        Optional<UndoStack.Popped> popped = undo.openLatest(player);
+        assertThat(popped).isPresent();
+        UndoStack.Popped op = popped.get();
+        assertThat(op).isInstanceOf(UndoStack.ReplayReference.class);
+        assertThat(op.operationType()).isEqualTo("ROLLBACK"); // marker stripped
+        assertThat(((UndoStack.ReplayReference) op).referenceBase64()).isEqualTo("ref-blob-base64");
+
+        op.tombstone();
+        assertThat(undo.openLatest(player)).isEmpty();
+    }
+
+    @Test
+    void undoReturnsNewestPerPlayer() {
+        SqliteUndoStack undo = new SqliteUndoStack(store);
+        UUID player = UUID.randomUUID();
+        undo.pushReference(player, "ROLLBACK", "older");
+        undo.pushReference(player, "RESTORE", "newer");
+        UndoStack.Popped op = undo.openLatest(player).orElseThrow();
+        assertThat(op.operationType()).isEqualTo("RESTORE");
+        assertThat(((UndoStack.ReplayReference) op).referenceBase64()).isEqualTo("newer");
+    }
+
+    @Test
+    void toolStateEnableDisableLoad() {
+        SqliteToolStateStore tools = new SqliteToolStateStore(store);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        assertThat(tools.loadActive()).isEmpty();
+
+        tools.enable(a);
+        tools.enable(b);
+        tools.enable(a); // idempotent upsert
+        assertThat(tools.loadActive()).containsExactlyInAnyOrder(a, b);
+
+        tools.disable(a);
+        assertThat(tools.loadActive()).containsExactly(b);
+    }
+
+    @Test
+    void salvageSaveGetReplaceDelete() {
+        SqliteSalvageStore salvage = new SqliteSalvageStore(store, 30L);
+        UUID id = UUID.randomUUID();
+        UUID rollbackOp = UUID.randomUUID();
+        SalvageSnapshot snapshot = new SalvageSnapshot(id, rollbackOp,
+                UUID.randomUUID(), "world", 1, 64, 2, "CHEST", "Operator",
+                java.time.Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS),
+                List.of(new StoredItem(0, "DIAMOND", "minecraft:diamond"),
+                        new StoredItem(1, "GOLD_INGOT", "minecraft:gold_ingot")));
+
+        salvage.save(snapshot);
+        Optional<SalvageSnapshot> fetched = salvage.get(id);
+        assertThat(fetched).isPresent();
+        assertThat(fetched.get().items()).hasSize(2);
+        assertThat(fetched.get().containerType()).isEqualTo("CHEST");
+        assertThat(fetched.get().operatorName()).isEqualTo("Operator");
+
+        assertThat(salvage.list(10)).hasSize(1);
+        List<SalvageStore.RollbackGroup> groups = salvage.listRollbacks(10);
+        assertThat(groups).singleElement().satisfies(g -> {
+            assertThat(g.rollbackId()).isEqualTo(rollbackOp);
+            assertThat(g.containerCount()).isEqualTo(1);
+        });
+        assertThat(salvage.listByRollback(rollbackOp, 10)).hasSize(1);
+
+        salvage.replaceItems(id, List.of(new StoredItem(0, "DIAMOND", "minecraft:diamond")));
+        assertThat(salvage.get(id).orElseThrow().items()).hasSize(1);
+
+        salvage.delete(id);
+        assertThat(salvage.get(id)).isEmpty();
+        assertThat(salvage.list(10)).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #106.

A third, zero-ops Spyglass backend: everything (events, undo ledger, wand state, salvage) in one embedded SQLite file. `database.backend = "sqlite"`. Default stays Mongo; nothing existing changes.

## Why it stays small (the design that beats CP·SQLite)

Four levers earn back the density Spyglass's richer records would otherwise cost:

- **Palette interning** — block-data/event/server strings in a `dict` table; world/player UUIDs (with names) in a `uuids` table; rows hold small int refs.
- **Hybrid schema** — a clean player-sourced block edit lives entirely in indexed columns; only complex records carry one `deflate(BSON(record))` blob the lean rollback never decodes.
- **`seq` is the sort key** — the EventIds sequence is the SQLite `rowid`, co-monotonic with `occurred`, so sort/keyset is on `seq` alone: `occurred` leaves every index and the time index is gone.
- **Derived/folded columns** — material from block-data, names from the UUID palette, expiry from retention, and a chunk-bucket expression index (`x>>4, z>>4`).

## Benchmark (measured in-JVM, same //replace-cube as CP's figure)

`./gradlew :spyglass-core:sqliteBench`:

| @ 2,000,000 block records | Spyglass·SQLite | CoreProtect·SQLite |
|---|---|---|
| On-disk (db + indexes) | **~156 MiB** (table ~81, indexes ~75) | ~160 MiB |
| Rollback read (2M lean keyset sweep) | **~1 s** (~2.0M effects/s) | n/a |

## Verification

- `./gradlew check` green (Docker present, so the Mongo/ClickHouse ITs ran too).
- New tests run **without Docker**: round-trip parity across event types, rollback both directions, keyset pagination, predicate pushdown + post-filter, interning, retention, aux stores.
- Security: the translator resolves every user value to an int palette ref up front, so no string reaches the SQL text; aux stores fully parameterized.

### Not run here (needs the live regression server)

The live-server proofs are wired but not executed in this session: `SG_BACKEND=sqlite CP_BACKEND=sqlite node regression/bot/compare.js` for in-world TPS, plus the distribution / multi-edit ordering proofs. The disk target is measured-and-met; the in-world TPS is the inherited property of the shared off-main engine.