### PR TITLE
fix(command): quote-aware query tokenizer so multi-word values like iname:"flaming sword" parse (#138)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
@@ -41,7 +41,7 @@ public final class QueryStringParser {
         ParseState state = new ParseState();
 
         if (raw != null && !raw.isBlank()) {
-            for (String token : raw.trim().split("\\s+")) {
+            for (String token : tokenize(raw.trim())) {
                 if (token.isEmpty()) {
                     continue;
                 }
@@ -133,6 +133,54 @@ public final class QueryStringParser {
         int limit = overrideLimit > 0 ? overrideLimit : config.limits().searchResult();
         boolean grouping = !flags.contains(Flag.NO_GROUP);
         return new QueryRequest(predicates, sort, limit, flags, grouping);
+    }
+
+    /**
+     * Split a raw query into tokens on whitespace, but keep a double-quoted
+     * span as a single token so multi-word values survive: {@code iname:"flaming
+     * sword"} becomes the one token {@code iname:flaming sword}. The quote
+     * characters themselves are stripped; whitespace inside the quotes is kept.
+     *
+     * <p>Only the double quote {@code "} is a delimiter. The apostrophe is left
+     * literal on purpose - fantasy item names routinely contain one (Maker's
+     * Blade, Dragon's Breath), and an unquoted {@code iname:Maker's} must keep
+     * parsing as the literal value {@code Maker's} rather than opening a span.
+     *
+     * <p>Escaping a literal quote (e.g. an inch mark in a name) is not
+     * supported; an unbalanced quote is a user error and is reported as one.
+     */
+    static List<String> tokenize(String raw) throws ParamParseException {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inToken = false;
+        boolean inQuote = false;
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            if (c == '"') {
+                inQuote = !inQuote;
+                inToken = true; // a quoted span is a token even if empty ("")
+                continue;
+            }
+            if (!inQuote && Character.isWhitespace(c)) {
+                if (inToken) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                    inToken = false;
+                }
+                continue;
+            }
+            current.append(c);
+            inToken = true;
+        }
+        if (inQuote) {
+            throw new ParamParseException(
+                    "Unterminated quote in query - close the \" around a multi-word value"
+                            + " like iname:\"flaming sword\".");
+        }
+        if (inToken) {
+            tokens.add(current.toString());
+        }
+        return tokens;
     }
 
     private static boolean isFlagAlias(String alias) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
@@ -1,0 +1,121 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.SpyglassApi;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link QueryStringParser} tokenizer + end-to-end tests, pinning the
+ * quote-aware tokenization that lets multi-word values survive
+ * ({@code iname:"flaming sword"}). Before this, the parser split on raw
+ * whitespace, so the second word fell through to the default {@code p:}
+ * alias - misparsing the value and, when another bare word was present,
+ * throwing a confusing {@code Duplicate parameter: p}.
+ */
+class QueryStringParserTest {
+
+    // ---- tokenizer: the core of the fix ----
+
+    @Test
+    void quotedMultiWordValueStaysOneTokenWithQuotesStripped() throws Exception {
+        assertThat(QueryStringParser.tokenize("iname:\"flaming sword\""))
+                .containsExactly("iname:flaming sword");
+    }
+
+    @Test
+    void mixedQuotedAndPlainTokensSplitOnUnquotedWhitespaceOnly() throws Exception {
+        assertThat(QueryStringParser.tokenize("a:deposit iname:\"flaming sword\" -g"))
+                .containsExactly("a:deposit", "iname:flaming sword", "-g");
+    }
+
+    @Test
+    void plainQueryTokenizesExactlyLikeTheOldWhitespaceSplit() throws Exception {
+        assertThat(QueryStringParser.tokenize("a:place b:stone p:Steve"))
+                .containsExactly("a:place", "b:stone", "p:Steve");
+    }
+
+    @Test
+    void runsOfWhitespaceBetweenTokensCollapse() throws Exception {
+        assertThat(QueryStringParser.tokenize("a:place    b:stone"))
+                .containsExactly("a:place", "b:stone");
+    }
+
+    @Test
+    void apostropheIsLiteralNotAQuoteDelimiter() throws Exception {
+        // Fantasy item names routinely carry an apostrophe (Maker's Blade).
+        // An unquoted one must stay a literal char, never open a span.
+        assertThat(QueryStringParser.tokenize("iname:Maker's"))
+                .containsExactly("iname:Maker's");
+    }
+
+    @Test
+    void quotedValueMayContainAColon() throws Exception {
+        // Only the first colon delimits key:value; an inner colon is data.
+        assertThat(QueryStringParser.tokenize("m:\"hello: there\""))
+                .containsExactly("m:hello: there");
+    }
+
+    @Test
+    void unterminatedQuoteIsRejectedWithAClearMessage() {
+        assertThatThrownBy(() -> QueryStringParser.tokenize("iname:\"flaming sword"))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Unterminated quote");
+    }
+
+    // ---- end-to-end parse(): the user-facing behaviour ----
+
+    @Test
+    void quotedItemNameParsesToOneInamePredicateThatMatchesTheWholeName() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.queryParam("iname")).thenReturn(Optional.of(new ItemNameParam()));
+
+        QueryRequest request = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "iname:\"flaming sword\"", 0);
+
+        // Exactly one predicate - the stray "sword" never became a second token.
+        assertThat(request.predicates()).hasSize(1);
+        QueryPredicate.Or or = (QueryPredicate.Or) request.predicates().get(0);
+        Pattern pattern = (Pattern) ((QueryPredicate.Eq) or.predicates().getFirst()).value();
+        // The whole phrase reached the handler, so "Flaming Sword" matches.
+        assertThat(pattern.matcher("Flaming Sword").find()).isTrue();
+        assertThat(pattern.matcher("flaming").find()).isFalse();
+    }
+
+    @Test
+    void quotedValueAlongsideAnotherParamDoesNotRaiseDuplicateP() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.queryParam("iname")).thenReturn(Optional.of(new ItemNameParam()));
+        when(api.queryParam("p")).thenReturn(Optional.of(
+                new PlayerParam(name -> new UUID(0, name.hashCode()))));
+
+        QueryRequest request = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "p:Steve iname:\"flaming sword\"", 0);
+
+        // Two clean predicates (p + iname); the old whitespace split would have
+        // turned "sword" into a second p token and thrown Duplicate parameter: p.
+        assertThat(request.predicates()).hasSize(2);
+    }
+
+    /**
+     * Config with defaults disabled, so {@code parse()} adds no implicit
+     * radius/time predicate and the assertions count only the user's params.
+     * {@code limits()} is still read unconditionally to build the context.
+     */
+    private static SpyglassConfig configNoDefaults() {
+        SpyglassConfig config = mock(SpyglassConfig.class);
+        when(config.defaults()).thenReturn(new SpyglassConfig.Defaults(false, 0, null));
+        when(config.limits()).thenReturn(new SpyglassConfig.Limits(100, 50, 0, 0, null, 0));
+        return config;
+    }
+}


