### PR TITLE
perf(pipeline): stream the spill/WAL batch encode instead of materializing a BsonDocument tree (#125)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodec.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodec.java
@@ -62,23 +62,30 @@ final class EventBatchCodec {
     private EventBatchCodec() {
     }
 
-    /** Encode a batch as a single BSON document. */
+    /**
+     * Encode a batch as a single BSON document {@code { r: [ <record>, ... ] }}.
+     *
+     * <p>Streams each record straight through the {@link BsonBinaryWriter} into
+     * the output buffer — it does NOT first build a {@code BsonArray} of
+     * {@code BsonDocument}s. The materialized-tree approach allocated ~3x the
+     * batch as a `LinkedHashMap`-backed BSON object graph, which dominated the
+     * heap while several batches spilled in parallel (#125); streaming drops the
+     * transient to roughly the serialized buffer. The bytes are identical, so
+     * {@link #decode} and on-disk WAL/spill segments are unchanged.
+     */
     static byte[] encode(List<EventRecord> batch) {
-        BsonArray array = new BsonArray();
-        for (EventRecord record : batch) {
-            BsonDocument wrapper = new BsonDocument();
-            try (org.bson.BsonDocumentWriter writer = new org.bson.BsonDocumentWriter(wrapper)) {
-                writer.writeStartDocument();
-                writer.writeName(VALUE_KEY);
-                EVENT_RECORD_CODEC.encode(writer, record, EncoderContext.builder().build());
-                writer.writeEndDocument();
-            }
-            array.add(wrapper.get(VALUE_KEY));
-        }
-        BsonDocument document = new BsonDocument().append(RECORDS_KEY, array);
+        EncoderContext ctx = EncoderContext.builder().build();
         BasicOutputBuffer buffer = new BasicOutputBuffer();
         try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
-            REGISTRY.get(BsonDocument.class).encode(writer, document, EncoderContext.builder().build());
+            writer.writeStartDocument();
+            writer.writeStartArray(RECORDS_KEY);
+            for (EventRecord record : batch) {
+                // Codec writes a document per record directly as an array
+                // element — same shape the old wrap-then-unwrap produced.
+                EVENT_RECORD_CODEC.encode(writer, record, ctx);
+            }
+            writer.writeEndArray();
+            writer.writeEndDocument();
         }
         return buffer.toByteArray();
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodecTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/EventBatchCodecTest.java
@@ -1,0 +1,54 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+class EventBatchCodecTest {
+
+    private static EventRecord record(UUID id, String name) {
+        Instant now = Instant.now();
+        return new JoinRecord(id, "join", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), name),
+                new BlockLocation(UUID.randomUUID(), "world", 0, 64, 0),
+                "srv", name, "127.0.0.1");
+    }
+
+    @Test
+    void streamedEncodeRoundTripsEveryRecordInOrder() {
+        // #125: encode streams records straight to the buffer (no intermediate
+        // BsonArray/BsonDocument tree). The on-disk bytes must stay decodable,
+        // in order, with every field intact.
+        List<UUID> ids = new ArrayList<>();
+        List<EventRecord> batch = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            UUID id = UUID.randomUUID();
+            ids.add(id);
+            batch.add(record(id, "player" + i));
+        }
+
+        List<EventRecord> decoded = EventBatchCodec.decode(EventBatchCodec.encode(batch));
+
+        assertThat(decoded).hasSize(batch.size());
+        assertThat(decoded.stream().map(EventRecord::id).toList())
+                .as("streamed encode must round-trip every record, in order, by id")
+                .containsExactlyElementsOf(ids);
+        assertThat(((JoinRecord) decoded.get(7)).target())
+                .as("record fields survive the streamed array-of-documents shape")
+                .isEqualTo("player7");
+    }
+
+    @Test
+    void encodesAnEmptyBatchToADecodableEmptyArray() {
+        assertThat(EventBatchCodec.decode(EventBatchCodec.encode(List.of()))).isEmpty();
+    }
+}


### PR DESCRIPTION
Live-testing the spill on ClickHouse + wal-batched, a heap histogram showed the
spill peaked ~900 MB HIGHER than the legacy unbounded queue for the same 1M-record
//set — the opposite of what the spill is for. Cause: EventBatchCodec.encode built
the whole batch as an in-memory BSON object tree (BsonArray of BsonDocuments)
before serializing; with several batches spilling in parallel that materialized
~9.4M LinkedHashMap$Entry (375 MB) plus BsonString/BsonArray/BsonDocument/byte[].

Stream it: write each record straight through a single BsonBinaryWriter into the
output buffer (writeStartArray + EVENT_RECORD_CODEC.encode per record), no
intermediate object tree. Same bytes ({r:[<record doc>...]}), so decode and the
on-disk WAL/spill format are unchanged and backward-compatible. Benefits both the
spill (#122) and the WAL (wal-batched), which share this codec.

Live re-measure (ClickHouse + wal, 1M-block //set, 3G heap): BSON
LinkedHashMap$Entry 375 MB -> 1.4 MB; spill peak heap 2856 -> 2192 MiB (~660 MB
saved), all 1M records still land losslessly, spill engages + drains.

Test: EventBatchCodecTest (streamed encode round-trips in order, by id, fields
intact; empty batch). Existing SpillBufferTest + WalCrashRecoveryTest (round-trip
+ crash replay) stay green, confirming format compatibility.
