### PR TITLE
fix(util): bound FallingBlockTracker so unconsumed cascade cells can't leak (#128)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -52,6 +52,7 @@ import net.medievalrp.spyglass.plugin.listener.block.ContainerDropListener;
 import net.medievalrp.spyglass.plugin.listener.block.DependantBreakListener;
 import net.medievalrp.spyglass.plugin.listener.block.FallingBlockLandListener;
 import net.medievalrp.spyglass.plugin.listener.block.MultiBlockBreakListener;
+import net.medievalrp.spyglass.plugin.util.FallingBlockTracker;
 import net.medievalrp.spyglass.plugin.listener.chat.ChatListener;
 import net.medievalrp.spyglass.plugin.listener.chat.CommandListener;
 import net.medievalrp.spyglass.plugin.listener.chat.CommandRedaction;
@@ -596,6 +597,15 @@ public final class SpyglassPlugin extends JavaPlugin {
             getLogger().info("Spyglass: bStats metrics enabled (opt out with metrics.enabled=false).");
         }
 
+        // Bound FallingBlockTracker's memory. consume() only removes cells
+        // whose falling block lands at its origin; cells that shatter over
+        // water/lava, fall into the void, or are removed (/kill, anti-cheat)
+        // are reclaimed only by TTL eviction. track() self-purges amortized,
+        // and this timer covers the idle-after-burst case. Async is safe:
+        // removeIf on the ConcurrentMap never touches the world (#128).
+        getServer().getScheduler().runTaskTimerAsynchronously(
+                this, FallingBlockTracker::purgeExpired, 600L, 600L);
+
         getLogger().info("Spyglass enabled; events=" + enabledEvents);
     }
 
@@ -676,6 +686,9 @@ public final class SpyglassPlugin extends JavaPlugin {
             }
             worldWriteExecutor = null;
         }
