### PR TITLE
feat(worldedit): bound the record-build stage for huge WorldEdit operations (#121)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -256,15 +256,19 @@ public final class AsyncRecorder implements Recorder {
         // for, and it runs off-main.
         //
         // When the queue is at the ceiling, spill this batch to disk instead
-        // of holding it in RAM. Vanilla WorldEdit's setBlock loop runs on the
-        // main thread (which we can't block), so parking the off-main build
-        // thread would just pile the overflow up in that thread's heap —
-        // O(paste size). Spilling keeps the heap flat (overflow lives on disk)
-        // and loses nothing: the drain replays spilled segments. The drain
+        // of holding it in RAM. Spilling keeps the heap flat (overflow lives on
+        // disk) and loses nothing: the drain replays spilled segments. The drain
         // also frees queue space continuously, so as soon as it keeps up the
         // batches flow back through the fast in-RAM path.
-        if (spill.enabled() && queueMax > 0 && !primaryThread.getAsBoolean()
-                && queue.size() >= queueMax) {
+        //
+        // Spill on ANY thread, including the main thread: under #121 backpressure
+        // a huge WorldEdit op builds inline on the editing (main) thread once the
+        // off-thread build pool is saturated, and that inline build must spill to
+        // disk too — not fall through to the main-thread always-admit path, which
+        // would grow the queue unbounded again. The bulk recordAll callers are
+        // the WE firehose and the (tiny, synthesized) rollback audit, so spilling
+        // regardless of thread is correct for both.
+        if (spill.enabled() && queueMax > 0 && queue.size() >= queueMax) {
             try {
                 spill.spill(records);
                 return;

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
@@ -28,10 +28,14 @@ import org.jetbrains.annotations.Nullable;
  * <h2>Why this exists</h2>
  *
  * <p>Pure backpressure (#119) bounds the queue but not vanilla WorldEdit: its
- * {@code setBlock} loop runs on the main thread, which can't be blocked, so
- * the records that don't fit in the capped queue would otherwise pile up in
- * the off-main build threads. Spilling them to disk is the only way to bound
- * RAM for an op the operator can't cap without dropping records.
+ * {@code setBlock} loop runs on the main thread, which can't be blocked, so the
+ * records that don't fit in the capped queue would otherwise pile up in the
+ * off-main build threads. Spilling them to disk bounds the RAM of an op the
+ * operator can't cap, without dropping records. This works hand-in-hand with
+ * the bounded build stage (#121, {@code BoundedAsyncDispatcher}): the dispatcher
+ * caps how many record-builds are in flight, and the inline build it falls back
+ * to spills here — so Spyglass's own footprint stays bounded for an op of any
+ * size (Minecraft's per-block world-edit cost is separate and unbounded by us).
  *
  * <h2>Format &amp; crash-safety</h2>
  *

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/BoundedAsyncDispatcher.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/BoundedAsyncDispatcher.java
@@ -1,0 +1,86 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Caps how many WorldEdit record-build tasks run off-thread at once, and
+ * applies backpressure when that cap is hit by running the task <b>inline</b>
+ * on the calling thread.
+ *
+ * <h2>Why</h2>
+ *
+ * Vanilla WorldEdit's {@code setBlock} loop runs on the main thread and hands
+ * 50k-cell batches to an <em>unbounded</em> virtual-thread executor. Each build
+ * task constructs (and, when the queue is full, spills) its whole batch of
+ * records in memory. On a slow store the spill encode is the slow step, so an
+ * unbounded pool could spawn build tasks faster than they finish and pile their
+ * batches across the pool — the queue ceiling caps the queue but not this stage
+ * (#121). Bounding the in-flight build count is the matching cap.
+ *
+ * <p>Capping in-flight builds to {@code maxInFlight} bounds the records alive in
+ * the build stage to {@code (maxInFlight + 1) x batch} — a few hundred MB,
+ * independent of operation size. When all slots are busy the edit builds inline,
+ * which paces the main-thread edit to the rate the build/spill stage can keep up
+ * with: a TPS dip during a giant operation, but never a dropped record. With the
+ * queue cap + spill this makes Spyglass's own footprint bounded for any op; it
+ * does not (and cannot) bound Minecraft's own per-block cost for a huge edit.
+ *
+ * <p>Thread-safe; one instance is shared across all concurrent edits so the
+ * bound is global, not per-edit.
+ */
+@ApiStatus.Internal
+final class BoundedAsyncDispatcher {
+
+    private final Executor executor;
+    private final Semaphore permits;
+
+    BoundedAsyncDispatcher(Executor executor, int maxInFlight) {
+        if (maxInFlight < 1) {
+            throw new IllegalArgumentException("maxInFlight must be >= 1, was " + maxInFlight);
+        }
+        this.executor = executor;
+        this.permits = new Semaphore(maxInFlight);
+    }
+
+    /**
+     * Run {@code task} on the executor if an in-flight slot is free (releasing
+     * the slot when it completes, success or failure); otherwise run it inline
+     * on the calling thread. If the executor rejects the task (shut down), run
+     * it inline too, so no work is dropped.
+     */
+    void dispatch(Runnable task) {
+        if (!permits.tryAcquire()) {
+            // Saturated: build inline on the caller. This is the backpressure —
+            // the producing thread pays the build/spill cost itself, so it can't
+            // outrun persistence into an OOM.
+            task.run();
+            return;
+        }
+        boolean submitted = false;
+        try {
+            executor.execute(() -> {
+                try {
+                    task.run();
+                } finally {
+                    permits.release();
+                }
+            });
+            submitted = true;
+        } catch (RejectedExecutionException rejected) {
+            // Executor shut down (server stopping): run inline so nothing drops.
+            task.run();
+        } finally {
+            if (!submitted) {
+                permits.release();
+            }
+        }
+    }
+
+    /** Free in-flight slots — for tests/diagnostics. */
+    int availableSlots() {
+        return permits.availablePermits();
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditSubscriber.java
@@ -75,9 +75,17 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class WorldEditSubscriber {
 
+    // Caps WorldEdit record-builds in flight; excess builds run inline on the
+    // editing thread as backpressure, so the records alive in the (otherwise
+    // unbounded) build stage stay bounded for an op of any size (#121). With the
+    // queue cap + spill this bounds Spyglass's own footprint; it does not bound
+    // Minecraft's per-block cost. (maxInFlight + 1) x DRAIN_THRESHOLD records is
+    // the in-flight bound — a few hundred MB.
+    private static final int MAX_INFLIGHT_BUILDS = 4;
+
     private final Recorder recorder;
     private final RecordingSupport support;
-    private final Executor asyncExecutor;
+    private final BoundedAsyncDispatcher buildDispatcher;
     private final Plugin plugin;
     private final Logger logger;
 
@@ -85,7 +93,7 @@ public final class WorldEditSubscriber {
                                Executor asyncExecutor, Plugin plugin, Logger logger) {
         this.recorder = recorder;
         this.support = support;
-        this.asyncExecutor = asyncExecutor;
+        this.buildDispatcher = new BoundedAsyncDispatcher(asyncExecutor, MAX_INFLIGHT_BUILDS);
         this.plugin = plugin;
         this.logger = logger;
     }
@@ -267,20 +275,18 @@ public final class WorldEditSubscriber {
             }
         }
 
-        /** Hand the current buffer to the async executor and start a fresh one.
-         *  If the executor has been shut down (server stopping), build inline so
-         *  no records are dropped. */
+        /** Hand the current buffer to the build dispatcher and start a fresh
+         *  one. The dispatcher builds off-thread while in-flight builds are
+         *  under the cap, and inline on this (editing) thread once they hit it —
+         *  bounding the records alive in the build stage, and never dropping a
+         *  batch (inline also covers executor shutdown). */
         private void drain() {
             if (buffer.isEmpty()) {
                 return;
             }
             List<Pending> batch = buffer;
             buffer = new ArrayList<>();
-            try {
-                asyncExecutor.execute(() -> build(batch));
-            } catch (RuntimeException rejected) {
-                build(batch);
-            }
+            buildDispatcher.dispatch(() -> build(batch));
         }
 
         /** Off-main: convert WorldEdit's captured block data into break / place

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -94,28 +94,30 @@ storage {
   # outage leaves a growth trail. Sized for ~10× steady-state peak — at
   # MedievalRP's ~600 ev/s that gives ~160 s of slack before the first warning.
   queue-capacity = 100000
-  # HARD CEILING on the ingest queue. When the queue reaches this depth the
-  # off-main bulk-edit firehoses (a large WorldEdit / FAWE paste) backpressure
-  # — they block until the drain frees space — so a multi-million-block edit
-  # can never grow the queue into an out-of-memory crash. Nothing is dropped:
-  # the edit's logging is simply paced to the database. The main server thread
-  # is NEVER blocked (its low-rate audit events are always admitted), so TPS is
-  # unaffected. At ~400 bytes/record the default 500000 caps the queue near
-  # ~200 MiB. Raise it if you have heap to spare and want more burst headroom;
-  # set 0 to disable the ceiling and restore the legacy unbounded queue (a big
-  # enough paste can then OOM the server). Keep it above queue-capacity.
+  # HARD CEILING on the in-memory ingest queue. When the queue reaches this
+  # depth, the bulk-edit firehoses (a large WorldEdit / FAWE operation) stop
+  # adding to it — off-main producers backpressure and the overflow goes to the
+  # disk spill (see spill-to-disk below). Nothing is dropped: the edit's logging
+  # is paced to what the database + disk can absorb. The main server thread is
+  # never blocked by THIS knob (its low-rate audit events are always admitted).
+  # At ~400 bytes/record the default 500000 caps the queue near ~200 MiB. Raise
+  # it if you have heap to spare and want more burst headroom; set 0 to disable
+  # the ceiling and restore the legacy unbounded queue (a big enough edit can
+  # then OOM the server). Keep it above queue-capacity.
   queue-max = 500000
-  # ON-DISK OVERFLOW. The queue-max ceiling above bounds the in-memory queue,
-  # but a vanilla-WorldEdit paste runs on the main thread (which is never
-  # blocked), so the records that don't fit in the queue have to go somewhere.
-  # With spill-to-disk on (default), that overflow is written to a spill buffer
-  # under plugins/Spyglass/spill/ and replayed to the database as it catches
-  # up — so even a giant paste you CAN'T cap stays heap-flat and loses nothing
-  # (the trade is transient disk use + I/O during the burst). Put the plugin
-  # data folder on a fast LOCAL disk (not a network mount). With it off, an
-  # over-ceiling vanilla paste falls back to buffering overflow in RAM, which a
-  # big enough edit can still OOM. Requires queue-max > 0 (no ceiling, no
-  # overflow to spill).
+  # ON-DISK OVERFLOW for huge WorldEdit operations (//set, //paste, //replace,
+  # //walls, brushes — anything, since logging hooks every block change). Such
+  # an op runs on the main thread and produces records faster than the database
+  # ingests, so the overflow has to go somewhere other than the heap. With
+  # spill-to-disk on (default), records past the queue-max ceiling are written
+  # to plugins/Spyglass/spill/ and replayed to the database as it catches up;
+  # together with the bounded record-build stage, this keeps the heap flat for
+  # an operation of ANY size and loses nothing. The trade is transient disk use
+  # + I/O during the op, and — for an op that outruns the disk too — a brief TPS
+  # dip while the edit paces itself to the spill (never an OOM, never a drop).
+  # Put the plugin data folder on a fast LOCAL disk (not a network mount). With
+  # it off, an over-ceiling op buffers overflow in RAM and a big enough one can
+  # still OOM. Requires queue-max > 0 (no ceiling, no overflow to spill).
   spill-to-disk = true
   # Shutdown drain deadline. On server stop the recorder keeps retrying to
   # flush any not-yet-stored events for up to this long (with backoff)

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -397,6 +397,58 @@ class AsyncRecorderTest {
         }
     }
 
+    private static List<EventRecord> sampleBatch(int n) {
+        List<EventRecord> out = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            out.add(sampleRecord());
+        }
+        return out;
+    }
+
+    @Test
+    @Timeout(15)
+    void recordAllSpillsOnTheMainThreadWhenTheQueueIsFull(@TempDir Path dataFolder) throws Exception {
+        // #121: when a huge WorldEdit op saturates the off-thread build pool it
+        // builds inline on the MAIN thread, and that inline recordAll must spill
+        // to disk — not fall through to the main-thread always-admit path, which
+        // would grow the queue unbounded again. So recordAll spills once the
+        // queue is at the ceiling regardless of thread.
+        SpillBuffer spill = new SpillBuffer(dataFolder, true, Logger.getLogger("test"));
+        GatedStore store = new GatedStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000L, 10L, store, new WalDurability(null, false, Logger.getLogger("test")),
+                spill, () -> true, Logger.getLogger("test")); // () -> true: every caller is "main"
+        try {
+            // Several main-thread batches: the first fills the queue past the
+            // ceiling, the rest must spill (the drain is wedged, so the queue
+            // can't drain below the ceiling). None may block the main thread — a
+            // blocking impl would deadlock against the wedged store.
+            int batches = 5;
+            int perBatch = 50;
+            for (int b = 0; b < batches; b++) {
+                recorder.recordAll(sampleBatch(perBatch));
+            }
+            assertThat(spill.hasPending())
+                    .as("main-thread recordAll must spill once the queue is at the ceiling")
+                    .isTrue();
+            assertThat(spill.pendingRecordCount()).isGreaterThan(0L);
+
+            store.open();
+            int total = batches * perBatch;
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline && store.totalSaved() < total) {
+                Thread.sleep(25L);
+            }
+            assertThat(store.totalSaved())
+                    .as("every record persists — queue + spill both replayed, nothing dropped")
+                    .isEqualTo(total);
+            assertThat(spill.hasPending()).isFalse();
+        } finally {
+            store.open();
+            assertThat(recorder.shutdown(Duration.parse("3s")).dropped()).isZero();
+        }
+    }
+
     /**
      * Store whose save() blocks until {@link #open()} is called — models a
      * wedged drain so the backpressure ceiling engages deterministically. No

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/BoundedAsyncDispatcherTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/worldedit/BoundedAsyncDispatcherTest.java
@@ -1,0 +1,88 @@
+package net.medievalrp.spyglass.plugin.worldedit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class BoundedAsyncDispatcherTest {
+
+    @Test
+    @Timeout(10)
+    void runsInlineOnTheCallerWhenAllSlotsAreBusy() throws Exception {
+        // The #121 backpressure: once the in-flight cap is reached, a dispatch
+        // must run on the CALLING thread (so a huge WorldEdit op paces itself to
+        // the build/spill rate instead of spawning unbounded builders → OOM).
+        ExecutorService pool = Executors.newCachedThreadPool();
+        try {
+            BoundedAsyncDispatcher dispatcher = new BoundedAsyncDispatcher(pool, 1);
+            CountDownLatch freeTheSlot = new CountDownLatch(1);
+            CountDownLatch asyncStarted = new CountDownLatch(1);
+            // Occupy the only slot with a task that blocks until released.
+            dispatcher.dispatch(() -> {
+                asyncStarted.countDown();
+                try {
+                    freeTheSlot.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertThat(asyncStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(dispatcher.availableSlots()).isZero();
+
+            AtomicReference<Thread> ranOn = new AtomicReference<>();
+            dispatcher.dispatch(() -> ranOn.set(Thread.currentThread()));
+            assertThat(ranOn.get())
+                    .as("a saturated dispatch must run inline on the calling thread")
+                    .isSameAs(Thread.currentThread());
+
+            freeTheSlot.countDown();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void releasesTheSlotAfterTheAsyncTaskFinishes() throws Exception {
+        ExecutorService pool = Executors.newCachedThreadPool();
+        try {
+            BoundedAsyncDispatcher dispatcher = new BoundedAsyncDispatcher(pool, 2);
+            CountDownLatch done = new CountDownLatch(1);
+            dispatcher.dispatch(done::countDown);
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+            long deadline = System.currentTimeMillis() + 2_000L;
+            while (dispatcher.availableSlots() < 2 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10L);
+            }
+            assertThat(dispatcher.availableSlots())
+                    .as("the slot must be released once the async task completes")
+                    .isEqualTo(2);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void runsInlineAndReleasesTheSlotWhenTheExecutorRejects() {
+        // Executor shut down (server stopping): the task must still run (inline),
+        // never be dropped, and the speculatively-acquired permit must be freed.
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        pool.shutdownNow();
+        BoundedAsyncDispatcher dispatcher = new BoundedAsyncDispatcher(pool, 4);
+        AtomicReference<Thread> ranOn = new AtomicReference<>();
+        dispatcher.dispatch(() -> ranOn.set(Thread.currentThread()));
+        assertThat(ranOn.get())
+                .as("a rejected task must run inline, never drop")
+                .isSameAs(Thread.currentThread());
+        assertThat(dispatcher.availableSlots())
+                .as("the permit must be released after a rejected submit")
+                .isEqualTo(4);
+    }
+}


### PR DESCRIPTION
Closes #121. Follow-up to #119 + #122.

## Context (and a correction)

Live-testing #122 on a constrained heap, I first concluded the spill "still OOMs" and that this was the build stage overflowing. A **heap histogram** corrected that: a 2M-block `//set` on a 768M heap is dominated by **`net.minecraft` world objects** — `AABB`, `ArrayVoxelShape`, Moonrise collision-shape caches, chunk `PalettedContainer`/byte-arrays — **not** Spyglass. Minecraft's own per-block cost for a huge edit simply doesn't fit a 768M heap, regardless of Spyglass.

What's genuinely true and worth fixing: vanilla WorldEdit hands 50k-cell batches to an **unbounded** virtual-thread executor, and on a **slow store** the spill encode is the slow step — so an unbounded pool could spawn builds faster than they finish and pile their batches. The queue cap (#119) + spill (#122) bound the queue; this bounds the build stage too.

## What

`BoundedAsyncDispatcher`: cap in-flight builds (4); when saturated, build **inline** on the editing thread. Inline paces the main-thread edit to the build/spill rate — a TPS dip during a giant op, **never a dropped record** — so records alive in the build stage stay bounded to `(maxInFlight + 1) x batch`, independent of op size. `recordAll` now spills regardless of thread, so an inline (main-thread) build spills to disk instead of growing the queue.

Covers **all** big WorldEdit ops (`//set`, `//paste`, `//replace`, `//walls`, brushes…) since logging hooks every block change.

**Scope, stated plainly:** with #119 + #122 this bounds **Spyglass's own footprint** for an op of any size. It does **not** bound Minecraft's per-block world-edit memory — a huge enough op still needs adequate heap and/or FAWE.

## Verification

- Unit: `BoundedAsyncDispatcherTest` (inline-when-saturated, slot release, reject fallback); `AsyncRecorder` recordAll-spills-on-the-main-thread. `./gradlew check` green.
- **Live** (isolated Paper 1.21.8, vanilla WE, no FAWE, SQLite, `queue-max=2000`): a 2M-block `//set` on a 2G/3G heap **survives**, spill engages (peak ~21 segments / ~670 MiB) and drains, all **2,097,152 records land losslessly**.
- Heap histogram confirming the 768M OOM is `net.minecraft` world objects, not Spyglass.

Also tempers the over-strong "can never OOM / stays heap-flat" wording in #122's config docs to "bounds Spyglass's footprint."