### PR TITLE
feat(pipeline): spill bulk-edit overflow to disk so uncappable WorldEdit pastes stay heap-flat (#122)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -248,9 +248,22 @@ public final class SpyglassPlugin extends JavaPlugin {
             getLogger().info("Spyglass durability mode: WAL-batched (fsync per drain batch).");
         }
 
+        // On-disk overflow for the uncappable bulk-edit firehose: when the
+        // queue is at its ceiling, a vanilla-WorldEdit paste spills here
+        // instead of growing the heap. Only meaningful with a ceiling set.
+        boolean spillEnabled = config.storage().spillToDisk()
+                && config.storage().queueMax() > 0;
+        net.medievalrp.spyglass.plugin.pipeline.SpillBuffer spill =
+                new net.medievalrp.spyglass.plugin.pipeline.SpillBuffer(
+                        getDataFolder().toPath(), spillEnabled, getLogger());
+        if (spillEnabled) {
+            getLogger().info("Spyglass overflow spill: enabled (bulk-edit overflow spills to disk "
+                    + "at the queue-max ceiling).");
+        }
+
         recorder = new AsyncRecorder(
                 config.storage().queueCapacity(), config.storage().queueMax(),
-                recordStore, wal, Bukkit::isPrimaryThread, getLogger());
+                recordStore, wal, spill, Bukkit::isPrimaryThread, getLogger());
         // Publish RecordCommittedEvent to Bukkit listeners on every
         // intake. Done via a hook (rather than a direct Bukkit call
         // inside AsyncRecorder) so the recorder stays unit-testable

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -90,6 +90,7 @@ public record SpyglassConfig(
                         Duration.parse(root.node("storage", "retention").getString("4w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
                         root.node("storage", "queue-max").getInt(500_000),
+                        root.node("storage", "spill-to-disk").getBoolean(true),
                         Duration.parse(root.node("storage", "flush-timeout").getString("5s")),
                         parseDurability(root.node("storage", "durability").getString("ram")),
                         "synthesized".equalsIgnoreCase(
@@ -223,6 +224,13 @@ public record SpyglassConfig(
      *                      main thread is never blocked. {@code 0} restores the
      *                      legacy unbounded queue. Must sit above
      *                      {@code queueCapacity} so the warning precedes it.
+     * @param spillToDisk   when {@code true} (default), the bulk-edit firehose
+     *                      writes its overflow to an on-disk spill buffer once
+     *                      the queue hits {@code queueMax}, instead of holding
+     *                      it in RAM. This is what keeps an uncappable vanilla
+     *                      WorldEdit paste heap-flat without dropping records:
+     *                      the drain replays spilled segments. Requires
+     *                      {@code queueMax > 0}; needs a fast local disk.
      * @param flushTimeout  upper bound on how long {@code onDisable} will
      *                      wait for the queue to drain before returning.
      * @param durability    how aggressive the write path is about
@@ -240,7 +248,7 @@ public record SpyglassConfig(
      *                      cheap; per-event overhead is negligible.
      */
     public record Storage(Duration retention, int queueCapacity, int queueMax,
-                          Duration flushTimeout,
+                          boolean spillToDisk, Duration flushTimeout,
                           Durability durability, boolean rolledAuditSynthesized) {
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -44,23 +44,33 @@ import org.jetbrains.annotations.ApiStatus;
  * fire at the first crossing and at doubling intervals thereafter, so a
  * genuine outage surfaces its growth shape in the log without flooding it.
  *
- * <h2>The only scenarios where records can be lost</h2>
+ * <h2>Overflow goes to disk, not the heap</h2>
  *
- * Under normal operation (server running, Mongo reachable) an event
- * that reaches {@link #record} always lands in the store. Two edge
- * cases still exist; both require spill-to-disk to eliminate, and v1
- * has the same exposure:
+ * Bounding the queue alone doesn't bound vanilla WorldEdit: its
+ * {@code setBlock} loop runs on the main thread, so overflow we refuse to
+ * block would pile up in the off-main build threads instead. When a
+ * {@link SpillBuffer} is wired, {@link #recordAll} writes the over-ceiling
+ * overflow to disk (fsynced) rather than RAM, and the drain replays those
+ * segments — so an uncappable paste stays heap-flat and loses nothing. The
+ * spilled segments also survive a hard crash and are replayed on next start.
+ *
+ * <h2>The scenarios where records can still be lost</h2>
+ *
+ * Under normal operation (server running, store reachable) an event that
+ * reaches {@link #record} always lands in the store. Two edge cases remain:
  *
  * <ol>
- *   <li><b>Hard JVM death</b> — server crash, SIGKILL, OOM, power loss.
- *       The queue is RAM-resident; anything not yet saved is lost with
- *       the process.</li>
+ *   <li><b>Hard JVM death</b> — server crash, SIGKILL, power loss. The
+ *       in-RAM queue (capped at {@code queueMax}) is lost with the process;
+ *       {@code wal-batched} durability closes that window, and spilled
+ *       overflow is already on disk and recovered on next start.</li>
  *   <li><b>Shutdown flush deadline exhaustion</b> —
  *       {@link #flushRemaining} retries with backoff for the full
- *       configured {@code flush-timeout}. If Mongo is still unreachable
- *       when the deadline expires, undrained records are counted into
- *       {@link ShutdownReport#dropped} and logged at SEVERE. Under
- *       normal Mongo availability this code path is unreachable.</li>
+ *       configured {@code flush-timeout}. If the store is still unreachable
+ *       when the deadline expires, undrained queue records are counted into
+ *       {@link ShutdownReport#dropped} and logged at SEVERE (spilled
+ *       segments stay on disk for next-start recovery). Under normal store
+ *       availability this code path is unreachable.</li>
  * </ol>
  *
  * <p>Aside from those, records are durable once {@link #record} returns.
@@ -78,6 +88,10 @@ public final class AsyncRecorder implements Recorder {
     private final BooleanSupplier primaryThread;
     private final RecordStore store;
     private final WalDurability wal;
+    // On-disk overflow buffer. When the queue is at queueMax, the uncappable
+    // vanilla-WorldEdit firehose (recordAll) spills here instead of holding
+    // overflow in RAM; the drain replays it. Disabled (no-op) by default.
+    private final SpillBuffer spill;
     private final Logger logger;
     private final AtomicBoolean running = new AtomicBoolean(true);
     private final CountDownLatch stopped = new CountDownLatch(1);
@@ -90,6 +104,11 @@ public final class AsyncRecorder implements Recorder {
     // whenever nobody is parked, which is the common case.
     private final Object spaceMonitor = new Object();
     private final AtomicLong backpressureWaiters = new AtomicLong();
+    // Count of spill-write failures (disk full / I/O), for rate-limited logging.
+    private final AtomicLong spillFailures = new AtomicLong();
+    // Consecutive store-save failures, for retry backoff. Touched only by the
+    // single drain thread, so it needs no synchronization.
+    private int consecutiveFailures = 0;
     private volatile Consumer<EventRecord> committedHook = r -> {};
     private volatile FlushBarrier flushBarrier = timeout -> true;
 
@@ -146,10 +165,25 @@ public final class AsyncRecorder implements Recorder {
      */
     public AsyncRecorder(long warnThreshold, long queueMax, RecordStore store,
                          WalDurability wal, BooleanSupplier primaryThread, Logger logger) {
+        this(warnThreshold, queueMax, store, wal,
+                new SpillBuffer(null, false, logger), primaryThread, logger);
+    }
+
+    /**
+     * Full constructor with on-disk overflow. {@code spill} absorbs the
+     * bulk-edit firehose's overflow when the queue hits {@code queueMax}, so a
+     * paste the operator can't cap stays heap-flat without dropping records.
+     * Pass a disabled {@link SpillBuffer} ({@code new SpillBuffer(null, false,
+     * logger)}) to keep everything in RAM — the shape headless tests want.
+     */
+    public AsyncRecorder(long warnThreshold, long queueMax, RecordStore store,
+                         WalDurability wal, SpillBuffer spill,
+                         BooleanSupplier primaryThread, Logger logger) {
         this.warnThreshold = warnThreshold;
         this.queueMax = queueMax;
         this.store = store;
         this.wal = wal;
+        this.spill = spill;
         this.primaryThread = primaryThread;
         this.logger = logger;
         // Dedicated platform thread, not a virtual thread. The drain is a
@@ -218,18 +252,39 @@ public final class AsyncRecorder implements Recorder {
             return;
         }
         // Bulk intake for the WorldEdit build stage and the rollback audit
-        // trail. The WorldEdit path is the firehose this whole ceiling
-        // exists for, and it runs off-main, so gate once before the batch:
-        // a parked producer here paces the paste to the drain. We admit the
-        // whole list once there is room, so the queue can transiently sit a
-        // little over the cap — bounded by one batch per builder that clears
-        // the gate, never the unbounded growth that caused the OOM.
+        // trail. The WorldEdit path is the firehose this whole ceiling exists
+        // for, and it runs off-main.
         //
-        // Deliberately skips the per-record committed hook: firing one
-        // Bukkit RecordCommittedEvent per rolled/edited block on the main
-        // thread would cost more than the op that produced them, and no
-        // reactive integration needs a per-block notification. The DB save
-        // path is identical — these records drain and persist like any other.
+        // When the queue is at the ceiling, spill this batch to disk instead
+        // of holding it in RAM. Vanilla WorldEdit's setBlock loop runs on the
+        // main thread (which we can't block), so parking the off-main build
+        // thread would just pile the overflow up in that thread's heap —
+        // O(paste size). Spilling keeps the heap flat (overflow lives on disk)
+        // and loses nothing: the drain replays spilled segments. The drain
+        // also frees queue space continuously, so as soon as it keeps up the
+        // batches flow back through the fast in-RAM path.
+        if (spill.enabled() && queueMax > 0 && !primaryThread.getAsBoolean()
+                && queue.size() >= queueMax) {
+            try {
+                spill.spill(records);
+                return;
+            } catch (java.io.IOException spillFailure) {
+                // Disk full / I/O error: fall back to in-RAM backpressure
+                // (park) rather than drop — no-loss is the chosen contract.
+                long n = spillFailures.incrementAndGet();
+                if (n == 1 || n % 1000 == 0) {
+                    logger.warning("Spyglass spill write failed (" + n + "x), falling back to"
+                            + " in-RAM backpressure: " + spillFailure.getMessage());
+                }
+            }
+        }
+        // No spill (disabled, unbounded, or below the ceiling): gate once
+        // before the batch — an off-main producer parks until there is room;
+        // the primary thread and an unbounded queue fall straight through.
+        // Deliberately skips the per-record committed hook: firing one Bukkit
+        // RecordCommittedEvent per rolled/edited block on the main thread would
+        // cost more than the op that produced them, and no reactive
+        // integration needs a per-block notification.
         awaitCapacityIfBlockable();
         for (EventRecord record : records) {
             queue.offer(record);
@@ -335,7 +390,10 @@ public final class AsyncRecorder implements Recorder {
         if (!flushBarrier.awaitQuiescent(timeout)) {
             return false;
         }
-        long highWaterMark = drained.get() + queue.size();
+        // Include spilled overflow in the mark: a rollback issued right after a
+        // paste must wait for records sitting in the disk spill too, not just
+        // the in-RAM queue, or it would read before they reach the store.
+        long highWaterMark = drained.get() + queue.size() + spill.pendingRecordCount();
         while (drained.get() < highWaterMark) {
             if (System.nanoTime() >= deadlineNanos) {
                 return false;
@@ -371,79 +429,127 @@ public final class AsyncRecorder implements Recorder {
     }
 
     private void drainLoop() {
-        int consecutiveFailures = 0;
         try {
-            while (running.get() || !queue.isEmpty()) {
-                EventRecord first = queue.poll(250, TimeUnit.MILLISECONDS);
-                if (first == null) {
+            while (running.get() || !queue.isEmpty() || spill.hasPending()) {
+                // Hot path first: drain the in-RAM queue non-blocking so, while
+                // a burst is live, batches keep cycling through RAM and the
+                // freed space lets producers stay off the (slower) spill path.
+                EventRecord first = queue.poll();
+                if (first != null) {
+                    if (!drainQueueBatch(first)) {
+                        return; // shutdown mid-retry; batch re-queued for the flush
+                    }
                     continue;
                 }
-                // Drain batch sized for ClickHouse's MergeTree, not Mongo.
-                // Mongo absorbs 512-doc batches in ~ms; ClickHouse pays the
-                // same fixed cost for any batch under ~10 k rows (one part
-                // per INSERT, then a merge), so small batches starve the
-                // ingest rate. With this larger batch, 1M-row WE bursts
-                // drain at ~50-100k records/sec instead of ~7k/sec, which
-                // is the difference between rollback waiting on a partial
-                // CH and rollback seeing the whole burst.
-                List<EventRecord> batch = new ArrayList<>();
-                batch.add(first);
-                queue.drainTo(batch, 9_999);
-                // Pulling the batch freed queue space; wake any producer
-                // parked on the backpressure gate before the (possibly slow)
-                // store.save() below, so it can refill while this batch ships.
-                wakeBackpressureWaiters();
-
-                // WAL durability: when enabled, fsync the batch to disk
-                // before the DB push so a hard crash leaves a recoverable
-                // file behind. write() is a no-op + null when WAL is
-                // disabled, which keeps the RAM-only path identical to v1.
-                java.nio.file.Path walFile = null;
-                try {
-                    walFile = wal.write(batch);
-                } catch (java.io.IOException walFailure) {
-                    logger.warning("Spyglass WAL write failed (" + walFailure.getMessage()
-                            + "); proceeding with DB save anyway. Records still durable iff DB save succeeds.");
-                }
-
-                // Persist with retry + exponential backoff. A transient store
-                // failure (Mongo hiccup, replica-set election, network blip)
-                // must not kill the drain thread and silently drop every
-                // subsequent record. We retry the same batch until either it
-                // succeeds or shutdown is requested, then loop back to polling.
-                while (true) {
-                    try {
-                        store.save(batch);
-                        wal.ack(walFile);
-                        drained.addAndGet(batch.size());
-                        consecutiveFailures = 0;
-                        break;
-                    } catch (RuntimeException saveFailure) {
-                        consecutiveFailures++;
-                        long backoffMs = Math.min(30_000L,
-                                250L << Math.min(consecutiveFailures - 1, 7));
-                        if (consecutiveFailures == 1 || consecutiveFailures % 10 == 0) {
-                            logger.warning("Spyglass recorder save failed ("
-                                    + consecutiveFailures + "x, retry in "
-                                    + backoffMs + "ms): " + saveFailure.getMessage());
-                        }
-                        if (!running.get()) {
-                            logger.warning("Recorder shutting down mid-retry; re-queueing "
-                                    + batch.size() + " records for final flush.");
-                            // Unbounded queue -> offerFirst always succeeds.
-                            for (int i = batch.size() - 1; i >= 0; i--) {
-                                queue.offerFirst(batch.get(i));
-                            }
+                // Queue empty: replay one spilled overflow segment (older than
+                // anything still arriving). Reclaims disk + honours the flush
+                // high-water mark. One segment in RAM at a time keeps heap flat.
+                if (spill.hasPending()) {
+                    SpillBuffer.Spilled spilled = spill.poll();
+                    if (spilled != null) {
+                        if (!persistWithRetry(spilled.records())) {
+                            // Shutdown mid-retry: leave the segment on disk; it
+                            // replays on next startup. Don't ack (delete) it.
                             return;
                         }
-                        Thread.sleep(backoffMs);
+                        spill.ack(spilled);
+                        wakeBackpressureWaiters();
+                        continue;
                     }
+                    // hasPending() but nothing polled (all-corrupt or a
+                    // counter/file skew): fall through to the blocking poll so
+                    // we throttle instead of busy-spinning.
+                }
+                // Nothing in queue or spill: block briefly for new queue work
+                // rather than spin.
+                EventRecord waited = queue.poll(250, TimeUnit.MILLISECONDS);
+                if (waited != null && !drainQueueBatch(waited)) {
+                    return;
                 }
             }
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
         } finally {
             stopped.countDown();
+        }
+    }
+
+    /**
+     * Pull a drain batch starting at {@code first}, persist it, and on a
+     * shutdown-mid-retry re-queue it for the final flush. Returns {@code false}
+     * only in that shutdown case (the caller must stop the drain loop).
+     */
+    private boolean drainQueueBatch(EventRecord first) {
+        // Drain batch sized for ClickHouse's MergeTree, not Mongo. Mongo
+        // absorbs 512-doc batches in ~ms; ClickHouse pays the same fixed cost
+        // for any batch under ~10 k rows (one part per INSERT, then a merge),
+        // so small batches starve the ingest rate. With this larger batch,
+        // 1M-row WE bursts drain at ~50-100k records/sec instead of ~7k/sec.
+        List<EventRecord> batch = new ArrayList<>();
+        batch.add(first);
+        queue.drainTo(batch, 9_999);
+        // Pulling the batch freed queue space; wake any producer parked on the
+        // backpressure gate before the (possibly slow) save below.
+        wakeBackpressureWaiters();
+        if (!persistWithRetry(batch)) {
+            logger.warning("Recorder shutting down mid-retry; re-queueing "
+                    + batch.size() + " records for final flush.");
+            for (int i = batch.size() - 1; i >= 0; i--) {
+                queue.offerFirst(batch.get(i));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Persist one batch with WAL fsync + retry/backoff. Retries the same batch
+     * until it saves or shutdown is requested. Returns {@code true} once saved
+     * (and {@link #drained} is incremented); {@code false} if shutdown
+     * interrupts mid-retry, leaving it to the caller to re-queue (queue path)
+     * or leave on disk (spill path). Runs only on the single drain thread, so
+     * {@link #consecutiveFailures} needs no synchronization.
+     */
+    private boolean persistWithRetry(List<EventRecord> batch) {
+        // WAL durability: when enabled, fsync the batch to disk before the DB
+        // push so a hard crash leaves a recoverable file behind. write() is a
+        // no-op + null when WAL is disabled, keeping the RAM-only path as v1.
+        java.nio.file.Path walFile = null;
+        try {
+            walFile = wal.write(batch);
+        } catch (java.io.IOException walFailure) {
+            logger.warning("Spyglass WAL write failed (" + walFailure.getMessage()
+                    + "); proceeding with DB save anyway. Records still durable iff DB save succeeds.");
+        }
+        // A transient store failure (Mongo hiccup, replica-set election,
+        // network blip) must not kill the drain thread and silently drop every
+        // subsequent record. Retry the same batch until it succeeds or shutdown.
+        while (true) {
+            try {
+                store.save(batch);
+                wal.ack(walFile);
+                drained.addAndGet(batch.size());
+                consecutiveFailures = 0;
+                return true;
+            } catch (RuntimeException saveFailure) {
+                consecutiveFailures++;
+                long backoffMs = Math.min(30_000L,
+                        250L << Math.min(consecutiveFailures - 1, 7));
+                if (consecutiveFailures == 1 || consecutiveFailures % 10 == 0) {
+                    logger.warning("Spyglass recorder save failed ("
+                            + consecutiveFailures + "x, retry in "
+                            + backoffMs + "ms): " + saveFailure.getMessage());
+                }
+                if (!running.get()) {
+                    return false;
+                }
+                try {
+                    Thread.sleep(backoffMs);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
         }
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodec.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodec.java
@@ -1,0 +1,108 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import com.mongodb.MongoClientSettings;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.plugin.storage.EventRecordCodec;
+import net.medievalrp.spyglass.plugin.storage.RollbackEffectCodec;
+import org.bson.BsonArray;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.UuidCodec;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.jsr310.Jsr310CodecProvider;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.record.RecordCodecProvider;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.io.ByteBufferBsonInput;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * BSON encode/decode for an {@link EventRecord} batch as a single
+ * self-describing byte block. Shared by the on-disk pipeline paths —
+ * {@link WalDurability} (drain-side write-ahead) and {@link SpillBuffer}
+ * (producer-side overflow) — so both round-trip records through the exact
+ * same polymorphic {@link EventRecordCodec} the storage backends use.
+ *
+ * <p>Layout: one BSON document {@code { r: [ <record>, <record>, ... ] }};
+ * each element is written via a one-key {@code { v: <record-doc> }} wrapper
+ * so the sealed-record codec encodes/decodes identically to the storage path.
+ */
+@ApiStatus.Internal
+final class EventBatchCodec {
+
+    private static final String RECORDS_KEY = "r";
+    private static final String VALUE_KEY = "v";
+
+    private static final CodecRegistry REGISTRY = CodecRegistries.fromRegistries(
+            CodecRegistries.fromCodecs(new UuidCodec(UuidRepresentation.STANDARD)),
+            MongoClientSettings.getDefaultCodecRegistry(),
+            CodecRegistries.fromProviders(
+                    new BsonValueCodecProvider(),
+                    new Jsr310CodecProvider(),
+                    new RecordCodecProvider(),
+                    EventRecordCodec.provider(),
+                    RollbackEffectCodec.provider(),
+                    PojoCodecProvider.builder().automatic(true).build()));
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static final Codec<EventRecord> EVENT_RECORD_CODEC =
+            (Codec) REGISTRY.get(EventRecord.class);
+
+    private EventBatchCodec() {
+    }
+
+    /** Encode a batch as a single BSON document. */
+    static byte[] encode(List<EventRecord> batch) {
+        BsonArray array = new BsonArray();
+        for (EventRecord record : batch) {
+            BsonDocument wrapper = new BsonDocument();
+            try (org.bson.BsonDocumentWriter writer = new org.bson.BsonDocumentWriter(wrapper)) {
+                writer.writeStartDocument();
+                writer.writeName(VALUE_KEY);
+                EVENT_RECORD_CODEC.encode(writer, record, EncoderContext.builder().build());
+                writer.writeEndDocument();
+            }
+            array.add(wrapper.get(VALUE_KEY));
+        }
+        BsonDocument document = new BsonDocument().append(RECORDS_KEY, array);
+        BasicOutputBuffer buffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+            REGISTRY.get(BsonDocument.class).encode(writer, document, EncoderContext.builder().build());
+        }
+        return buffer.toByteArray();
+    }
+
+    /** Decode a batch previously produced by {@link #encode}. */
+    static List<EventRecord> decode(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        BsonDocument document;
+        try (BsonBinaryReader reader = new BsonBinaryReader(new ByteBufferBsonInput(
+                new org.bson.ByteBufNIO(buf)))) {
+            document = REGISTRY.get(BsonDocument.class)
+                    .decode(reader, DecoderContext.builder().build());
+        }
+        BsonArray array = document.getArray(RECORDS_KEY);
+        List<EventRecord> out = new ArrayList<>(array.size());
+        for (BsonValue value : array) {
+            BsonDocument wrapper = new BsonDocument().append(VALUE_KEY, value);
+            try (org.bson.BsonDocumentReader reader = new org.bson.BsonDocumentReader(wrapper)) {
+                reader.readStartDocument();
+                reader.readName();
+                out.add(EVENT_RECORD_CODEC.decode(reader, DecoderContext.builder().build()));
+                reader.readEndDocument();
+            }
+        }
+        return out;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
@@ -1,0 +1,226 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * On-disk overflow buffer for {@link AsyncRecorder}. When the in-RAM queue
+ * is at its ceiling, the uncappable bulk-edit firehose (vanilla WorldEdit,
+ * via {@link AsyncRecorder#recordAll}) writes its overflow batch <em>here</em>
+ * instead of holding it in memory — so a multi-million-block paste keeps the
+ * heap flat (the overflow lives on disk) while losing nothing: the drain
+ * replays spilled segments back to the store.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * <p>Pure backpressure (#119) bounds the queue but not vanilla WorldEdit: its
+ * {@code setBlock} loop runs on the main thread, which can't be blocked, so
+ * the records that don't fit in the capped queue would otherwise pile up in
+ * the off-main build threads. Spilling them to disk is the only way to bound
+ * RAM for an op the operator can't cap without dropping records.
+ *
+ * <h2>Format &amp; crash-safety</h2>
+ *
+ * <p>One segment file per spilled batch in {@code <dataFolder>/spill/}, named
+ * {@code <seq>.<count>.spill} where {@code seq} is a zero-padded monotonic
+ * counter (so lexical order = chronological) and {@code count} is the record
+ * count (readable even from a corrupt segment, for metrics). Each segment is
+ * fsynced to a {@code .tmp} sibling then {@linkplain StandardCopyOption#ATOMIC_MOVE
+ * atomically renamed}, so the drain never reads a half-written file. Segments
+ * left behind by a crash are counted on construction and replayed by the drain
+ * on the next run; the same BSON layout as the WAL ({@link EventBatchCodec})
+ * means a replayed record round-trips identically to the storage path.
+ *
+ * <p>Producers ({@link #spill}) may run on many threads; {@link #poll}/{@link
+ * #ack} run only on the single drain thread.
+ */
+@ApiStatus.Internal
+public final class SpillBuffer {
+
+    private static final String EXTENSION = ".spill";
+    private static final String TMP_SUFFIX = EXTENSION + ".tmp";
+
+    @Nullable
+    private final Path dir; // null => disabled
+    private final Logger logger;
+    private final AtomicLong seq = new AtomicLong();
+    private final AtomicLong pendingRecords = new AtomicLong();
+    private final AtomicLong pendingFiles = new AtomicLong();
+
+    public SpillBuffer(@Nullable Path dataFolder, boolean enabled, Logger logger) {
+        this.logger = logger;
+        if (!enabled || dataFolder == null) {
+            this.dir = null;
+            return;
+        }
+        this.dir = dataFolder.resolve("spill");
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to create spill directory " + dir, ex);
+        }
+        seedFromExisting();
+    }
+
+    boolean enabled() {
+        return dir != null;
+    }
+
+    boolean hasPending() {
+        return pendingFiles.get() > 0;
+    }
+
+    /** Approximate count of records currently on disk — used by flush's
+     *  high-water mark so read-your-writes waits for spilled records too. */
+    long pendingRecordCount() {
+        return pendingRecords.get();
+    }
+
+    /**
+     * Append a batch to a new on-disk segment (fsync + atomic rename) and
+     * return. Off-main producers call this instead of holding the overflow in
+     * RAM. Throws on I/O failure (e.g. disk full) so the caller can fall back
+     * to in-RAM backpressure rather than drop.
+     */
+    void spill(List<EventRecord> batch) throws IOException {
+        if (dir == null || batch.isEmpty()) {
+            return;
+        }
+        byte[] bytes = EventBatchCodec.encode(batch);
+        String base = String.format("%016d.%d", seq.getAndIncrement(), batch.size());
+        Path tmp = dir.resolve(base + TMP_SUFFIX);
+        Path file = dir.resolve(base + EXTENSION);
+        try (FileChannel channel = FileChannel.open(tmp,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            channel.write(ByteBuffer.wrap(bytes));
+            // fsync the bytes before the segment becomes visible to the drain.
+            channel.force(true);
+        }
+        Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE);
+        pendingRecords.addAndGet(batch.size());
+        pendingFiles.incrementAndGet();
+    }
+
+    /**
+     * Read + decode the oldest segment <b>without</b> deleting it (the drain
+     * {@link #ack}s only after a successful save, so a crash mid-save leaves
+     * the segment for recovery). Returns {@code null} when nothing is spilled.
+     */
+    @Nullable
+    Spilled poll() {
+        if (dir == null) {
+            return null;
+        }
+        // Skip past any unreadable segments (drop them) until a good one or none.
+        for (Path oldest = oldestSegment(); oldest != null; oldest = oldestSegment()) {
+            try {
+                byte[] bytes = Files.readAllBytes(oldest);
+                return new Spilled(oldest, EventBatchCodec.decode(bytes));
+            } catch (IOException | RuntimeException ex) {
+                // A segment that won't decode would wedge the drain forever;
+                // its records are unrecoverable, so drop it and move to the next.
+                logger.log(Level.WARNING, "Spyglass spill: dropping unreadable segment "
+                        + oldest.getFileName() + " (" + ex.getMessage() + ")");
+                pendingRecords.addAndGet(-recordCountOf(oldest));
+                pendingFiles.decrementAndGet();
+                deleteQuietly(oldest);
+            }
+        }
+        return null;
+    }
+
+    /** Delete a segment after its records were saved, and update counters. */
+    void ack(Spilled spilled) {
+        pendingRecords.addAndGet(-spilled.records().size());
+        pendingFiles.decrementAndGet();
+        deleteQuietly(spilled.file());
+    }
+
+    @Nullable
+    private Path oldestSegment() {
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream
+                    .filter(p -> p.getFileName().toString().endsWith(EXTENSION))
+                    .min(Comparator.comparing(p -> p.getFileName().toString()))
+                    .orElse(null);
+        } catch (IOException ex) {
+            logger.log(Level.WARNING, "Spyglass spill: failed to list " + dir, ex);
+            return null;
+        }
+    }
+
+    private void seedFromExisting() {
+        List<Path> all;
+        try (Stream<Path> stream = Files.list(dir)) {
+            all = stream.toList();
+        } catch (IOException ex) {
+            logger.log(Level.WARNING, "Spyglass spill: failed to scan " + dir, ex);
+            return;
+        }
+        long maxSeq = -1L;
+        long files = 0;
+        long records = 0;
+        for (Path p : all) {
+            String name = p.getFileName().toString();
+            if (name.endsWith(TMP_SUFFIX)) {
+                deleteQuietly(p); // half-written at the crash; the rename never landed
+                continue;
+            }
+            if (!name.endsWith(EXTENSION)) {
+                continue;
+            }
+            files++;
+            records += recordCountOf(p);
+            maxSeq = Math.max(maxSeq, seqOf(p));
+        }
+        seq.set(maxSeq + 1);
+        pendingFiles.set(files);
+        pendingRecords.set(records);
+        if (files > 0) {
+            logger.info("Spyglass spill: " + records + " overflow record(s) in " + files
+                    + " segment(s) left from a prior run; the drain will replay them.");
+        }
+    }
+
+    private static long seqOf(Path p) {
+        try {
+            return Long.parseLong(p.getFileName().toString().split("\\.")[0]);
+        } catch (RuntimeException ex) {
+            return -1L;
+        }
+    }
+
+    private static long recordCountOf(Path p) {
+        try {
+            return Long.parseLong(p.getFileName().toString().split("\\.")[1]);
+        } catch (RuntimeException ex) {
+            return 0L;
+        }
+    }
+
+    private void deleteQuietly(Path p) {
+        try {
+            Files.deleteIfExists(p);
+        } catch (IOException ex) {
+            logger.log(Level.WARNING, "Spyglass spill: failed to delete " + p, ex);
+        }
+    }
+
+    /** A decoded segment paired with its file, so the drain can {@link #ack} it. */
+    record Spilled(Path file, List<EventRecord> records) {
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/WalDurability.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/WalDurability.java
@@ -1,6 +1,5 @@
 package net.medievalrp.spyglass.plugin.pipeline;
 
-import com.mongodb.MongoClientSettings;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -15,26 +14,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import net.medievalrp.spyglass.api.event.EventRecord;
-import net.medievalrp.spyglass.plugin.storage.EventRecordCodec;
-import net.medievalrp.spyglass.plugin.storage.RollbackEffectCodec;
-import org.bson.BsonArray;
-import org.bson.BsonBinaryReader;
-import org.bson.BsonBinaryWriter;
-import org.bson.BsonDocument;
-import org.bson.BsonValue;
-import org.bson.UuidRepresentation;
-import org.bson.codecs.BsonValueCodecProvider;
-import org.bson.codecs.Codec;
-import org.bson.codecs.DecoderContext;
-import org.bson.codecs.EncoderContext;
-import org.bson.codecs.UuidCodec;
-import org.bson.codecs.configuration.CodecRegistries;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.jsr310.Jsr310CodecProvider;
-import org.bson.codecs.pojo.PojoCodecProvider;
-import org.bson.codecs.record.RecordCodecProvider;
-import org.bson.io.BasicOutputBuffer;
-import org.bson.io.ByteBufferBsonInput;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -87,23 +66,6 @@ import org.jetbrains.annotations.Nullable;
 public final class WalDurability {
 
     private static final String EXTENSION = ".wal";
-    private static final String RECORDS_KEY = "r";
-    private static final String VALUE_KEY = "v";
-
-    private static final CodecRegistry REGISTRY = CodecRegistries.fromRegistries(
-            CodecRegistries.fromCodecs(new UuidCodec(UuidRepresentation.STANDARD)),
-            MongoClientSettings.getDefaultCodecRegistry(),
-            CodecRegistries.fromProviders(
-                    new BsonValueCodecProvider(),
-                    new Jsr310CodecProvider(),
-                    new RecordCodecProvider(),
-                    EventRecordCodec.provider(),
-                    RollbackEffectCodec.provider(),
-                    PojoCodecProvider.builder().automatic(true).build()));
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private static final Codec<EventRecord> EVENT_RECORD_CODEC =
-            (Codec) REGISTRY.get(EventRecord.class);
 
     private final boolean enabled;
     private final Path pendingDir;
@@ -138,7 +100,7 @@ public final class WalDurability {
         if (!enabled || batch.isEmpty()) {
             return null;
         }
-        byte[] bytes = encode(batch);
+        byte[] bytes = EventBatchCodec.encode(batch);
         Path file = pendingDir.resolve(UUID.randomUUID() + EXTENSION);
         try (FileChannel channel = FileChannel.open(file,
                 StandardOpenOption.CREATE_NEW,
@@ -192,7 +154,7 @@ public final class WalDurability {
         for (Path file : files) {
             try {
                 byte[] bytes = Files.readAllBytes(file);
-                List<EventRecord> batch = decode(bytes);
+                List<EventRecord> batch = EventBatchCodec.decode(bytes);
                 recovered.addAll(batch);
                 filesRecovered++;
             } catch (RuntimeException | IOException ex) {
@@ -224,54 +186,5 @@ public final class WalDurability {
         } catch (IOException ex) {
             return 0L;
         }
-    }
-
-    /**
-     * Encode a batch as a single BSON document with shape:
-     * {@code { r: [ <wrapped record>, <wrapped record>, ... ] }}.
-     * Each wrapped record is itself a one-key document {@code { v:
-     * <record-doc> }} so the polymorphic {@link EventRecordCodec}
-     * round-trips identically to how it does on the storage path.
-     */
-    private static byte[] encode(List<EventRecord> batch) {
-        BsonArray array = new BsonArray();
-        for (EventRecord record : batch) {
-            BsonDocument wrapper = new BsonDocument();
-            try (org.bson.BsonDocumentWriter writer = new org.bson.BsonDocumentWriter(wrapper)) {
-                writer.writeStartDocument();
-                writer.writeName(VALUE_KEY);
-                EVENT_RECORD_CODEC.encode(writer, record, EncoderContext.builder().build());
-                writer.writeEndDocument();
-            }
-            array.add(wrapper.get(VALUE_KEY));
-        }
-        BsonDocument document = new BsonDocument().append(RECORDS_KEY, array);
-        BasicOutputBuffer buffer = new BasicOutputBuffer();
-        try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
-            REGISTRY.get(BsonDocument.class).encode(writer, document, EncoderContext.builder().build());
-        }
-        return buffer.toByteArray();
-    }
-
-    private static List<EventRecord> decode(byte[] bytes) {
-        ByteBuffer buf = ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN);
-        BsonDocument document;
-        try (BsonBinaryReader reader = new BsonBinaryReader(new ByteBufferBsonInput(
-                new org.bson.ByteBufNIO(buf)))) {
-            document = REGISTRY.get(BsonDocument.class)
-                    .decode(reader, DecoderContext.builder().build());
-        }
-        BsonArray array = document.getArray(RECORDS_KEY);
-        List<EventRecord> out = new ArrayList<>(array.size());
-        for (BsonValue value : array) {
-            BsonDocument wrapper = new BsonDocument().append(VALUE_KEY, value);
-            try (org.bson.BsonDocumentReader reader = new org.bson.BsonDocumentReader(wrapper)) {
-                reader.readStartDocument();
-                reader.readName();
-                out.add(EVENT_RECORD_CODEC.decode(reader, DecoderContext.builder().build()));
-                reader.readEndDocument();
-            }
-        }
-        return out;
     }
 }

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -105,6 +105,18 @@ storage {
   # set 0 to disable the ceiling and restore the legacy unbounded queue (a big
   # enough paste can then OOM the server). Keep it above queue-capacity.
   queue-max = 500000
+  # ON-DISK OVERFLOW. The queue-max ceiling above bounds the in-memory queue,
+  # but a vanilla-WorldEdit paste runs on the main thread (which is never
+  # blocked), so the records that don't fit in the queue have to go somewhere.
+  # With spill-to-disk on (default), that overflow is written to a spill buffer
+  # under plugins/Spyglass/spill/ and replayed to the database as it catches
+  # up — so even a giant paste you CAN'T cap stays heap-flat and loses nothing
+  # (the trade is transient disk use + I/O during the burst). Put the plugin
+  # data folder on a fast LOCAL disk (not a network mount). With it off, an
+  # over-ceiling vanilla paste falls back to buffering overflow in RAM, which a
+  # big enough edit can still OOM. Requires queue-max > 0 (no ceiling, no
+  # overflow to spill).
+  spill-to-disk = true
   # Shutdown drain deadline. On server stop the recorder keeps retrying to
   # flush any not-yet-stored events for up to this long (with backoff)
   # before giving up; whatever cannot drain in time is counted as lost and

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -2,7 +2,9 @@ package net.medievalrp.spyglass.plugin.pipeline;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -22,6 +24,7 @@ import net.medievalrp.spyglass.api.util.Duration;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 class AsyncRecorderTest {
 
@@ -329,6 +332,68 @@ class AsyncRecorderTest {
             assertThat(report.dropped())
                     .as("main-thread admit path drops nothing")
                     .isZero();
+        }
+    }
+
+    @Test
+    @Timeout(20)
+    void recordAllSpillsToDiskAtCeilingThenDrainsLosslessly(@TempDir Path dataFolder) throws Exception {
+        // #122: the uncappable vanilla-WorldEdit firehose (recordAll) must spill
+        // its overflow to disk at the ceiling instead of holding it in RAM or
+        // blocking — so a giant paste stays heap-flat and loses nothing. With
+        // the store wedged, the queue caps and the bulk lands on disk; once the
+        // store opens, the drain replays queue + spill and every record persists.
+        long queueMax = 200L;
+        int batchSize = 100;
+        int batches = 40; // 4000 records — 20x the ceiling
+        int total = batchSize * batches;
+        SpillBuffer spill = new SpillBuffer(dataFolder, true, Logger.getLogger("test"));
+        GatedStore store = new GatedStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000L, queueMax, store, new WalDurability(null, false, Logger.getLogger("test")),
+                spill, () -> false, Logger.getLogger("test"));
+        AtomicInteger submitted = new AtomicInteger();
+        Thread producer = new Thread(() -> {
+            for (int b = 0; b < batches; b++) {
+                List<EventRecord> batch = new ArrayList<>(batchSize);
+                for (int i = 0; i < batchSize; i++) {
+                    batch.add(sampleRecord());
+                }
+                recorder.recordAll(batch);
+                submitted.incrementAndGet();
+            }
+        }, "we-firehose");
+        try {
+            producer.start();
+            // recordAll spills instead of parking, so the producer finishes the
+            // whole burst even though the store is wedged the entire time.
+            producer.join(8_000L);
+            assertThat(submitted.get())
+                    .as("recordAll must not block at the ceiling — it spills overflow to disk")
+                    .isEqualTo(batches);
+            assertThat(spill.hasPending())
+                    .as("the over-ceiling overflow must have gone to disk, not RAM")
+                    .isTrue();
+            assertThat(spill.pendingRecordCount())
+                    .as("the bulk of the burst is on disk; only ~queue-max stays in RAM")
+                    .isGreaterThan(total / 2L);
+
+            // Open the store: the drain replays queue + spill, losslessly.
+            store.open();
+            long deadline = System.currentTimeMillis() + 12_000L;
+            while (System.currentTimeMillis() < deadline && store.totalSaved() < total) {
+                Thread.sleep(25L);
+            }
+            assertThat(store.totalSaved())
+                    .as("every record persists — spilled overflow is replayed, nothing dropped")
+                    .isEqualTo(total);
+            assertThat(spill.hasPending())
+                    .as("all spilled segments are acked (deleted) after replay")
+                    .isFalse();
+        } finally {
+            store.open();
+            AsyncRecorder.ShutdownReport report = recorder.shutdown(Duration.parse("3s"));
+            assertThat(report.dropped()).as("the spill path drops nothing").isZero();
         }
     }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
@@ -1,0 +1,116 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SpillBufferTest {
+
+    private static final Logger LOG = Logger.getLogger("spill-test");
+
+    private static EventRecord record(UUID id) {
+        Instant now = Instant.now();
+        return new JoinRecord(id, "join", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "tester"),
+                new BlockLocation(UUID.randomUUID(), "world", 0, 64, 0),
+                "test", "tester", "127.0.0.1");
+    }
+
+    private static List<EventRecord> batch(UUID... ids) {
+        List<EventRecord> out = new ArrayList<>();
+        for (UUID id : ids) {
+            out.add(record(id));
+        }
+        return out;
+    }
+
+    @Test
+    void spillThenPollRoundTripsRecordsAndAckClears(@TempDir Path dir) throws Exception {
+        SpillBuffer spill = new SpillBuffer(dir, true, LOG);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        spill.spill(batch(a, b));
+
+        assertThat(spill.hasPending()).isTrue();
+        assertThat(spill.pendingRecordCount()).isEqualTo(2);
+
+        SpillBuffer.Spilled polled = spill.poll();
+        assertThat(polled).isNotNull();
+        assertThat(polled.records().stream().map(EventRecord::id).toList())
+                .as("spilled records round-trip through the on-disk codec by id")
+                .containsExactly(a, b);
+
+        spill.ack(polled);
+        assertThat(spill.hasPending()).isFalse();
+        assertThat(spill.pendingRecordCount()).isZero();
+        assertThat(spill.poll()).isNull();
+    }
+
+    @Test
+    void pollReturnsOldestSegmentFirst(@TempDir Path dir) throws Exception {
+        SpillBuffer spill = new SpillBuffer(dir, true, LOG);
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        spill.spill(batch(first));
+        spill.spill(batch(second));
+
+        SpillBuffer.Spilled a = spill.poll();
+        assertThat(a.records().getFirst().id()).isEqualTo(first);
+        spill.ack(a);
+        SpillBuffer.Spilled b = spill.poll();
+        assertThat(b.records().getFirst().id()).isEqualTo(second);
+    }
+
+    @Test
+    void recoversSegmentsLeftByAPriorRun(@TempDir Path dir) throws Exception {
+        UUID id = UUID.randomUUID();
+        new SpillBuffer(dir, true, LOG).spill(batch(id, UUID.randomUUID()));
+
+        // A fresh instance over the same data folder (i.e. a restart) must see
+        // the leftover segment and hand it back to the drain.
+        SpillBuffer restarted = new SpillBuffer(dir, true, LOG);
+        assertThat(restarted.hasPending()).isTrue();
+        assertThat(restarted.pendingRecordCount()).isEqualTo(2);
+        assertThat(restarted.poll().records().getFirst().id()).isEqualTo(id);
+    }
+
+    @Test
+    void disabledSpillIsANoOp(@TempDir Path dir) throws Exception {
+        SpillBuffer spill = new SpillBuffer(dir, false, LOG);
+        assertThat(spill.enabled()).isFalse();
+        spill.spill(batch(UUID.randomUUID()));
+        assertThat(spill.hasPending()).isFalse();
+        assertThat(spill.poll()).isNull();
+    }
+
+    @Test
+    void unreadableSegmentIsDroppedNotWedged(@TempDir Path dir) throws Exception {
+        // Hand-write a segment whose name parses (seq 0, 5 records) but whose
+        // bytes are garbage, then let a fresh buffer seed from it.
+        Path spillDir = dir.resolve("spill");
+        Files.createDirectories(spillDir);
+        Files.write(spillDir.resolve(String.format("%016d.%d.spill", 0, 5)),
+                new byte[]{1, 2, 3, 4});
+
+        SpillBuffer spill = new SpillBuffer(dir, true, LOG);
+        assertThat(spill.hasPending()).isTrue();
+        // poll() must drop the corrupt segment and return null, not throw or
+        // loop forever — a wedged segment would otherwise stall the drain.
+        assertThat(spill.poll()).isNull();
+        assertThat(spill.hasPending()).isFalse();
+        assertThat(spill.pendingRecordCount()).isZero();
+    }
+}


### PR DESCRIPTION
Closes #122. Follow-up to #119.

## Why

#119 bounded the recorder queue, but that alone doesn't bound **vanilla WorldEdit**: its `setBlock` loop runs on the main thread (which can't be blocked), so the over-ceiling records the off-main build threads can't hand off would just pile up in those threads' heap — `O(paste size)`. For a paste the operator **can't cap**, the only no-loss way to bound RAM is to put the overflow somewhere other than memory.

## What

An on-disk `SpillBuffer`. When the queue is at `queue-max`, `recordAll` (the WorldEdit firehose) writes its overflow batch to a fsynced disk segment instead of holding it in RAM; the drain replays spilled segments back to the store.

- **Heap stays flat** — overflow lives on disk; only ~`queue-max` stays in RAM.
- **Nothing is dropped** — the drain replays every spilled segment; as soon as it keeps up, batches flow back through the fast in-RAM path.
- **Crash-safe** — segments are fsync'd + atomically renamed (the drain never reads a partial), survive a hard crash, and are replayed on next start.
- **Read-your-writes** — `flush()`'s high-water mark includes spilled records, so a rollback issued right after a paste still waits for them.

Targeted at the firehose that needs it: `recordAll` spills; `record()` (FAWE / main thread) keeps #119's behaviour (FAWE backpressures upstream, the main thread always admits).

## Notable pieces

- New `SpillBuffer` — monotonic-named segments (`<seq>.<count>.spill`, lexical = chronological), fsync + atomic rename, oldest-first replay, corrupt-segment drop (can't wedge the drain), crash recovery on construction.
- Extracted the WAL's BSON batch encode/decode into a shared `EventBatchCodec` so spill and WAL share one on-disk format (no second serializer).
- Drain loop: hot in-RAM queue first; spilled overflow replayed when the queue idles; `persistWithRetry` extracted and shared by both paths (queue path re-queues on shutdown-mid-retry; spill path leaves the segment on disk for recovery).
- `storage.spill-to-disk` config (default `true`; requires `queue-max > 0`).

## Tests

- `SpillBufferTest` — spill→poll→ack round-trip (by id), oldest-first ordering, crash recovery from a prior run, corrupt-segment drop, disabled no-op.
- `recordAllSpillsToDiskAtCeilingThenDrainsLosslessly` — with the store wedged, a 4000-record burst (20× the ceiling) submits without blocking, the bulk lands on disk (`> total/2`), and once the store opens the drain replays queue + spill so all 4000 persist with `dropped == 0`.

`./gradlew check` green (all module jacoco floors held; `WalCrashRecoveryTest` confirms the refactored shared codec round-trips).

## Operator note

Put the plugin data folder on a **fast local disk** (not a network mount). Trade is transient disk use + I/O during a giant burst, in exchange for never OOMing and never dropping. `spill-to-disk = false` reverts to #119 (over-ceiling vanilla pastes buffer overflow in RAM and a big enough one can still OOM).