### PR TITLE
docs: add quoted-value examples to README and commands.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,15 +120,17 @@ Search, rollback, and restore share one `key:value` query language. Combine as m
 
 #### Query keys
 
+Values are plain terms. Wrap in double quotes to search for a value that contains spaces or colons: `iname:"Storm Caller"`, `itags:"mmoitems:type"`.
+
 | Key | Aliases | Example | Notes |
 |---|---|---|---|
 | `p:` | `player:` | `p:Steve,Alex` · `p:!Steve` | Comma-separated for OR; `!name` excludes |
 | `a:` | `action:`, `event:` | `a:break,place` · `a:!place` | Event type. See `/sg events`; `!name` excludes |
 | `b:` | `block:` | `b:diamond_ore` · `b:!chest` | Target block material; `!material` excludes |
 | `i:` | `item:` | `i:netherite_sword` | Item material involved (drop, pickup, container, etc.) |
-| `iname:` | `itemname:` | `iname:Excalibur` | Item display name (substring). Works on both backends |
-| `ilore:` | `itemlore:`, `d:` | `ilore:cursed` | Item lore line (substring). Works on both backends |
-| `itags:` | `itag:` | `itags:deliver_letter` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values. Works on all backends |
+| `iname:` | `itemname:` | `iname:Excalibur` · `iname:"Storm Caller"` | Item display name (substring). Works on both backends |
+| `ilore:` | `itemlore:`, `d:` | `ilore:cursed` · `ilore:"for the worthy"` | Item lore line (substring). Works on both backends |
+| `itags:` | `itag:` | `itags:deliver_letter` · `itags:"mmoitems:type"` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values. Works on all backends |
 | `ench:` | `enchant:`, `enchantment:`, `ienchant:`, `ienchantments:` | `ench:sharpness=5` | Item enchantment. Works on both backends |
 | `cu:` | `custom:` | `cu:my-custom-item` | Item carries metadata: custom name, lore, enchants, or custom data |
 | `e:` | `entity:` | `e:creeper` | Entity type involved |
@@ -225,6 +227,12 @@ If the server crashes mid-rollback, the job comes back as resumable on the next 
 
 # Track a specific enchanted item through drops and pickups.
 /sg search ench:sharpness=5 t:1d -g
+
+# Find items tagged by a plugin. Values that contain colons require quotes.
+/sg search a:deposit itags:"mmoitems:type" t:1d -g
+
+# Find an item by its full multi-word name. Values with spaces require quotes.
+/sg search iname:"Storm Caller" t:1w -g
 
 # Every command a specific IP ran today.
 /sg search ip:1.2.3.4 a:command t:1d -g

--- a/commands.md
+++ b/commands.md
@@ -36,7 +36,7 @@ Root: `/spyglass`. Short alias: `/sg`.
 
 ## Query keys
 
-`key:value`. Combine freely; results match all keys. On `p:`, `a:`, `b:`, and `c:`, prefix a value with `!` to exclude it instead — `b:stone,!chest` matches stone but never chests; `a:!place` matches everything except placements.
+`key:value`. Combine freely; results match all keys. On `p:`, `a:`, `b:`, and `c:`, prefix a value with `!` to exclude it instead (`b:stone,!chest` matches stone but never chests; `a:!place` matches everything except placements). Wrap a value in double quotes when it contains spaces or colons: `iname:"Storm Caller"`, `itags:"mmoitems:type"`.
 
 | Key | Aliases | Notes |
 |---|---|---|
@@ -44,9 +44,9 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `a` | `action`, `event` | Event type. See `/sg events`; `!name` excludes |
 | `b` | `block` | Target block material; `!material` excludes |
 | `i` | `item` | Item material |
-| `iname` | `itemname` | Item display name (substring) |
-| `ilore` | `itemlore`, `d` | Item lore (substring) |
-| `itags` | `itag` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values |
+| `iname` | `itemname` | Item display name (substring). Quote multi-word names: `iname:"Storm Caller"` |
+| `ilore` | `itemlore`, `d` | Item lore (substring). Quote multi-word phrases: `ilore:"for the worthy"` |
+| `itags` | `itag` | Item custom data / NBT (substring): vanilla `custom_data`, datapack, and plugin PDC values. Quote plugin-namespaced keys: `itags:"mmoitems:type"` |
 | `ench` | `enchant`, `enchantment`, `ienchant`, `ienchantments` | Enchantment |
 | `cu` | `custom` | Item has metadata: custom name, lore, enchants, or custom data |
 | `e` | `entity` | Entity type |


### PR DESCRIPTION
## Summary

- Adds a lead-in sentence above each query-key table explaining that values with spaces or colons require double quotes
- Updates the `iname:`, `ilore:`, and `itags:` example columns in README.md with quoted-value variants (`iname:"Storm Caller"`, `ilore:"for the worthy"`, `itags:"mmoitems:type"`)
- Adds inline examples to the Notes column of those same rows in commands.md
- Adds two new entries to the README Examples block showing the quoted syntax in real queries
- Fixes the em dash in the commands.md intro paragraph

## Test plan

- [ ] Review rendered Markdown in the PR diff - table examples and inline code look correct
- [ ] Verify no em/en dashes in the changed lines