### PR DESCRIPTION
Closes #138.

## What
`QueryStringParser` tokenized the raw query with `split("\\s+")`, so any value containing a space split across tokens. `iname:"flaming sword"` became `iname:"flaming` + `sword"`: the second word fell through to the default `p:` alias (misparsing the value, and throwing a confusing `Duplicate parameter: p` when another bare word was present), and the stray quote chars poisoned the match.

This swaps the whitespace split for a quote-aware tokenizer: whitespace splits tokens **except inside a double-quoted span**, which is kept as one token with the quote chars stripped. `iname:"flaming sword"` now reaches the handler as the whole phrase `flaming sword`.

## Design notes
- **Double-quote `"` is the only delimiter.** The apostrophe is deliberately left literal: fantasy RP item names routinely contain one (`Maker's Blade`, `Dragon's Breath`), and an unquoted `iname:Maker's` must keep parsing. Treating `'` as a delimiter would have broken that common case.
- An unterminated quote is reported as a clear `ParamParseException` telling the user to close the quote.
- Backslash-escaping a literal quote is out of scope.
- Contained entirely to the tokenizer - the search/rollback commands feed the query through Cloud `greedyStringParser`, which preserves quotes verbatim. No event-type-parity impact; `spyglass` module only.

## Tests
New `QueryStringParserTest` (9 tests): tokenizer behaviour (quoted multi-word, mixed quoted/plain, apostrophe-literal, inner colon, whitespace collapse, unterminated-quote rejection) plus two end-to-end `parse()` tests proving `iname:"flaming sword"` yields a single matching `iname` predicate and that combining it with another param no longer throws `Duplicate parameter: p`.

`./gradlew :spyglass:check` green (tests + jacoco floor).