### PR TITLE
feat(query): searchable item custom-data (itags:) + enchant aliases (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ Search, rollback, and restore share one `key:value` query language. Combine as m
 | `i:` | `item:` | `i:netherite_sword` | Item material involved (drop, pickup, container, etc.) |
 | `iname:` | `itemname:` | `iname:Excalibur` | Item display name (substring). Works on both backends |
 | `ilore:` | `itemlore:`, `d:` | `ilore:cursed` | Item lore line (substring). Works on both backends |
-| `ench:` | `enchant:`, `enchantment:` | `ench:sharpness=5` | Item enchantment. Works on both backends |
-| `cu:` | `custom:` | `cu:my-custom-item` | Plugin custom-item id (via the API) |
+| `itags:` | `itag:` | `itags:deliver_letter` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values. Works on all backends |
+| `ench:` | `enchant:`, `enchantment:`, `ienchant:`, `ienchantments:` | `ench:sharpness=5` | Item enchantment. Works on both backends |
+| `cu:` | `custom:` | `cu:my-custom-item` | Item carries metadata: custom name, lore, enchants, or custom data |
 | `e:` | `entity:` | `e:creeper` | Entity type involved |
 | `c:` | `cause:` | `c:tnt,!creeper` | Change cause; `!cause` excludes |
 | `m:` | `message:` | `m:hello` | Chat, sign, or book text (substring) |

--- a/commands.md
+++ b/commands.md
@@ -46,8 +46,9 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `i` | `item` | Item material |
 | `iname` | `itemname` | Item display name (substring) |
 | `ilore` | `itemlore`, `d` | Item lore (substring) |
-| `ench` | `enchant`, `enchantment` | Enchantment |
-| `cu` | `custom` | Plugin custom-item id |
+| `itags` | `itag` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values |
+| `ench` | `enchant`, `enchantment`, `ienchant`, `ienchantments` | Enchantment |
+| `cu` | `custom` | Item has metadata: custom name, lore, enchants, or custom data |
 | `e` | `entity` | Entity type |
 | `c` | `cause` | Change cause |
 | `m` | `message` | Chat / sign / book text |

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/StoredItem.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/StoredItem.java
@@ -6,11 +6,18 @@ import java.util.List;
  * An item as it lived in a container slot / dropped entity / pickup.
  *
  * <p>{@code data} is the base64-encoded {@code ItemStack.serializeAsBytes()}
- * blob — it's the source of truth for faithful reconstruction (rollback,
- * restoration) but is opaque to queries. {@code name}, {@code lore} and
- * {@code enchants} are extracted plain-text projections of the same stack so
- * operators can search the DB for custom names / lore phrases / enchantments
- * without having to decode NBT on every row.
+ * blob: it's the source of truth for faithful reconstruction (rollback,
+ * restoration) but is opaque to queries. {@code name}, {@code lore},
+ * {@code enchants} and {@code tags} are extracted plain-text projections of
+ * the same stack so operators can search the DB for custom names / lore
+ * phrases / enchantments / custom NBT without having to decode NBT on every
+ * row.
+ *
+ * <p>{@code tags} holds the item's {@code minecraft:custom_data} component:
+ * the NBT that vanilla {@code /give ...[custom_data={...}]}, datapacks, and
+ * plugin {@code PersistentDataContainer}s all write, rendered as a
+ * searchable string (e.g. {@code {quest:"deliver_letter"}}), or {@code null}
+ * when the item carries none. It backs the {@code itags:} query.
  */
 public record StoredItem(
         int slot,
@@ -18,16 +25,24 @@ public record StoredItem(
         String data,
         String name,
         List<String> lore,
-        List<String> enchants) {
+        List<String> enchants,
+        String tags) {
 
     public StoredItem {
         lore = lore == null ? List.of() : List.copyOf(lore);
         enchants = enchants == null ? List.of() : List.copyOf(enchants);
     }
 
+    /** Back-compat constructor for call sites that predate the {@code tags}
+     *  custom-data projection. Leaves {@code tags} {@code null}. */
+    public StoredItem(int slot, String material, String data, String name,
+                      List<String> lore, List<String> enchants) {
+        this(slot, material, data, name, lore, enchants, null);
+    }
+
     /** Back-compat constructor for call sites (especially tests) that only
      *  know about slot/material/data. Leaves projections empty. */
     public StoredItem(int slot, String material, String data) {
-        this(slot, material, data, null, List.of(), List.of());
+        this(slot, material, data, null, List.of(), List.of(), null);
     }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -200,6 +200,7 @@ final class PredicateEvaluator {
             case "slot" -> item.slot();
             case "lore" -> item.lore();
             case "enchants" -> item.enchants();
+            case "tags" -> item.tags();
             // hasMetadata() probes array non-emptiness via ".0".
             case "lore.0" -> item.lore().isEmpty() ? null : item.lore().get(0);
             case "enchants.0" -> item.enchants().isEmpty() ? null : item.enchants().get(0);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -547,7 +547,8 @@ class ClickHouseRecordStoreIT {
         StoredItem excaliblur = new StoredItem(0, "DIAMOND_SWORD", "AAAA",
                 "Excaliblur",
                 List.of("Forged in primordial fire"),
-                List.of("sharpness=5"));
+                List.of("sharpness=5"),
+                "{quest:\"primordial_rite\"}");
         StoredItem mundane = new StoredItem(0, "IRON_SWORD", "BBBB",
                 null, List.of(), List.of());
         store.save(List.of(
@@ -585,6 +586,13 @@ class ClickHouseRecordStoreIT {
                 .hasSize(1);
         assertThat(store.query(req.apply(anyItem.apply("enchants", "sharpness"))).records())
                 .hasSize(1);
+        // itags: resolves from the decoded item blob via the in-memory
+        // post-filter, the same as iname/ilore/ench (#140).
+        assertThat(store.query(req.apply(anyItem.apply("tags", "primordial_rite"))).records())
+                .hasSize(1)
+                .allMatch(r -> "DIAMOND_SWORD".equals(r.target()));
+        assertThat(store.query(req.apply(anyItem.apply("tags", "nonexistent"))).records())
+                .isEmpty();
         assertThat(store.query(req.apply(anyItem.apply("name", "nonexistent"))).records())
                 .isEmpty();
         // Summary entry point must hydrate + filter identically.

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -309,7 +309,8 @@ class MongoRecordStoreIT {
                 0, "DIAMOND_SWORD", null,
                 "Excaliblur",
                 List.of("Forged in primordial fire", "Blessed by saints"),
-                List.of("sharpness=5", "mending=1"));
+                List.of("sharpness=5", "mending=1"),
+                "{quest:\"primordial_rite\"}");
 
         // deposit carries the item as afterItem; drop carries it as item;
         // place carries it inside newBlock.containerItems[]. Save one of each
@@ -359,6 +360,12 @@ class MongoRecordStoreIT {
                 List.of(anyItemField("enchants", "sharpness=5")),
                 Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
         assertThat(store.query(byEnchLevel).records()).hasSize(3);
+
+        // itags:primordial_rite: custom_data substring, all three paths (#140).
+        QueryRequest byTags = new QueryRequest(
+                List.of(anyItemField("tags", "primordial_rite")),
+                Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byTags).records()).hasSize(3);
 
         // Missing name, no hits.
         QueryRequest missing = new QueryRequest(

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluatorTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluatorTest.java
@@ -1,0 +1,63 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link PredicateEvaluator} resolution of the item {@code tags} projection
+ * (#140). This is the in-memory post-filter ClickHouse and SQLite fall back
+ * to for the {@code itags:} query, since custom_data lives inside an opaque
+ * item blob on those backends rather than an indexable column.
+ */
+class PredicateEvaluatorTest {
+
+    private static EventRecord deposit(StoredItem afterItem) {
+        Instant now = Instant.now();
+        return new ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(UUID.randomUUID(), "world", 1, 2, 3),
+                "srv", "PAPER", "CHEST", 0, 1, null, afterItem);
+    }
+
+    private static QueryPredicate tagsMatch(String term) {
+        return new QueryPredicate.Eq("afterItem.tags",
+                Pattern.compile(Pattern.quote(term), Pattern.CASE_INSENSITIVE));
+    }
+
+    @Test
+    void matchesCustomDataSubstringCaseInsensitively() {
+        EventRecord record = deposit(new StoredItem(
+                0, "PAPER", null, null, List.of(), List.of(),
+                "{quest:\"deliver_letter\"}"));
+
+        assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("deliver_letter")), record)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("DELIVER")), record)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("slay_dragon")), record)).isFalse();
+    }
+
+    @Test
+    void doesNotMatchWhenItemHasNoCustomData() {
+        // tags == null (vanilla item / no custom_data) -> itags: never matches
+        EventRecord record = deposit(new StoredItem(0, "PAPER", null));
+        assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("anything")), record)).isFalse();
+    }
+
+    @Test
+    void doesNotMatchWhenItemAbsent() {
+        EventRecord record = deposit(null);
+        assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("anything")), record)).isFalse();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -320,6 +320,32 @@ class SqliteRecordStoreTest {
     }
 
     @Test
