### PR TITLE
feat: ship SQLite as the default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Spyglass runs on SQLite, MongoDB, or ClickHouse. The embedded SQLite backend nee
 - Paper 1.21.8 or newer 1.21.x
 - Java 21
 - A database, one of:
-  - Embedded SQLite, no external database (set `database.backend = "sqlite"`); writes to a file under the plugin folder
-  - MongoDB at `mongodb://localhost:27017` (default)
-  - ClickHouse (set `database.backend = "clickhouse"` in config)
+  - Embedded SQLite, no external database (the default); writes to a file under the plugin folder
+  - MongoDB (set `database.backend = "mongo"`) at `mongodb://localhost:27017`
+  - ClickHouse (set `database.backend = "clickhouse"`)
 - Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for WorldEdit-edit capture and `-we` queries. Capture hooks the edit-session pipeline, not command names, so every block-mutating operation is recorded — `//set`, `//replace`, `//walls`, `//overlay`, `//paste`, schematic paste, brushes, generation, `//move`/`//stack`, and `//undo`/`//redo` alike — for player and non-player (console/plugin) edits
 
 ## Commands

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -62,7 +62,7 @@ public record SpyglassConfig(
 
         java.util.List<String> commandRedact = parseCommandRedact(root);
 
-        String backendName = root.node("database", "backend").getString("mongo").trim().toLowerCase(java.util.Locale.ROOT);
+        String backendName = root.node("database", "backend").getString("sqlite").trim().toLowerCase(java.util.Locale.ROOT);
         Backend backend = switch (backendName) {
             case "clickhouse" -> Backend.CLICKHOUSE;
             case "sqlite" -> Backend.SQLITE;

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -5,18 +5,20 @@ database {
   # auxiliary UndoHistory / Tools / Salvage collections; the unused
   # backend blocks are ignored.
   #
-  # "mongo"      — MongoDB; production-tested default.
+  # "sqlite"     — embedded SQLite file; the default. Zero external
+  #                database to run: every store (events, undo, wand state,
+  #                salvage) lives in one file (database.sqlite.path).
+  #                Palette-interned + chunk-bucketed, so it stays smaller
+  #                on disk than CoreProtect's SQLite while holding 20 TPS
+  #                on rollback. The zero-ops choice for small/medium servers.
+  # "mongo"      — MongoDB; the document-store option when you outgrow a
+  #                single file.
   # "clickhouse" — ClickHouse; columnar, ~3-4x storage compression,
   #                ~10x faster on full-table analytics, ~5-15x slower
   #                on per-player /spyglass search lookups (architectural
-  #                trade-off — sparse primary index vs. B-tree).
-  # "sqlite"     — embedded SQLite file; zero external database to run.
-  #                The zero-ops option for small/medium servers: every
-  #                store lives in one file (database.sqlite.path).
-  #                Palette-interned + chunk-bucketed, so it stays smaller
-  #                on disk than CoreProtect's SQLite while holding 20 TPS
-  #                on rollback.
-  backend = "mongo"
+  #                trade-off — sparse primary index vs. B-tree). For the
+  #                largest servers.
+  backend = "sqlite"
 
   # The defaults below assume the database lives on THIS host. Before
   # pointing them at another machine (shared store, Velocity search),


### PR DESCRIPTION
Makes `database.backend = "sqlite"` the shipped default (bundled `config.conf` + the code fallback when the key is absent), so a fresh install runs with no external database. It's the fastest rollback of the three backends (the new perf-table column) and zero-ops; Mongo/ClickHouse are one config line away.

- Existing installs read the backend from their own on-disk `config.conf`, so they're unaffected.
- The Velocity proxy default stays `mongo`: the proxy does cross-server search over a shared network store, which an embedded single-file SQLite can't serve.
- `./gradlew check` green; no test pins the backend default.