### PR TITLE
fix(rollback): fail the job on an apply-phase exception instead of wedging the queue (#127)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -246,6 +246,59 @@ public final class RollbackEngine {
         return applyAllChunked(effects, sender, ServiceSupport.synchronous(), Integer.MAX_VALUE).join();
     }
 
+    // --- Apply-phase fail-safe (#127) -----------------------------------
+    // The chunked apply drives world writes through a `done` future across
+    // many main-thread continuations (resolve chunk, finish chunk, salvage
+    // capture, advance batch). Each runs via scheduler.onMainThread/Later,
+    // whose Bukkit impl swallows-and-logs any throwable — so a throw from
+    // prepareChunk / finishChunk / a salvage capture / a worker palette write
+    // would leave `done` forever uncompleted. RollbackService.streamPagesAndApply
+    // joins on `done`, so that strands the rollback thread, wedges the whole
+    // job queue (finish() never runs, no other rollback can start), leaks the
+    // physics-blocker region (gravity blocks freeze in the bbox), and pins
+    // chunk tickets — until restart. Wrapping the scheduler funnels every
+    // continuation through guardApply: a throw now fails `done` instead, so
+    // the join throws, the job is marked FAILED, the queue advances, and the
+    // physics region is released (done.whenComplete(exit) fires on failure).
+
+    /** Decorate {@code delegate} so any throwable from a dispatched apply step
+     *  completes {@code done} exceptionally instead of vanishing. Identical
+     *  threading — it only adds a try/catch frame around each runnable. */
+    private static ServiceSupport failOnThrow(ServiceSupport delegate,
+                                              CompletableFuture<?> done) {
+        return new ServiceSupport() {
+            @Override
+            public void onMainThread(Runnable runnable) {
+                delegate.onMainThread(() -> guardApply(runnable, done));
+            }
+
+            @Override
+            public void onMainThreadLater(long delayTicks, Runnable runnable) {
+                delegate.onMainThreadLater(delayTicks, () -> guardApply(runnable, done));
+            }
+
+            @Override
+            public void onAsyncThread(Runnable runnable) {
+                delegate.onAsyncThread(() -> guardApply(runnable, done));
+            }
+        };
+    }
+
+    private static void guardApply(Runnable step, CompletableFuture<?> done) {
+        try {
+            step.run();
+        } catch (Throwable thrown) {
+            failApply(done, thrown);
+        }
+    }
+
+    private static void failApply(CompletableFuture<?> done, Throwable thrown) {
+        LOGGER.log(Level.SEVERE, "Spyglass rollback apply step threw; failing the job so the"
+                + " rollback queue, physics-blocker region, and chunk tickets are released (#127)",
+                thrown);
+        done.completeExceptionally(thrown);
+    }
+
     public CompletableFuture<List<RollbackResult>> applyAllChunked(
             List<RollbackEffect> effects, CommandSender sender,
             ServiceSupport scheduler, int batchSize) {
@@ -294,6 +347,11 @@ public final class RollbackEngine {
 
         RollbackResult[] resultArray = new RollbackResult[effects.size()];
 
+        // Fail-safe scheduler: any throw from an apply continuation fails
+        // `done` instead of stranding the join (#127). Threaded through the
+        // whole chain so every onMainThread/Later hop is guarded.
+        ServiceSupport guarded = failOnThrow(scheduler, done);
+
         // Stage 1 is pure compute (filter, bbox, sort) and runs off
         // the main thread when an executor is wired. Stage 2 touches
         // Bukkit and hops back to the server thread.
@@ -326,15 +384,17 @@ public final class RollbackEngine {
 
             sortParallelByChunk(blockReplaceIndices, blockReplaceEffects);
 
-            scheduler.onMainThread(() -> applyChunkByChunk(0, effects, resultArray,
+            guarded.onMainThread(() -> applyChunkByChunk(0, effects, resultArray,
                     blockReplaceIndices, blockReplaceEffects,
- sender, scheduler, batchSize, done, cancelFlag));
+ sender, guarded, batchSize, done, cancelFlag));
         };
 
+        // Guard the off-main stage-1 work too: a throw on the executor thread
+        // (sort/bbox/enter) would otherwise leave `done` uncompleted.
         if (worldWriteExecutor != null) {
-            CompletableFuture.runAsync(stageOne, worldWriteExecutor);
+            CompletableFuture.runAsync(() -> guardApply(stageOne, done), worldWriteExecutor);
         } else {
-            stageOne.run();
+            guardApply(stageOne, done);
         }
         return done;
     }
@@ -703,6 +763,14 @@ public final class RollbackEngine {
 
         CompletableFuture.allOf(futures)
                 .whenComplete((v, throwable) -> {
+                    if (throwable != null) {
+                        // A worker palette write failed. The main-thread post
+                        // below still runs (finishChunk/tile-entities/ticket
+                        // release), but those cells may be left unrolled —
+                        // surface it rather than silently dropping it (#127).
+                        LOGGER.log(Level.WARNING, "Spyglass rollback: a parallel chunk"
+                                + " write failed; affected cells may be left unrolled", throwable);
+                    }
                     applyWriteNanos.addAndGet(System.nanoTime() - tDispatch);
                     applyBatchCount.incrementAndGet();
                     applyChunkApplies.addAndGet(batchChunks);
@@ -934,16 +1002,19 @@ public final class RollbackEngine {
                     cols.maxX(), cols.maxY(), cols.maxZ());
             done.whenComplete((r, t) -> physicsBlocker.exit(handle));
         }
+        // Fail-safe scheduler: any throw from an apply continuation fails
+        // `done` instead of stranding the join (#127).
+        ServiceSupport guarded = failOnThrow(scheduler, done);
         // Sort off-main (chunk-grouped, bottom-up Y), then apply on main.
         Runnable stageOne = () -> {
             int[] order = cols.chunkSortedOrder();
-            scheduler.onMainThread(() -> applyColumnBatch(
-                    world, cols, order, 0, counts, sender, scheduler, batchSize, done, cancelFlag));
+            guarded.onMainThread(() -> applyColumnBatch(
+                    world, cols, order, 0, counts, sender, guarded, batchSize, done, cancelFlag));
         };
         if (worldWriteExecutor != null) {
-            CompletableFuture.runAsync(stageOne, worldWriteExecutor);
+            CompletableFuture.runAsync(() -> guardApply(stageOne, done), worldWriteExecutor);
         } else {
-            stageOne.run();
+            guardApply(stageOne, done);
         }
         return done;
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackApplyFailsafeTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackApplyFailsafeTest.java
@@ -1,0 +1,158 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.RollbackResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.command.service.ServiceSupport;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Fail-safe for the chunked apply path (#127). A throw from a main-thread
+ * apply step (chunk resolve / finish / salvage capture / worker write) must
+ * fail the {@code done} future instead of leaving it forever uncompleted —
+ * otherwise {@code RollbackService.streamPagesAndApply} joins on it forever,
+ * stranding the rollback thread, wedging the whole job queue, leaking the
+ * physics-blocker region, and pinning chunk tickets until restart.
+ */
+class RollbackApplyFailsafeTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("88888888-8888-8888-8888-888888888888");
+
+    /**
+     * A scheduler that mimics Bukkit's {@code runTask}: it executes the
+     * runnable but <b>swallows</b> any exception (logs-and-drops in real
+     * Bukkit). This is exactly the behaviour that makes the unguarded engine
+     * hang — the throw never reaches the {@code done} future.
+     */
+    private static ServiceSupport swallowingScheduler() {
+        return new ServiceSupport() {
+            @Override
+            public void onMainThread(Runnable runnable) {
+                runSwallowing(runnable);
+            }
+
+            @Override
+            public void onMainThreadLater(long delayTicks, Runnable runnable) {
+                runSwallowing(runnable);
+            }
+
+            @Override
+            public void onAsyncThread(Runnable runnable) {
+                runSwallowing(runnable);
+            }
+
+            private void runSwallowing(Runnable runnable) {
+                try {
+                    runnable.run();
+                } catch (Throwable ignored) {
+                    // Bukkit's scheduler logs and drops; the future never sees it.
+                }
+            }
+        };
+    }
+
+    @Test
+    void applyStepThrowFailsTheFutureInsteadOfStrandingTheJoin() {
+        List<RollbackEffect> effects = List.of(new RollbackEffect.BlockReplace(
+                new BlockLocation(WORLD_ID, "world", 0, 64, 0),
+                snapshot(Material.STONE, "minecraft:stone"),
+                snapshot(Material.AIR, "minecraft:air")));
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            stubBukkit(bukkit);
+
+            // The salvage hook throws while snapshotting the chunk — one of the
+            // unguarded main-thread steps in the resolve phase.
+            SalvageHook hook = mock(SalvageHook.class);
+            doThrow(new RuntimeException("salvage boom"))
+                    .when(hook).onChunkResolved(any(World.class), anyInt(), anyInt());
+
+            RollbackEngine engine = new RollbackEngine();
+            engine.setSalvageHook(hook);
+
+            CompletableFuture<List<RollbackResult>> future = engine.applyAllChunked(
+                    effects, mock(CommandSender.class), swallowingScheduler(),
+                    4000, new AtomicBoolean(false));
+
+            // Without the fail-safe this future never completes (the throw is
+            // swallowed by the scheduler) and join() would block forever.
+            assertThat(future)
+                    .as("apply-step throw must terminate the future, not strand the join")
+                    .isCompletedExceptionally();
+            assertThatThrownBy(future::join).hasMessageContaining("salvage boom");
+        }
+    }
+
+    @Test
+    void happyPathStillCompletesNormallyUnderASwallowingScheduler() {
+        // Guards that wrapping the scheduler doesn't break the success path:
+        // no throwing hook, the rollback completes and reports the effect.
+        List<RollbackEffect> effects = List.of(new RollbackEffect.BlockReplace(
+                new BlockLocation(WORLD_ID, "world", 0, 64, 0),
+                snapshot(Material.STONE, "minecraft:stone"),
+                snapshot(Material.AIR, "minecraft:air")));
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            stubBukkit(bukkit);
+
+            RollbackEngine engine = new RollbackEngine();
+            CompletableFuture<List<RollbackResult>> future = engine.applyAllChunked(
+                    effects, mock(CommandSender.class), swallowingScheduler(),
+                    4000, new AtomicBoolean(false));
+
+            assertThat(future).isCompletedWithValueMatching(results ->
+                    results.size() == 1
+                            && results.get(0) instanceof RollbackResult.Applied);
+        }
+    }
+
+    private static void stubBukkit(MockedStatic<Bukkit> bukkit) {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.STONE);
+        BlockData blockData = mock(BlockData.class);
+        when(blockData.getAsString()).thenReturn("minecraft:stone");
+        when(block.getBlockData()).thenReturn(blockData);
+        when(world.getBlockAt(0, 64, 0)).thenReturn(block);
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+        bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+        bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+        bukkit.when(() -> Bukkit.createBlockData(anyString())).thenReturn(mock(BlockData.class));
+    }
+
+    private static BlockSnapshot snapshot(Material material, String blockData) {
+        return new BlockSnapshot(material, blockData,
+                List.of(), List.of(), List.of(), List.of(), null);
+    }
+}


