### PR TITLE
feat(command): add /spyglass version

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.plugin.command;
 
 import java.util.List;
+import net.kyori.adventure.text.Component;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.plugin.command.render.Feedback;
 import net.medievalrp.spyglass.plugin.command.service.HelpService;
@@ -81,6 +82,7 @@ public final class SpyglassCommands {
     private static final List<String> EVENTS_ALIASES = List.of("events", "e");
     private static final List<String> HELP_ALIASES = List.of("help", "h", "?");
     private static final List<String> INVENTORY_ALIASES = List.of("inventory", "inv", "salvage");
+    private static final List<String> VERSION_ALIASES = List.of("version", "ver");
 
     public CommandManager<CommandSender> register() {
         LegacyPaperCommandManager<CommandSender> manager = LegacyPaperCommandManager.createNative(
@@ -100,6 +102,12 @@ public final class SpyglassCommands {
                 manager.command(manager.commandBuilder(root).literal(name)
                         .permission("spyglass.use")
                         .handler(ctx -> sendEnabledEvents(ctx.sender())));
+            }
+
+            for (String name : VERSION_ALIASES) {
+                manager.command(manager.commandBuilder(root).literal(name)
+                        .permission("spyglass.use")
+                        .handler(ctx -> sendVersion(ctx.sender())));
             }
 
             for (String name : SEARCH_ALIASES) {
@@ -180,5 +188,22 @@ public final class SpyglassCommands {
                 .orElse("(none)");
         sender.sendMessage(Feedback.success("Enabled Events: "));
         sender.sendMessage(Feedback.bonus(joined));
+    }
+
+    private void sendVersion(CommandSender sender) {
+        for (Component line : versionLines(plugin.getPluginMeta().getVersion(),
+                plugin.getPluginMeta().getAuthors(),
+                plugin.getServer().getMinecraftVersion())) {
+            sender.sendMessage(line);
+        }
+    }
+
+    // Package-private and pure so the formatting is unit-testable without a
+    // live server or command manager.
+    static List<Component> versionLines(String version, List<String> authors, String serverVersion) {
+        String by = authors.isEmpty() ? "" : "by " + String.join(", ", authors) + ", ";
+        return List.of(
+                Feedback.success("Spyglass v" + version),
+                Feedback.bonus(by + "on Paper " + serverVersion));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -20,6 +20,7 @@ public final class HelpService {
             new Entry("page", "<Page #>", "Moves you to the specified page of results (cached 15 min)."),
             new Entry("tool", "", "Toggle the inspection wand."),
             new Entry("events", "", "List every event type currently being recorded."),
+            new Entry("version", "", "Show the Spyglass version."),
     };
 
     public void send(CommandSender sender) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
@@ -1,0 +1,36 @@
+package net.medievalrp.spyglass.plugin.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.junit.jupiter.api.Test;
+
+class SpyglassCommandsTest {
+
+    private static String plain(List<Component> lines) {
+        return lines.stream()
+                .map(c -> PlainTextComponentSerializer.plainText().serialize(c))
+                .collect(Collectors.joining(" | "));
+    }
+
+    @Test
+    void versionLinesShowVersionAuthorsAndServer() {
+        String out = plain(SpyglassCommands.versionLines("1.0.0", List.of("MedievalRP"), "1.21.8"));
+        assertThat(out)
+                .contains("Spyglass v1.0.0")
+                .contains("by MedievalRP")
+                .contains("on Paper 1.21.8");
+    }
+
+    @Test
+    void versionLinesOmitByWhenNoAuthors() {
+        String out = plain(SpyglassCommands.versionLines("2.3.4", List.of(), "26.2"));
+        assertThat(out)
+                .contains("Spyglass v2.3.4")
+                .contains("on Paper 26.2")
+                .doesNotContain("by ");
+    }
+}


### PR DESCRIPTION
Adds `/spyglass version` (aliases `/sg version`, `/sg ver`): prints the plugin version, authors, and the running server version (e.g. "Spyglass v1.0.0" / "by MedievalRP, on Paper 26.1.2"). Registered under both root aliases at `spyglass.use`, listed in `/spyglass help`.

Formatting extracted into a pure, package-private `versionLines(...)` for a unit test (no live server needed). Verified live on Paper 26.1.2 over RCON; renders through the asComponent-fixed Feedback so it is clean on 26.x. `./gradlew :spyglass:build` green. Targets `dev` per the branch model.