+    void itemTagFilterFallsToPostFilter() {
+        // itags: lives inside the per-event blob (no column), so SQLite pushes
+        // what it can and matches custom_data in memory (#140), the same
+        // residual path as iname/ilore/ench.
+        Instant occurred = BASE.minusSeconds(1);
+        ContainerDepositRecord quested = new ContainerDepositRecord(
+                EventIds.newId(), "deposit", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Bob"),
+                new BlockLocation(WORLD, "world", 1, 70, 1), "srv", "CHEST", "CHEST", 0, 1,
+                new StoredItem(0, "PAPER", "blob", null, List.of(), List.of(),
+                        "{quest:\"deliver_letter\"}"),
+                null);
+        store.save(List.of(quested, deposit(2))); // deposit(2): plain diamond, no tags
+
+        QueryPredicate byTags = new QueryPredicate.Eq("beforeItem.tags",
+                Pattern.compile(Pattern.quote("deliver_letter"), Pattern.CASE_INSENSITIVE));
+        assertThat(store.query(request(List.of(byTags))).records())
+                .singleElement()
+                .satisfies(r -> assertThat(r.event()).isEqualTo("deposit"));
+
+        QueryPredicate miss = new QueryPredicate.Eq("beforeItem.tags",
+                Pattern.compile(Pattern.quote("nonexistent"), Pattern.CASE_INSENSITIVE));
+        assertThat(store.query(request(List.of(miss))).records()).isEmpty();
+    }
+
+    @Test
     void paletteInternsRepeatedValuesOnce() throws SQLException {
         UUID player = UUID.randomUUID();
         // Three breaks by one player in one world: world + player UUIDs and

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/StoredItemBackCompatTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/StoredItemBackCompatTest.java
@@ -1,0 +1,78 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+import java.util.List;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.ByteBufNIO;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.io.ByteBufferBsonInput;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Back-compat guard for the {@code tags} custom-data projection (#140):
+ * records written before the field existed have no {@code tags} key in their
+ * BSON, and the auto-generated {@link StoredItem} record codec must decode
+ * that absence as {@code null} rather than throwing, otherwise every
+ * pre-#140 deposit/withdraw/container-snapshot row stored on Mongo, the
+ * ClickHouse item columns, or the SQLite per-event blob would fail to read.
+ */
+class StoredItemBackCompatTest {
+
+    @Test
+    void decodesLegacyDocumentWithoutTagsKeyAsNull() {
+        // Encode a current item, then strip the tags key from its BSON to
+        // mimic a record serialized before the projection was added.
+        StoredItem full = new StoredItem(2, "DIAMOND_SWORD", "blob",
+                "Storm Caller", List.of("Forged deep"), List.of("sharpness=5"),
+                "{quest:\"x\"}");
+        BsonDocument wrapper = readBson(Base64.getDecoder().decode(BsonBlobs.encodeStoredItem(full)));
+        wrapper.getDocument("v").remove("tags");
+        String legacy = Base64.getEncoder().encodeToString(writeBson(wrapper));
+
+        StoredItem decoded = BsonBlobs.decodeStoredItem(legacy);
+
+        assertThat(decoded).isNotNull();
+        assertThat(decoded.tags()).as("absent tags key must decode to null").isNull();
+        // The rest of the record must still round-trip unharmed.
+        assertThat(decoded.slot()).isEqualTo(2);
+        assertThat(decoded.material()).isEqualTo("DIAMOND_SWORD");
+        assertThat(decoded.name()).isEqualTo("Storm Caller");
+        assertThat(decoded.lore()).containsExactly("Forged deep");
+        assertThat(decoded.enchants()).containsExactly("sharpness=5");
+    }
+
+    @Test
+    void currentItemRoundTripsTags() {
+        StoredItem item = new StoredItem(0, "PAPER", "blob", null, List.of(), List.of(),
+                "{PublicBukkitValues:{\"mmoitems:type\":\"SWORD\"}}");
+        StoredItem decoded = BsonBlobs.decodeStoredItem(BsonBlobs.encodeStoredItem(item));
+        assertThat(decoded).isNotNull();
+        assertThat(decoded.tags()).isEqualTo("{PublicBukkitValues:{\"mmoitems:type\":\"SWORD\"}}");
+    }
+
+    private static BsonDocument readBson(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        try (BsonBinaryReader reader = new BsonBinaryReader(
+                new ByteBufferBsonInput(new ByteBufNIO(buf)))) {
+            return new BsonDocumentCodec().decode(reader, DecoderContext.builder().build());
+        }
+    }
+
+    private static byte[] writeBson(BsonDocument document) {
+        BasicOutputBuffer buffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+            new BsonDocumentCodec().encode(writer, document, EncoderContext.builder().build());
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -24,6 +24,7 @@ import net.medievalrp.spyglass.plugin.command.param.IpParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemLoreParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemMaterialParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemNameParam;
+import net.medievalrp.spyglass.plugin.command.param.ItemTagParam;
 import net.medievalrp.spyglass.plugin.command.param.MessageParam;
 import net.medievalrp.spyglass.plugin.command.param.PlayerParam;
 import net.medievalrp.spyglass.plugin.command.param.QueryStringParser;
@@ -382,6 +383,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         apiImpl.registerQueryParamHandler(new WorldParam());
         apiImpl.registerQueryParamHandler(new ItemNameParam());
         apiImpl.registerQueryParamHandler(new ItemLoreParam());
+        apiImpl.registerQueryParamHandler(new ItemTagParam());
         apiImpl.registerQueryParamHandler(new EnchantParam());
         apiImpl.registerQueryParamHandler(new MessageParam());
         apiImpl.registerQueryParamHandler(new CauseParam());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EnchantParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EnchantParam.java
@@ -15,7 +15,11 @@ public final class EnchantParam implements QueryParamHandler {
 
     @Override
     public List<String> aliases() {
-        return List.of("ench", "enchant", "enchantment");
+        // {@code ienchant}/{@code ienchantments} mirror the {@code i}-prefixed
+        // item param family ({@code iname}/{@code ilore}/{@code itags}) for
+        // discoverability; {@code ench}/{@code enchant}/{@code enchantment}
+        // stay for existing operator macros.
+        return List.of("ench", "enchant", "enchantment", "ienchant", "ienchantments");
     }
 
     @Override

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ItemFieldParams.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ItemFieldParams.java
@@ -75,16 +75,19 @@ final class ItemFieldParams {
     /**
      * Build a predicate that matches whenever any of the item-bearing record
      * paths has at least one populated meta field — non-null custom name,
-     * non-empty lore, or non-empty enchants. Mirrors v1's
-     * {@code cu:y} semantic ("item has metadata") without depending on a
-     * single boolean flag, since v2 always serializes the full {@code
-     * StoredItem} record.
+     * non-empty lore, non-empty enchants, or non-null custom data
+     * ({@code tags}). Mirrors v1's {@code cu:y} semantic ("item has metadata")
+     * without depending on a single boolean flag, since v2 always serializes
+     * the full {@code StoredItem} record. Custom data counts because an item
+     * carrying only {@code minecraft:custom_data} (a plugin/quest item with no
+     * display name or lore) is still a custom item.
      */
     static QueryPredicate hasMetadata() {
-        List<QueryPredicate> clauses = new java.util.ArrayList<>(ITEM_PATHS.size() * 3);
+        List<QueryPredicate> clauses = new java.util.ArrayList<>(ITEM_PATHS.size() * 4);
         for (String path : ITEM_PATHS) {
-            // name: non-null custom display name
+            // name / tags: non-null projected scalar
             clauses.add(new QueryPredicate.Not(new QueryPredicate.Eq(path + ".name", null)));
+            clauses.add(new QueryPredicate.Not(new QueryPredicate.Eq(path + ".tags", null)));
             // lore.0 / enchants.0 exist <=> the array is non-empty
             clauses.add(new QueryPredicate.Exists(path + ".lore.0", true));
             clauses.add(new QueryPredicate.Exists(path + ".enchants.0", true));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ItemTagParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ItemTagParam.java
@@ -1,0 +1,38 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.bukkit.command.CommandSender;
+
+/**
+ * {@code itags:quest}: case-insensitive substring match against a
+ * StoredItem's {@code tags} projection, i.e. its {@code minecraft:custom_data}
+ * compound (the NBT that vanilla {@code /give ...[custom_data={...}]},
+ * datapacks, and plugin {@code PersistentDataContainer}s write). Lets staff
+ * find a custom/plugin item by any fragment of its custom data (for example
+ * {@code itags:"mmoitems:type"} or {@code itags:deliver_letter}) without
+ * decoding NBT per row. Same five-path OR expansion as {@code ilore:}.
+ */
+public final class ItemTagParam implements QueryParamHandler {
+
+    @Override
+    public List<String> aliases() {
+        return List.of("itags", "itag");
+    }
+
+    @Override
+    public QueryPredicate parse(String alias, String value, ParamContext context) throws ParamParseException {
+        if (value == null || value.isBlank()) {
+            throw new ParamParseException(alias + " requires a value.");
+        }
+        String safe = ItemFieldParams.requireSafeTerm(alias, value.trim());
+        return ItemFieldParams.anyItemField("tags", ItemFieldParams.substringPattern(safe));
+    }
+
+    @Override
+    public List<String> suggestions(CommandSender sender, String input) {
+        return List.of();
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -305,6 +305,10 @@ public final class ResultRenderer {
      *  produce a screen-filling tooltip. */
     private static final int MAX_LORE_LINES = 12;
 
+    /** Custom-data ({@code tags}) can run to kilobytes; the hover shows a
+     *  preview and trusts {@code itags:} for the full search. */
+    private static final int MAX_TAGS_HOVER = 128;
+
     /**
      * The item a record is "about", for hover detail: the deposited item
      * for a deposit, the withdrawn item for a withdraw, the dropped /
@@ -323,10 +327,10 @@ public final class ResultRenderer {
     }
 
     /**
-     * Append "Item Name" / "Enchants" / "Lore" hover lines for the record's
-     * subject item when it carries custom metadata. Plain-text projections
-     * only (colors were stripped at record time); a vanilla item with no
-     * name, lore, or enchants adds nothing.
+     * Append "Item Name" / "Enchants" / "Tags" / "Lore" hover lines for the
+     * record's subject item when it carries custom metadata. Plain-text
+     * projections only (colors were stripped at record time); a vanilla item
+     * with no name, lore, enchants, or custom data adds nothing.
      */
     private static void appendItemDetail(List<Component> lines, EventRecord record) {
         StoredItem item = subjectItem(record);
@@ -336,7 +340,8 @@ public final class ResultRenderer {
         boolean hasName = item.name() != null && !item.name().isBlank();
         boolean hasLore = !item.lore().isEmpty();
         boolean hasEnchants = !item.enchants().isEmpty();
-        if (!hasName && !hasLore && !hasEnchants) {
+        boolean hasTags = item.tags() != null && !item.tags().isBlank();
+        if (!hasName && !hasLore && !hasEnchants && !hasTags) {
             return;
         }
         if (hasName) {
@@ -344,6 +349,15 @@ public final class ResultRenderer {
         }
         if (hasEnchants) {
             lines.add(kv("Enchants", String.join(", ", item.enchants())));
+        }
+        if (hasTags) {
+            // The full custom_data is searchable via itags:; the hover only
+            // previews it so a kilobyte NBT blob can't blow up the tooltip.
+            String tags = item.tags();
+            String preview = tags.length() > MAX_TAGS_HOVER
+                    ? tags.substring(0, MAX_TAGS_HOVER) + "…"
+                    : tags;
+            lines.add(kv("Tags", preview));
         }
         if (hasLore) {
             lines.add(Component.text("Lore:", NamedTextColor.GRAY));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ItemSerialization.java
@@ -70,6 +70,7 @@ public final class ItemSerialization {
         String name = null;
         List<String> lore = List.of();
         List<String> enchants = List.of();
+        String tags = null;
         // hasItemMeta() short-circuits the common no-NBT item (cobblestone,
         // plain tools): getItemMeta() allocates a fresh ItemMeta snapshot
         // even when there's nothing to extract, so skip it entirely there
@@ -97,10 +98,102 @@ public final class ItemSerialization {
                 if (meta.hasEnchants()) {
                     enchants = enchantStrings(meta.getEnchants());
                 }
+                // Custom-data projection (#140). getAsComponentString() renders
+                // every set component; we lift just the minecraft:custom_data
+                // compound back out so itags: can substring-match it. Only
+                // reached for meta-bearing items, so the plain-item hot path
+                // (no NBT, short-circuited above) never pays for it.
+                tags = extractCustomData(meta.getAsComponentString());
             }
         }
         String data = includeData ? encode(itemStack) : null;
-        return new StoredItem(slot, itemStack.getType().name(), data, name, lore, enchants);
+        return new StoredItem(slot, itemStack.getType().name(), data, name, lore, enchants, tags);
+    }
+
+    /**
+     * Marker that opens the {@code minecraft:custom_data} component inside an
+     * {@link ItemMeta#getAsComponentString()} rendering.
+     */
+    private static final String CUSTOM_DATA_MARKER = "minecraft:custom_data=";
+
+    /**
+     * Pull the {@code minecraft:custom_data} compound out of an item's
+     * {@link ItemMeta#getAsComponentString()} rendering as a searchable
+     * string, e.g. {@code {quest:"deliver_letter",PublicBukkitValues:{...}}}.
+     *
+     * <p>Custom data is where vanilla {@code /give ...[custom_data={...}]},
+     * datapacks, and Bukkit {@code PersistentDataContainer}s all park their
+     * payloads, so one substring-searchable projection ({@code itags:}) covers
+     * every custom-item source without decoding NBT per row. Returns
+     * {@code null} when the item has no custom data, or an empty {@code {}}
+     * compound (nothing worth indexing).
+     *
+     * <p>The scan is brace-balanced and quote-aware so a string value
+     * containing a stray {@code {}/}} can't truncate or over-run the captured
+     * compound. Output is length-capped via {@link RecordingSupport#safeText}
+     * to keep a pathological NBT blob from bloating a row. Package-private so
+     * it can be unit-tested without a live server.
+     */
+    static String extractCustomData(String componentString) {
+        if (componentString == null) {
+            return null;
+        }
+        int marker = componentString.indexOf(CUSTOM_DATA_MARKER);
+        if (marker < 0) {
+            return null;
+        }
+        int start = marker + CUSTOM_DATA_MARKER.length();
+        // Tolerate any whitespace the renderer might put between '=' and the
+        // compound; the canonical form is compact but we don't want a stray
+        // space to silently drop the capture.
+        while (start < componentString.length()
+                && Character.isWhitespace(componentString.charAt(start))) {
+            start++;
+        }
+        // custom_data always serializes as a compound; anything else is junk.
+        if (start >= componentString.length() || componentString.charAt(start) != '{') {
+            return null;
+        }
+        int depth = 0;
+        boolean inSingle = false;
+        boolean inDouble = false;
+        boolean escaped = false;
+        for (int i = start; i < componentString.length(); i++) {
+            char c = componentString.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (inSingle) {
+                inSingle = c != '\'';
+                continue;
+            }
+            if (inDouble) {
+                inDouble = c != '"';
+                continue;
+            }
+            switch (c) {
+                case '\'' -> inSingle = true;
+                case '"' -> inDouble = true;
+                case '{' -> depth++;
+                case '}' -> {
+                    if (--depth == 0) {
+                        String value = componentString.substring(start, i + 1);
+                        return "{}".equals(value) ? null : RecordingSupport.safeText(value);
+                    }
+                }
+                default -> {
+                    // ordinary character inside the compound
+                }
+            }
+        }
+        // Unbalanced braces: malformed component string; index nothing rather
+        // than capture a half-open compound.
+        return null;
     }
 
     /**

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EnchantParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EnchantParamTest.java
@@ -97,8 +97,22 @@ class EnchantParamTest {
     }
 
     @Test
-    void allThreeAliasesExposed() {
-        assertThat(new EnchantParam().aliases()).containsExactly("ench", "enchant", "enchantment");
+    void aliasesExposeShortAndIPrefixedForms() {
+        // ienchant/ienchantments join the i-prefixed item param family
+        // (iname/ilore/itags) for discoverability (#140).
+        assertThat(new EnchantParam().aliases())
+                .containsExactly("ench", "enchant", "enchantment", "ienchant", "ienchantments");
+    }
+
+    @Test
+    void iPrefixedAliasParsesIdentically() throws Exception {
+        // the new alias must resolve to the same predicate shape as ench:
+        QueryPredicate predicate = new EnchantParam().parse("ienchantments", "sharpness", ctx());
+        assertThat(predicate).isInstanceOf(QueryPredicate.Or.class);
+        List<String> fields = ((QueryPredicate.Or) predicate).predicates().stream()
+                .map(p -> ((QueryPredicate.Eq) p).field())
+                .toList();
+        assertThat(fields).containsExactlyElementsOf(EXPECTED_PATHS);
     }
 
     private static Pattern firstPattern(QueryPredicate predicate) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ItemTagParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ItemTagParamTest.java
@@ -1,0 +1,89 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ItemTagParam} unit tests. Structurally mirrors
+ * {@link ItemLoreParamTest} (same five-path OR expansion), but the sub-field
+ * is {@code tags} (the item's {@code minecraft:custom_data} projection). The
+ * stored value is a single string, so Mongo regex matches it like {@code name}
+ * rather than needing per-element array semantics.
+ */
+class ItemTagParamTest {
+
+    private static final List<String> EXPECTED_PATHS = List.of(
+            "item.tags",
+            "beforeItem.tags",
+            "afterItem.tags",
+            "originalBlock.containerItems.tags",
+            "newBlock.containerItems.tags");
+
+    @Test
+    void producesOrAcrossAllFiveTagPaths() throws Exception {
+        QueryPredicate predicate = new ItemTagParam().parse("itags", "quest", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.Or.class);
+        QueryPredicate.Or or = (QueryPredicate.Or) predicate;
+        assertThat(or.predicates()).hasSize(5);
+        List<String> fields = or.predicates().stream()
+                .map(p -> ((QueryPredicate.Eq) p).field())
+                .toList();
+        assertThat(fields).containsExactlyElementsOf(EXPECTED_PATHS);
+    }
+
+    @Test
+    void patternMatchesCustomDataSubstrings() throws Exception {
+        QueryPredicate predicate = new ItemTagParam().parse("itags", "deliver_letter", ctx());
+        Pattern pattern = (Pattern) ((QueryPredicate.Eq) ((QueryPredicate.Or) predicate)
+                .predicates().getFirst()).value();
+        assertThat(pattern.matcher("{quest:\"deliver_letter\",stage:2}").find()).isTrue();
+        assertThat(pattern.matcher("{quest:\"DELIVER_LETTER\"}").find()).isTrue();
+        assertThat(pattern.matcher("{quest:\"slay_dragon\"}").find()).isFalse();
+    }
+
+    @Test
+    void matchesPluginNamespacedKeys() throws Exception {
+        // operators search PDC keys like "mmoitems:type" verbatim
+        QueryPredicate predicate = new ItemTagParam().parse("itags", "mmoitems:type", ctx());
+        Pattern pattern = (Pattern) ((QueryPredicate.Eq) ((QueryPredicate.Or) predicate)
+                .predicates().getFirst()).value();
+        assertThat(pattern.matcher(
+                "{PublicBukkitValues:{\"mmoitems:type\":\"SWORD\"}}").find()).isTrue();
+    }
+
+    @Test
+    void regexMetacharactersQuoted() throws Exception {
+        QueryPredicate predicate = new ItemTagParam().parse("itags", "a{b", ctx());
+        Pattern pattern = (Pattern) ((QueryPredicate.Eq) ((QueryPredicate.Or) predicate)
+                .predicates().getFirst()).value();
+        assertThat(pattern.matcher("xa{by").find()).isTrue();
+    }
+
+    @Test
+    void blankValueRejected() {
+        ItemTagParam param = new ItemTagParam();
+        assertThatThrownBy(() -> param.parse("itags", "", ctx()))
+                .isInstanceOf(ParamParseException.class);
+        assertThatThrownBy(() -> param.parse("itags", "   ", ctx()))
+                .isInstanceOf(ParamParseException.class);
+        assertThatThrownBy(() -> param.parse("itags", null, ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void aliasesCoverShortAndLong() {
+        assertThat(new ItemTagParam().aliases()).containsExactly("itags", "itag");
+    }
+
+    private static ParamContext ctx() {
+        return new ParamContext(null, null, 100);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -335,6 +335,45 @@ class ResultRendererTest {
         assertThat(hover).contains("(+8 more)");
     }
 
+    @Test
+    void hoverShowsCustomDataTags() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("deposit")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("deposit", "deposited"));
+
+        // An item carrying ONLY custom_data (no name/lore/enchants) still
+        // surfaces a Tags line (#140).
+        net.medievalrp.spyglass.api.event.StoredItem item =
+                new net.medievalrp.spyglass.api.event.StoredItem(
+                        0, "PAPER", null, null, List.of(), List.of(),
+                        "{quest:\"deliver_letter\"}");
+
+        String hover = hoverPlain(renderer.renderSingle(
+                depositRecord(item), EnumSet.noneOf(Flag.class), true));
+
+        assertThat(hover).contains("Tags").contains("deliver_letter");
+    }
+
+    @Test
+    void hoverCapsLongTags() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("deposit")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("deposit", "deposited"));
+
+        String big = "{data:\"" + "x".repeat(400) + "\"}";
+        net.medievalrp.spyglass.api.event.StoredItem item =
+                new net.medievalrp.spyglass.api.event.StoredItem(
+                        0, "PAPER", null, null, List.of(), List.of(), big);
+
+        String hover = hoverPlain(renderer.renderSingle(
+                depositRecord(item), EnumSet.noneOf(Flag.class), true));
+
+        // The hover previews custom_data with an ellipsis; the full blob is
+        // only reachable via itags:, so it must not appear verbatim.
+        assertThat(hover).contains("Tags").contains("…");
+        assertThat(hover).doesNotContain(big);
+    }
+
     private static String findRunCommand(Component component) {
         net.kyori.adventure.text.event.ClickEvent click = component.clickEvent();
         if (click != null

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ItemSerializationTest.java
@@ -149,4 +149,121 @@ class ItemSerializationTest {
         assertThat(item.enchants()).isEmpty();
         verify(stack, never()).getItemMeta();
     }
+
+    // ── custom-data projection (#140): tags carry minecraft:custom_data ──
+
+    @Test
+    void capturesCustomDataFromComponentString() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.PAPER);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1});
+        ItemMeta meta = mock(ItemMeta.class);
+        when(stack.hasItemMeta()).thenReturn(true);
+        when(stack.getItemMeta()).thenReturn(meta);
+        when(meta.hasDisplayName()).thenReturn(false);
+        when(meta.hasLore()).thenReturn(false);
+        when(meta.hasEnchants()).thenReturn(false);
+        when(meta.getAsComponentString()).thenReturn(
+                "[minecraft:max_stack_size=1,minecraft:custom_data={quest:\"deliver_letter\"}]");
+
+        StoredItem item = ItemSerialization.storedItem(0, stack);
+
+        assertThat(item).isNotNull();
+        assertThat(item.tags()).isEqualTo("{quest:\"deliver_letter\"}");
+    }
+
+    @Test
+    void tagsNullWhenItemHasNoCustomData() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.DIAMOND_SWORD);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1});
+        ItemMeta meta = mock(ItemMeta.class);
+        when(stack.hasItemMeta()).thenReturn(true);
+        when(stack.getItemMeta()).thenReturn(meta);
+        when(meta.hasDisplayName()).thenReturn(false);
+        when(meta.hasLore()).thenReturn(false);
+        when(meta.hasEnchants()).thenReturn(false);
+        when(meta.getAsComponentString()).thenReturn("[minecraft:damage=42]");
+
+        StoredItem item = ItemSerialization.storedItem(0, stack);
+
+        assertThat(item).isNotNull();
+        assertThat(item.tags()).isNull();
+    }
+
+    // ── extractCustomData(): pure string parsing, no Bukkit needed ──
+
+    @Test
+    void extractCustomDataNullAndAbsent() {
+        assertThat(ItemSerialization.extractCustomData(null)).isNull();
+        assertThat(ItemSerialization.extractCustomData("[minecraft:damage=5]")).isNull();
+        assertThat(ItemSerialization.extractCustomData("[]")).isNull();
+    }
+
+    @Test
+    void extractCustomDataSimpleAndPositioned() {
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={quest:\"x\"}]"))
+                .isEqualTo("{quest:\"x\"}");
+        // custom_data need not be the first component
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:damage=1,minecraft:custom_data={k:1},minecraft:max_stack_size=1]"))
+                .isEqualTo("{k:1}");
+    }
+
+    @Test
+    void extractCustomDataEmptyCompoundIsNull() {
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={}]")).isNull();
+    }
+
+    @Test
+    void extractCustomDataHandlesNestedBraces() {
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={a:{b:1},c:2}]"))
+                .isEqualTo("{a:{b:1},c:2}");
+        // plugin PersistentDataContainer values live under PublicBukkitValues
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={PublicBukkitValues:{\"mmoitems:type\":\"SWORD\"}}]"))
+                .isEqualTo("{PublicBukkitValues:{\"mmoitems:type\":\"SWORD\"}}");
+    }
+
+    @Test
+    void extractCustomDataIgnoresBracesInsideQuotes() {
+        // a brace inside a double-quoted value must not unbalance the scan
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={msg:\"a}b{c\"},minecraft:damage=1]"))
+                .isEqualTo("{msg:\"a}b{c\"}");
+        // single-quoted strings count too
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={msg:'x}y'}]"))
+                .isEqualTo("{msg:'x}y'}");
+    }
+
+    @Test
+    void extractCustomDataHandlesEscapedQuote() {
+        // \" is an escaped quote, so the } that follows is still inside the
+        // string and must not close the compound early.
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={msg:\"a\\\"}b\"}]"))
+                .isEqualTo("{msg:\"a\\\"}b\"}");
+    }
+
+    @Test
+    void extractCustomDataToleratesWhitespaceBeforeCompound() {
+        // hedge against a renderer that pads the '=' with a space
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data= {k:1}]"))
+                .isEqualTo("{k:1}");
+    }
+
+    @Test
+    void extractCustomDataMalformedIsNull() {
+        // unbalanced compound
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data={oops:1")).isNull();
+        // marker present but the value isn't a compound
+        assertThat(ItemSerialization.extractCustomData(
+                "[minecraft:custom_data=5]")).isNull();
+    }
 }


### PR DESCRIPTION
Closes #140.

## What
- **`itags:`** (alias `itag`) - case-insensitive substring search over an item's `minecraft:custom_data`: vanilla `/give ...[custom_data={...}]`, datapack data, and plugin `PersistentDataContainer` values (which Paper stores under `custom_data`). Same five-path OR expansion as `ilore:` (item / beforeItem / afterItem / container snapshots).
- **`ench:` aliases** `ienchant`, `ienchantments` for discoverability alongside `iname`/`ilore`/`itags`.
- New `StoredItem.tags` projection, captured at record time from `ItemMeta.getAsComponentString()` (the data-component API does not expose `CUSTOM_DATA`, so we lift the compound out of the rendered component string with a brace-balanced, quote/escape-aware scan).
- Result hover gains a length-capped **Tags** line.
- `cu:` (has-metadata) now also counts an item carrying only custom_data.

## Why this needed no schema change
`StoredItem` serializes through the auto record codec on Mongo, and ClickHouse/SQLite store items inside that same BSON blob, so the new field propagates to all three backends for free. On Mongo the `*.tags` regex pushes down on the subdocument; on ClickHouse/SQLite item-paths fall to the in-memory `PredicateEvaluator` post-filter (added the `tags` case there). Records written before the field decode with `tags == null` (verified).

## Tests
`./gradlew check` green (jacoco floors hold on all modules). Store ITs ran against real Mongo + ClickHouse via Docker (0 skipped):
- `ItemSerializationTest` - custom_data extraction edge cases (nested braces, quoted/escaped braces, whitespace, empty/malformed) + capture path.
- `ItemTagParamTest` / `EnchantParamTest` - param shape, paths, new aliases.
- `PredicateEvaluatorTest` - `tags` resolution (the ClickHouse/SQLite path).
- `StoredItemBackCompatTest` - genuinely-absent `tags` key decodes to null + round-trip.
- `MongoRecordStoreIT` (push-down) / `ClickHouseRecordStoreIT` + `SqliteRecordStoreTest` (residual) - end-to-end `itags:` queries.
- `ResultRendererTest` - Tags hover line + truncation.

## Not in scope
Left/right-click item interactions: Minecraft chat components have no right-click action, and the item preview is already served by the hover (which now includes Tags).

## One thing to confirm live
The capture assumes `getAsComponentString()` emits the compact `minecraft:custom_data={...}` form (verified at unit level on representative strings; the extractor also tolerates optional whitespace). Worth a quick confirm on a live custom item before relying on it in anger.