### PR DESCRIPTION
Closes #127.

## Problem
The chunked apply drives world writes through a `done` future across many main-thread continuations (resolve chunk, finish chunk, salvage capture, advance batch), each dispatched via `scheduler.onMainThread/Later`. Bukkit's scheduler swallows-and-logs any throwable, so a throw from `prepareChunk` / `finishChunk` / a salvage capture / a worker palette write left `done` forever uncompleted. `RollbackService.streamPagesAndApply` joins on it, so the consequences cascaded:

- the rollback thread blocks in `join()` forever;
- `runJob` never reaches `jobQueue.finish()`, so `inFlight` stays set and **every** subsequent rollback/restore/undo queues forever (`finish()` is the only path that starts the next job) — the whole subsystem wedges until restart;
- `cancelInFlight()` only sets a flag the parked thread never re-reads;
- the physics-blocker region leaks → gravity blocks freeze in the bbox;
- pinned chunk tickets leak.

A single rare exception (rare trigger, severe blast radius) bricks the admin rollback tool for the rest of uptime.

## Fix
Wrap the scheduler so every apply continuation runs through `guardApply` — any throwable now completes `done` exceptionally. The join then throws, `runJob` marks the job FAILED, the queue advances, and the physics region is released (`done.whenComplete(exit)` fires on exceptional completion). Off-main stage-1 work is guarded too, and the previously-ignored `allOf` throwable is now logged.

Additive: identical threading, only adds a try/catch frame per dispatch — no happy-path change. Applied to **both** apply paths (object `applyAllChunked` + columnar `applyColumnsChunked`).

### Residual (follow-up, not in this PR)
Chunk tickets added in a resolve batch before the throw still leak until plugin disable (Bukkit reclaims plugin tickets on disable). Bounded to one batch and a big improvement over the permanent wedge; a fuller fix would release them in a `finally` during resolve.

## Verification
- `RollbackApplyFailsafeTest`: a throwing salvage hook under a Bukkit-faithful **swallowing** scheduler → the future fails fast (was: hung forever); plus a happy-path control.
- `RollbackEngineChaosTest` / `RollbackSortTest` unchanged and green.
- Full `./gradlew :spyglass:test` green (288 tests, 0 failures).

⚠️ Touches the perf-sensitive apply engine. The change is provably allocation-free / branch-free on the happy path, but it has **not** been run through the live regression harness (no running RP server in this session). Recommend a quick `./gradlew regression` pass before merge.

🤖 Found and fixed during an autonomous production bug hunt.