+        // Drop any falling-block attribution so a /reload doesn't carry stale
+        // cells across into the next plugin instance (the map is static).
+        FallingBlockTracker.clear();
         Bukkit.getServicesManager().unregisterAll(this);
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockTracker.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockTracker.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -26,11 +28,23 @@ import org.jetbrains.annotations.ApiStatus;
  * {@link org.bukkit.entity.Entity#getOrigin()} gives the listener the
  * exact spawn coordinate to look up.
  *
- * <p>TTL guards against the rare case where a falling-block entity is
- * frozen by /tp, /freeze, plot border, ride, …; without TTL eviction
- * a stuck entity would leave a row in the map indefinitely. Falls
- * normally complete in well under a second; 30 s is a wide safety
- * margin.
+ * <p>TTL guards against the case where a falling-block entity never
+ * lands at its origin: it shatters into an item over water/lava, falls
+ * into the void, or is removed by {@code /kill}, an anti-cheat, a plot
+ * border, a ride, … In all of those the matching {@link #consume} never
+ * fires, so the entry can only leave the map by TTL eviction. Falls
+ * complete in well under a second; 30 s is a wide safety margin.
+ *
+ * <p><b>Memory bound.</b> Because {@link #consume} only removes the
+ * entries that <em>do</em> land, eviction of the rest is not optional —
+ * it is the only thing that keeps the map from growing without limit
+ * (a {@code //set air} under a desert over water cascades thousands of
+ * cells whose falling blocks all shatter and never land). {@link #track}
+ * therefore sweeps expired entries amortized, every {@link #PURGE_INTERVAL}
+ * inserts, so the live set can never exceed roughly one purge-interval
+ * plus whatever was tracked inside the last TTL window — independent of
+ * uptime. The plugin also runs {@link #purgeExpired} on a timer so an
+ * idle burst that stops tracking is still reclaimed promptly.
  */
 @ApiStatus.Internal
 public final class FallingBlockTracker {
@@ -40,7 +54,20 @@ public final class FallingBlockTracker {
      *  this is a wide margin for stuck entities (frozen, ridden, …). */
     private static final long TTL_MILLIS = 30_000L;
 
+    /** Amortized self-purge cadence: every this many {@link #track} calls
+     *  we sweep expired entries. Bounds the map without a scheduler even
+     *  if the timer never runs. Small relative to a bulk-edit cascade so
+     *  a giant op purges many times as it streams. */
+    private static final int PURGE_INTERVAL = 1024;
+
     private static final ConcurrentMap<Key, Cell> CELLS = new ConcurrentHashMap<>();
+
+    /** Inserts since the last amortized purge. */
+    private static final AtomicInteger SINCE_PURGE = new AtomicInteger();
+
+    /** Clock seam so tests can drive TTL eviction deterministically;
+     *  production reads the wall clock. */
+    private static volatile LongSupplier clock = System::currentTimeMillis;
 
     private FallingBlockTracker() {
     }
@@ -50,12 +77,20 @@ public final class FallingBlockTracker {
      * falling-block entity, caused by {@code playerId}/{@code
      * playerName}. The matching landing event will look this up via
      * {@link #consume}.
+     *
+     * <p>Sweeps expired entries every {@link #PURGE_INTERVAL} inserts so
+     * a cascade of cells that never land can't grow the map without
+     * bound.
      */
     public static void track(UUID worldId, int x, int y, int z,
                              UUID playerId, String playerName) {
-        long expiresAt = System.currentTimeMillis() + TTL_MILLIS;
+        long now = clock.getAsLong();
         CELLS.put(new Key(worldId, x, y, z),
-                new Cell(playerId, playerName, expiresAt));
+                new Cell(playerId, playerName, now + TTL_MILLIS));
+        if (SINCE_PURGE.incrementAndGet() >= PURGE_INTERVAL) {
+            SINCE_PURGE.set(0);
+            purgeExpired();
+        }
     }
 
     /**
@@ -70,20 +105,22 @@ public final class FallingBlockTracker {
         if (cell == null) {
             return Optional.empty();
         }
-        if (System.currentTimeMillis() > cell.expiresAt) {
+        if (clock.getAsLong() > cell.expiresAt) {
             return Optional.empty();
         }
         return Optional.of(new Tracked(cell.playerId, cell.playerName));
     }
 
     /**
-     * Lazy purge — sweeps expired entries. Cheap when the map is small
-     * (no entries within the live window). Callers can run this on a
-     * timer or just before a {@link #track} burst; not required for
-     * correctness because {@link #consume} TTL-checks on read.
+     * Sweep expired entries. Cheap when the map is small (no entries
+     * within the live window). Run amortized from {@link #track} and on
+     * a timer from the plugin; correctness of attribution does not
+     * depend on it (consume TTL-checks on read), but the memory bound
+     * does — an entry whose falling block never lands is only ever
+     * removed here.
      */
     public static void purgeExpired() {
-        long now = System.currentTimeMillis();
+        long now = clock.getAsLong();
         CELLS.entrySet().removeIf(entry -> now > entry.getValue().expiresAt);
     }
 
@@ -92,9 +129,17 @@ public final class FallingBlockTracker {
         return CELLS.size();
     }
 
-    /** Test hook — wipes the map. Production code never calls this. */
+    /** Test hook — wipes the map. Production code calls this on disable
+     *  so a {@code /reload} doesn't carry stale attribution across. */
     public static void clear() {
         CELLS.clear();
+        SINCE_PURGE.set(0);
+    }
+
+    /** Test seam: override the clock used for TTL. Pass {@code null} to
+     *  restore the wall clock. */
+    static void setClockForTest(LongSupplier testClock) {
+        clock = testClock == null ? System::currentTimeMillis : testClock;
     }
 
     /** Public DTO returned to the landing listener. */

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockTrackerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockTrackerTest.java
@@ -1,0 +1,90 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the memory bound of {@link FallingBlockTracker} (#128). Cells whose
+ * falling block never lands at its origin (shatter over water/lava, fall into
+ * the void, removed by /kill) are never {@code consume}d, so eviction is the
+ * only thing keeping the map from growing without limit.
+ */
+class FallingBlockTrackerTest {
+
+    private final AtomicLong now = new AtomicLong(1_000L);
+
+    @BeforeEach
+    void useFakeClock() {
+        FallingBlockTracker.clear();
+        FallingBlockTracker.setClockForTest(now::get);
+    }
+
+    @AfterEach
+    void restoreClock() {
+        FallingBlockTracker.clear();
+        FallingBlockTracker.setClockForTest(null);
+    }
+
+    @Test
+    void purgeExpiredDropsCellsPastTtl() {
+        UUID world = UUID.randomUUID();
+        for (int i = 0; i < 50; i++) {
+            FallingBlockTracker.track(world, i, 64, 0, UUID.randomUUID(), "p" + i);
+        }
+        assertThat(FallingBlockTracker.size()).isEqualTo(50);
+
+        // Advance past the 30 s TTL: none of these landed (no consume call).
+        now.addAndGet(31_000L);
+        FallingBlockTracker.purgeExpired();
+
+        assertThat(FallingBlockTracker.size()).isZero();
+    }
+
+    @Test
+    void trackSelfPurgesSoUnconsumedCellsCannotGrowWithoutBound() {
+        UUID world = UUID.randomUUID();
+
+        // A burst of cascade cells that all shatter and never land.
+        for (int i = 0; i < 2_000; i++) {
+            FallingBlockTracker.track(world, i, 64, 0, UUID.randomUUID(), "p" + i);
+        }
+        int afterBurst = FallingBlockTracker.size();
+
+        // Time moves past their TTL, then a steady trickle of fresh cells keeps
+        // coming (more terrain edits). Without the amortized purge in track(),
+        // the 2 000 dead cells would sit forever and the map would only grow.
+        now.addAndGet(31_000L);
+        for (int i = 0; i < 2_000; i++) {
+            FallingBlockTracker.track(world, 100_000 + i, 64, 0, UUID.randomUUID(), "q" + i);
+        }
+
+        // The dead burst has been reclaimed: the live set reflects only the
+        // recent fresh cells, not burst + trickle accumulated.
+        assertThat(FallingBlockTracker.size())
+                .as("expired cells must not accumulate across track() calls")
+                .isLessThan(afterBurst + 1_024);
+    }
+
+    @Test
+    void freshCellStillConsumableAfterSelfPurge() {
+        UUID world = UUID.randomUUID();
+        UUID player = UUID.randomUUID();
+        FallingBlockTracker.track(world, 7, 70, 7, player, "alex");
+
+        // Drive enough tracks to trigger the amortized purge; the fresh cell
+        // is within TTL so it must survive and stay attributable.
+        for (int i = 0; i < 1_100; i++) {
+            FallingBlockTracker.track(world, 200_000 + i, 64, 0, UUID.randomUUID(), "x");
+        }
+
+        assertThat(FallingBlockTracker.consume(world, 7, 70, 7))
+                .get()
+                .extracting(FallingBlockTracker.Tracked::playerId)
+                .isEqualTo(player);
+    }
+}


### PR DESCRIPTION
Closes #128.

## Problem
`FallingBlockTracker.CELLS` is drained only by `consume()` on a successful landing. Cells whose falling block shatters over water/lava, falls into the void, or is removed (/kill, anti-cheat, plot border) never fire `EntityChangeBlockEvent` at their origin, so they can only leave the map via TTL eviction — and `purgeExpired()` was **never called anywhere**. WorldEdit terrain work (e.g. `//set air` under desert dunes over water) cascades thousands of never-landing cells, so the static map grew without bound across uptime — the same unbounded-input shape as the WorldEdit-paste OOM, slower.

## Fix
- `track()` sweeps expired entries amortized (every `PURGE_INTERVAL` inserts) so growth is bounded with no scheduler dependency.
- `SpyglassPlugin` schedules `purgeExpired()` every 30s (async; `removeIf` on the `ConcurrentMap` never touches the world) for the idle-after-burst case, and clears the map on disable so a `/reload` does not carry stale attribution.
- Clock seam + `FallingBlockTrackerTest` (3 tests) cover TTL eviction, the self-purge bound, and that a fresh cell stays consumable across a purge.

## Verification
`./gradlew :spyglass:test` green. New tests pass; no regressions.

🤖 Found and fixed during an autonomous production bug hunt.