### PR TITLE
fix(pipeline): bound the recorder queue so big WorldEdit pastes can't OOM the server (#119)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -249,7 +249,8 @@ public final class SpyglassPlugin extends JavaPlugin {
         }
 
         recorder = new AsyncRecorder(
-                config.storage().queueCapacity(), recordStore, wal, getLogger());
+                config.storage().queueCapacity(), config.storage().queueMax(),
+                recordStore, wal, Bukkit::isPrimaryThread, getLogger());
         // Publish RecordCommittedEvent to Bukkit listeners on every
         // intake. Done via a hook (rather than a direct Bukkit call
         // inside AsyncRecorder) so the recorder stays unit-testable

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -89,6 +89,7 @@ public record SpyglassConfig(
                 new Storage(
                         Duration.parse(root.node("storage", "retention").getString("4w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
+                        root.node("storage", "queue-max").getInt(500_000),
                         Duration.parse(root.node("storage", "flush-timeout").getString("5s")),
                         parseDurability(root.node("storage", "durability").getString("ram")),
                         "synthesized".equalsIgnoreCase(
@@ -214,6 +215,14 @@ public record SpyglassConfig(
      *                      back-compat; semantically it's the
      *                      warn threshold passed to
      *                      {@link net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder}.
+     * @param queueMax      <b>Hard ceiling</b> on the ingest queue. When the
+     *                      queue reaches this depth the off-main bulk-edit
+     *                      firehoses (WorldEdit / FAWE) backpressure — they
+     *                      block until the drain frees space — so a huge paste
+     *                      can't grow the queue into an OutOfMemoryError. The
+     *                      main thread is never blocked. {@code 0} restores the
+     *                      legacy unbounded queue. Must sit above
+     *                      {@code queueCapacity} so the warning precedes it.
      * @param flushTimeout  upper bound on how long {@code onDisable} will
      *                      wait for the queue to drain before returning.
      * @param durability    how aggressive the write path is about
@@ -230,7 +239,8 @@ public record SpyglassConfig(
      *                      One fsync amortised over a 512-row batch is
      *                      cheap; per-event overhead is negligible.
      */
-    public record Storage(Duration retention, int queueCapacity, Duration flushTimeout,
+    public record Storage(Duration retention, int queueCapacity, int queueMax,
+                          Duration flushTimeout,
                           Durability durability, boolean rolledAuditSynthesized) {
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -7,6 +7,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import net.medievalrp.spyglass.api.event.EventRecord;
@@ -19,20 +20,29 @@ import org.jetbrains.annotations.ApiStatus;
  * out to the {@link RecordStore} with exponential-backoff retry on
  * transient failures.
  *
- * <h2>No-drop guarantee at intake</h2>
+ * <h2>Bounded queue with off-main backpressure</h2>
  *
- * The queue is <b>unbounded</b>. {@link #record} never rejects a record,
- * no matter how far behind the drain is. This matches the v1
- * v1 contract (every event that fires a listener reaches the persistence
- * pipeline) and is the behaviour operators expect from an
- * audit-logging plugin.
+ * The queue is bounded by {@code queueMax} (the {@code storage.queue-max}
+ * config). When an <b>off-main</b> producer — the WorldEdit build stage
+ * (via {@link #recordAll}) or FAWE (via {@link #record} on its own worker
+ * threads) — would enqueue while the queue is already at the ceiling, it
+ * <b>blocks</b> until the drain frees space. This paces the bulk-edit
+ * firehoses to the drain so a multi-million-block paste can never grow the
+ * queue past the cap into an {@link OutOfMemoryError}. Nothing is dropped
+ * at intake: a parked producer resumes the instant space opens.
  *
- * <p>The {@code warnThreshold} passed to the constructor is a soft
- * signal, <i>not</i> a ceiling: crossing it logs a warning to give the
- * operator an early heads-up that Mongo may be lagging, but the queue
- * keeps accepting records. Warnings fire at the first crossing and at
- * doubling intervals thereafter, so a genuine outage surfaces its
- * growth shape in the log without flooding it.
+ * <p>The Bukkit primary thread is <b>never</b> blocked. Its per-event
+ * listeners record at a low rate and must not stall a tick, so they are
+ * always admitted even at the ceiling — a small, bounded overshoot that
+ * keeps the v1 no-drop guarantee for the main-thread audit path. Set
+ * {@code queueMax <= 0} ({@code storage.queue-max = 0}) to restore the
+ * legacy fully-unbounded queue.
+ *
+ * <p>{@code warnThreshold} ({@code storage.queue-capacity}) is a softer,
+ * lower signal that sits below the ceiling: crossing it logs a warning so
+ * operators notice drain lag early, before backpressure engages. Warnings
+ * fire at the first crossing and at doubling intervals thereafter, so a
+ * genuine outage surfaces its growth shape in the log without flooding it.
  *
  * <h2>The only scenarios where records can be lost</h2>
  *
@@ -60,6 +70,12 @@ public final class AsyncRecorder implements Recorder {
 
     private final LinkedBlockingDeque<EventRecord> queue = new LinkedBlockingDeque<>();
     private final long warnThreshold;
+    // Hard queue ceiling that off-main producers backpressure against;
+    // <= 0 means unbounded (legacy behaviour). See awaitCapacityIfBlockable.
+    private final long queueMax;
+    // Reports whether the calling thread is the Bukkit server thread, which
+    // is never blocked by the ceiling. Bukkit::isPrimaryThread in production.
+    private final BooleanSupplier primaryThread;
     private final RecordStore store;
     private final WalDurability wal;
     private final Logger logger;
@@ -68,6 +84,12 @@ public final class AsyncRecorder implements Recorder {
     private final AtomicLong drained = new AtomicLong();
     private final AtomicLong dropped = new AtomicLong();
     private final AtomicLong lastWarnedDepth = new AtomicLong();
+    // Backpressure gate: off-main producers park on spaceMonitor when the
+    // queue is at queueMax; the drain notifies after it frees space. The
+    // waiter count keeps the drain's wake check lock-free (a plain read)
+    // whenever nobody is parked, which is the common case.
+    private final Object spaceMonitor = new Object();
+    private final AtomicLong backpressureWaiters = new AtomicLong();
     private volatile Consumer<EventRecord> committedHook = r -> {};
     private volatile FlushBarrier flushBarrier = timeout -> true;
 
@@ -97,7 +119,7 @@ public final class AsyncRecorder implements Recorder {
      * @param logger        plugin logger for warnings + retry diagnostics.
      */
     public AsyncRecorder(long warnThreshold, RecordStore store, Logger logger) {
-        this(warnThreshold, store, new WalDurability(null, false, logger), logger);
+        this(warnThreshold, 0L, store, new WalDurability(null, false, logger), () -> false, logger);
     }
 
     /**
@@ -106,11 +128,29 @@ public final class AsyncRecorder implements Recorder {
      * before pushing to the database, then deletes the file after a
      * successful save. Crash recovery on next startup replays any
      * leftover files via {@link WalDurability#recover()}.
+     *
+     * <p>Leaves the queue unbounded ({@code queueMax = 0}) and treats no
+     * thread as primary — the shape unit tests want headless.
      */
     public AsyncRecorder(long warnThreshold, RecordStore store, WalDurability wal, Logger logger) {
+        this(warnThreshold, 0L, store, wal, () -> false, logger);
+    }
+
+    /**
+     * Full constructor. {@code queueMax} is the hard queue ceiling that
+     * off-main producers backpressure against (≤ 0 = unbounded);
+     * {@code primaryThread} reports whether the calling thread is the
+     * Bukkit server thread, which is never blocked by the ceiling. The
+     * plugin passes {@code Bukkit::isPrimaryThread}; headless tests pass a
+     * controllable fake.
+     */
+    public AsyncRecorder(long warnThreshold, long queueMax, RecordStore store,
+                         WalDurability wal, BooleanSupplier primaryThread, Logger logger) {
         this.warnThreshold = warnThreshold;
+        this.queueMax = queueMax;
         this.store = store;
         this.wal = wal;
+        this.primaryThread = primaryThread;
         this.logger = logger;
         // Dedicated platform thread, not a virtual thread. The drain is a
         // single perpetual consumer loop that blocks on store.save() I/O;
@@ -157,11 +197,12 @@ public final class AsyncRecorder implements Recorder {
 
     @Override
     public void record(EventRecord record) {
-        // offer() on an unbounded LinkedBlockingDeque only returns false
-        // on OutOfMemoryError; we deliberately do not bound the queue.
-        // Losing an event at intake is the cost v2 explicitly refuses
-        // to pay — same contract as v1. Heap pressure becomes the
-        // operator's early-warning signal, surfaced via warnThreshold.
+        // Backpressure an off-main firehose (FAWE worker threads reach the
+        // pipeline here) when the queue is at the ceiling; the main thread
+        // and an unbounded queue both fall straight through. offer() on a
+        // LinkedBlockingDeque only returns false on OutOfMemoryError, so once
+        // the gate guarantees room the record always lands.
+        awaitCapacityIfBlockable();
         queue.offer(record);
         try {
             committedHook.accept(record);
@@ -176,13 +217,20 @@ public final class AsyncRecorder implements Recorder {
         if (records.isEmpty()) {
             return;
         }
-        // Bulk intake for synthesized records (the rollback audit
-        // trail). Deliberately skips the per-record committed hook:
-        // firing one Bukkit RecordCommittedEvent per rolled block on
-        // the main thread would cost more than the rollback that
-        // produced them, and no reactive integration needs a
-        // per-rolled-block notification. The DB save path is identical
-        // — these records drain and persist like any other.
+        // Bulk intake for the WorldEdit build stage and the rollback audit
+        // trail. The WorldEdit path is the firehose this whole ceiling
+        // exists for, and it runs off-main, so gate once before the batch:
+        // a parked producer here paces the paste to the drain. We admit the
+        // whole list once there is room, so the queue can transiently sit a
+        // little over the cap — bounded by one batch per builder that clears
+        // the gate, never the unbounded growth that caused the OOM.
+        //
+        // Deliberately skips the per-record committed hook: firing one
+        // Bukkit RecordCommittedEvent per rolled/edited block on the main
+        // thread would cost more than the op that produced them, and no
+        // reactive integration needs a per-block notification. The DB save
+        // path is identical — these records drain and persist like any other.
+        awaitCapacityIfBlockable();
         for (EventRecord record : records) {
             queue.offer(record);
         }
@@ -193,7 +241,7 @@ public final class AsyncRecorder implements Recorder {
     // depth doubling past that, so a sustained outage produces a
     // visible growth trail in the log without flooding it. atomic-CAS
     // on lastWarnedDepth so concurrent callers don't duplicate the same
-    // warning. Not a ceiling — the queue stays unbounded.
+    // warning. Soft signal below the ceiling, not the ceiling itself.
     private void warnIfQueueDeep() {
         int depth = queue.size();
         if (depth > warnThreshold) {
@@ -202,10 +250,65 @@ public final class AsyncRecorder implements Recorder {
             boolean doubledSinceLast = last > 0 && depth >= last * 2;
             if ((firstCrossing || doubledSinceLast)
                     && lastWarnedDepth.compareAndSet(last, depth)) {
+                String ceiling = queueMax > 0
+                        ? "; off-main edits backpressure at the queue-max ceiling of " + queueMax
+                        : ", and the queue is unbounded so heap pressure grows with depth";
                 logger.warning("Spyglass recorder queue depth " + depth
-                        + " (warn threshold " + warnThreshold + "). No records dropped"
-                        + " — queue is unbounded — but heap pressure grows with depth."
-                        + " Check Mongo reachability and drain latency.");
+                        + " (warn threshold " + warnThreshold + "). The drain is"
+                        + " falling behind" + ceiling + ". No records dropped — check the"
+                        + " storage backend's reachability and drain latency.");
+            }
+        }
+    }
+
+    /**
+     * Backpressure gate for the bulk-edit firehoses. When {@link #queueMax}
+     * is set and an <i>off-main</i> producer (the WorldEdit build stage via
+     * {@link #recordAll}, or FAWE via {@link #record} on its worker threads)
+     * is about to enqueue while the queue is already at the ceiling, it parks
+     * here until the drain frees space — so a multi-million-block paste can
+     * never grow the queue past the cap into an {@link OutOfMemoryError}.
+     * Nothing is dropped: the producer is paced, not rejected.
+     *
+     * <p>The Bukkit primary thread is never parked. Its per-event listeners
+     * are low-rate and must not stall a tick, so they are always admitted —
+     * a small bounded overshoot that preserves the no-drop guarantee for the
+     * main-thread audit path. With {@code queueMax <= 0} this is a no-op.
+     */
+    private void awaitCapacityIfBlockable() {
+        // Fast path: unbounded, room to spare, or the primary thread (never
+        // parked). queue.size() is an O(1) counter read on a deque.
+        if (queueMax <= 0 || queue.size() < queueMax || primaryThread.getAsBoolean()) {
+            return;
+        }
+        backpressureWaiters.incrementAndGet();
+        try {
+            synchronized (spaceMonitor) {
+                // Re-check under the monitor. The 50 ms timeout is a
+                // belt-and-suspenders backstop so a missed notify still
+                // resolves promptly; running == false (shutdown) releases the
+                // producer so the final flush isn't blocked behind it.
+                while (running.get() && queue.size() >= queueMax) {
+                    try {
+                        spaceMonitor.wait(50L);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        } finally {
+            backpressureWaiters.decrementAndGet();
+        }
+    }
+
+    // Wake any producers parked on the backpressure gate. Called after the
+    // drain frees space and at shutdown. The waiter-count guard keeps this a
+    // single volatile read (no monitor) whenever nobody is parked.
+    private void wakeBackpressureWaiters() {
+        if (backpressureWaiters.get() > 0) {
+            synchronized (spaceMonitor) {
+                spaceMonitor.notifyAll();
             }
         }
     }
@@ -251,6 +354,10 @@ public final class AsyncRecorder implements Recorder {
     public ShutdownReport shutdown(Duration timeout) {
         long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeout.seconds());
         running.set(false);
+        // Release any producer parked on the backpressure gate so it admits
+        // its record and the final flush can account for it, instead of
+        // hanging behind a full queue while we tear down.
+        wakeBackpressureWaiters();
         try {
             long remainingNanos = deadlineNanos - System.nanoTime();
             if (remainingNanos > 0) {
@@ -282,6 +389,10 @@ public final class AsyncRecorder implements Recorder {
                 List<EventRecord> batch = new ArrayList<>();
                 batch.add(first);
                 queue.drainTo(batch, 9_999);
+                // Pulling the batch freed queue space; wake any producer
+                // parked on the backpressure gate before the (possibly slow)
+                // store.save() below, so it can refill while this batch ships.
+                wakeBackpressureWaiters();
 
                 // WAL durability: when enabled, fsync the batch to disk
                 // before the DB push so a hard crash leaves a recoverable

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -88,13 +88,23 @@ storage {
   #       Only useful if an external consumer reads rolled-* rows
   #       straight from the database instead of through Spyglass.
   rolled-audit = "synthesized"
-  # WARN THRESHOLD — not a drop ceiling. The ingest queue is unbounded
-  # (never drops events at intake, same contract as v1). Crossing this
-  # depth logs a warning so operators notice Mongo backlog early; depth
-  # doublings past it log again so a real outage leaves a growth trail.
-  # Sized for ~10× steady-state peak — at MedievalRP's ~600 ev/s that
-  # gives ~160 s of slack before the first warning.
+  # WARN THRESHOLD — not the ceiling. Crossing this depth logs a warning so
+  # operators notice the drain falling behind early, before backpressure
+  # engages at queue-max below; depth doublings past it log again so a real
+  # outage leaves a growth trail. Sized for ~10× steady-state peak — at
+  # MedievalRP's ~600 ev/s that gives ~160 s of slack before the first warning.
   queue-capacity = 100000
+  # HARD CEILING on the ingest queue. When the queue reaches this depth the
+  # off-main bulk-edit firehoses (a large WorldEdit / FAWE paste) backpressure
+  # — they block until the drain frees space — so a multi-million-block edit
+  # can never grow the queue into an out-of-memory crash. Nothing is dropped:
+  # the edit's logging is simply paced to the database. The main server thread
+  # is NEVER blocked (its low-rate audit events are always admitted), so TPS is
+  # unaffected. At ~400 bytes/record the default 500000 caps the queue near
+  # ~200 MiB. Raise it if you have heap to spare and want more burst headroom;
+  # set 0 to disable the ceiling and restore the legacy unbounded queue (a big
+  # enough paste can then OOM the server). Keep it above queue-capacity.
+  queue-max = 500000
   # Shutdown drain deadline. On server stop the recorder keeps retrying to
   # flush any not-yet-stored events for up to this long (with backoff)
   # before giving up; whatever cannot drain in time is counted as lost and

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -21,6 +21,7 @@ import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.api.util.Duration;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 class AsyncRecorderTest {
 
@@ -237,6 +238,135 @@ class AsyncRecorderTest {
                     .isTrue();
         } finally {
             recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
+    @Timeout(15)
+    void offMainProducerBackpressuresAtQueueMaxThenResumesLosslessly() throws Exception {
+        // #119: an off-main bulk-edit firehose (WorldEdit/FAWE) must not be
+        // able to grow the queue past queue-max into an OOM. With the store
+        // wedged, the producer fills to the ceiling then PARKS — admitted
+        // freezes well below the total — and resumes losslessly once the drain
+        // can move again. () -> false marks every caller as off-main.
+        long queueMax = 50L;
+        int total = 5_000;
+        GatedStore store = new GatedStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000L, queueMax, store, new WalDurability(null, false, Logger.getLogger("test")),
+                () -> false, Logger.getLogger("test"));
+        AtomicInteger admitted = new AtomicInteger();
+        Thread producer = new Thread(() -> {
+            for (int i = 0; i < total; i++) {
+                recorder.record(sampleRecord());
+                admitted.incrementAndGet();
+            }
+        }, "test-producer");
+        try {
+            producer.start();
+            // The drain takes one batch and blocks in the wedged save(); no
+            // space frees after that, so the producer parks at the ceiling.
+            // Sample twice — a frozen count proves backpressure, not just slow.
+            Thread.sleep(500L);
+            int sample1 = admitted.get();
+            Thread.sleep(500L);
+            int sample2 = admitted.get();
+            assertThat(sample2)
+                    .as("off-main producer must park at the ceiling, not admit the whole burst")
+                    .isLessThan(total);
+            assertThat(sample2)
+                    .as("admitted must be frozen while the drain is wedged (backpressure, not slow)")
+                    .isEqualTo(sample1);
+
+            // Let the drain move; the parked producer must resume and finish.
+            store.open();
+            producer.join(10_000L);
+            assertThat(admitted.get())
+                    .as("every record is eventually admitted once the drain catches up")
+                    .isEqualTo(total);
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline && store.totalSaved() < total) {
+                Thread.sleep(25L);
+            }
+            assertThat(store.totalSaved())
+                    .as("no records lost: backpressure paces the firehose, it does not drop")
+                    .isEqualTo(total);
+        } finally {
+            store.open();
+            recorder.shutdown(Duration.parse("3s"));
+        }
+    }
+
+    @Test
+    @Timeout(15)
+    void mainThreadProducerIsNeverBlockedByTheCeiling() throws Exception {
+        // #119: the Bukkit primary thread must never park on the ceiling — its
+        // low-rate audit events are always admitted (a small overshoot), so a
+        // tick can't stall. () -> true marks the caller as primary; with the
+        // store wedged and a tiny ceiling, a blocking impl would deadlock this
+        // thread, so completing the loop at all is the proof.
+        GatedStore store = new GatedStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000L, 10L, store, new WalDurability(null, false, Logger.getLogger("test")),
+                () -> true, Logger.getLogger("test"));
+        try {
+            for (int i = 0; i < 100; i++) {
+                recorder.record(sampleRecord());
+            }
+            // Reached here without hanging => the primary thread was never
+            // blocked even though the queue is far past its 10-record ceiling.
+            store.open();
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline && store.totalSaved() < 100) {
+                Thread.sleep(25L);
+            }
+            assertThat(store.totalSaved())
+                    .as("main-thread records are admitted and persist; none dropped")
+                    .isEqualTo(100);
+        } finally {
+            store.open();
+            AsyncRecorder.ShutdownReport report = recorder.shutdown(Duration.parse("3s"));
+            assertThat(report.dropped())
+                    .as("main-thread admit path drops nothing")
+                    .isZero();
+        }
+    }
+
+    /**
+     * Store whose save() blocks until {@link #open()} is called — models a
+     * wedged drain so the backpressure ceiling engages deterministically. No
+     * internal timeout: the test controls exactly when the drain may move.
+     */
+    private static final class GatedStore implements RecordStore {
+        private final CountDownLatch gate = new CountDownLatch(1);
+        private final AtomicInteger saved = new AtomicInteger();
+
+        void open() {
+            gate.countDown();
+        }
+
+        int totalSaved() {
+            return saved.get();
+        }
+
+        @Override
+        public void save(List<EventRecord> records) {
+            try {
+                gate.await();
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            saved.addAndGet(records.size());
+        }
+
+        @Override
+        public QueryResult query(QueryRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
         }
     }
 


### PR DESCRIPTION
Closes #119.

## Problem

A large WorldEdit/FAWE edit produces a break+place record per block and feeds them into `AsyncRecorder`'s **unbounded** queue far faster than the single drain thread can persist them. The queue *is* retained heap, so a big enough paste grows it until the JVM OOMs and the server crashes. Observed in the wild: queue depth `100001 → 3200102` in ~1 second (~1.6M-block paste), then crash. `storage.queue-capacity` was only a **warn** threshold, not a ceiling.

## Fix

Make `storage.queue-max` a **hard ceiling** with **off-main backpressure**:

- When the queue reaches `queue-max`, the off-main bulk-edit firehoses block until the drain frees space — so the queue can't grow into an OOM. Nothing is dropped; the edit's logging is paced to the database.
  - vanilla WorldEdit build → `recordAll` (off-main virtual thread)
  - FAWE `processSet` → `record` (off-main FAWE worker)
- The **Bukkit primary thread is never blocked** — its low-rate per-event listeners are always admitted (a small bounded overshoot), preserving the no-drop guarantee for the main-thread audit path and never stalling a tick. Keys on `Bukkit::isPrimaryThread` (injected, so the recorder stays headless-testable).
- `queue-max = 0` restores the legacy fully-unbounded queue (full back-compat; existing tests use it and are unchanged).
- The queue-depth warning is now backend-agnostic (was hardcoded `Check Mongo reachability`).

Default `queue-max = 500000` (~200 MiB at ~400 B/record); `queue-capacity` (warn) stays 100000 so operators get an early signal before backpressure engages.

## Tests

- `offMainProducerBackpressuresAtQueueMaxThenResumesLosslessly` — with the store wedged, an off-main producer parks at the ceiling (admitted count frozen well below the burst), then resumes and every record persists once the drain moves; `dropped == 0`.
- `mainThreadProducerIsNeverBlockedByTheCeiling` — with the store wedged and a tiny ceiling, a primary-thread producer admits its whole burst without blocking (a blocking impl would deadlock); `dropped == 0`.

`./gradlew check` green (all module jacoco floors held).

## Out of scope (follow-ups, noted on #119)

- Bound the WorldEdit in-flight `Pending` backlog so vanilla pastes are fully constant-memory beyond the queue cap (parked build threads still hold their cells). Needs live TPS verification.
- Disk-spill overflow for true no-drop under a *sustained* store outage during a firehose.