### PR TITLE
feat(metrics): bStats usage metrics + publish the Velocity jar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           # link can point at /releases/latest/download/<name> permanently.
           cp "spyglass/build/libs/Spyglass-${v}.jar"        "dist/Spyglass.jar"
           cp "spyglass/build/libs/Spyglass-${v}-shaded.jar" "dist/Spyglass-shaded.jar"
+          cp "spyglass-velocity/build/libs/Spyglass-Velocity-${v}.jar" "dist/Spyglass-Velocity.jar"
           {
             echo "**Spyglass v${v}** - forensic logging & rollback for Paper 1.21.x (Java 21)."
             echo
@@ -72,6 +73,10 @@ jobs:
             echo "- **\`Spyglass-shaded.jar\`** - fat fallback with every dependency bundled."
             echo "  Use it if your host blocks outbound network at boot, or you hit a"
             echo "  library-loader issue. Identical behavior, larger file."
+            echo "- **\`Spyglass-Velocity.jar\`** - optional Velocity proxy companion for"
+            echo "  cross-server search. Read-only: never writes records, never rolls back."
+            echo "  Install on the proxy only if you run a Velocity network; a standalone"
+            echo "  Paper server doesn't need it."
           } > dist/NOTES.md
 
       - name: Create release
@@ -80,6 +85,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "v${{ steps.ver.outputs.version }}" \
-            dist/Spyglass.jar dist/Spyglass-shaded.jar \
+            dist/Spyglass.jar dist/Spyglass-shaded.jar dist/Spyglass-Velocity.jar \
             --title "Spyglass ${{ steps.ver.outputs.version }}" \
             --notes-file dist/NOTES.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val testcontainersVersion = "1.21.3"
 val jetbrainsAnnotationsVersion = "26.0.2"
 val faweVersion = "2.15.2"
 val worldeditVersion = "7.3.15"
+val bstatsVersion = "3.2.1"
 
 // True when a Docker daemon is reachable. Used to warn (not fail) when the
 // Testcontainers store ITs will assume-skip, so a no-Docker `check` isn't
@@ -158,4 +159,5 @@ extra.apply {
     set("jetbrainsAnnotationsVersion", jetbrainsAnnotationsVersion)
     set("faweVersion", faweVersion)
     set("worldeditVersion", worldeditVersion)
+    set("bstatsVersion", bstatsVersion)
 }

--- a/spyglass-velocity/build.gradle.kts
+++ b/spyglass-velocity/build.gradle.kts
@@ -80,6 +80,10 @@ tasks.shadowJar {
 
 tasks.jar {
     archiveBaseName.set("Spyglass-Velocity")
+    // Classified so the plain module jar never shares a filename with the
+    // shipped shadowJar (Spyglass-Velocity-<version>.jar). Mirrors the spyglass
+    // module's `thin` jar. Not a published artifact.
+    archiveClassifier.set("thin")
 }
 
 tasks.build {

--- a/spyglass/build.gradle.kts
+++ b/spyglass/build.gradle.kts
@@ -2,7 +2,11 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     java
-    id("com.gradleup.shadow") version "8.3.6"
+    // 9.x required: the 8.3.6 Groovy ASM remapper throws on integer/Type
+    // constant fields under Gradle 9 the moment any relocate rule is active
+    // (we relocate org.bstats below, and SpyglassPlugin references it). 9.x
+    // rewrote the remapper and fixes it; the task package is unchanged.
+    id("com.gradleup.shadow") version "9.4.2"
 }
 
 val paperApiVersion: String by rootProject.extra
@@ -19,6 +23,7 @@ val testcontainersVersion: String by rootProject.extra
 val jetbrainsAnnotationsVersion: String by rootProject.extra
 val faweVersion: String by rootProject.extra
 val worldeditVersion: String by rootProject.extra
+val bstatsVersion: String by rootProject.extra
 
 java {
     toolchain {
@@ -67,6 +72,12 @@ dependencies {
     implementation("org.incendo:cloud-paper:$cloudMinecraftVersion")
     implementation("org.incendo:cloud-annotations:$cloudCoreVersion")
     implementation("org.incendo:cloud-minecraft-extras:$cloudMinecraftVersion")
+    // bStats metrics. Shaded + relocated into BOTH shipped jars (see the
+    // ShadowJar relocate below) - deliberately NOT placed under plugin.yml
+    // `libraries:`, because Paper's library loader can't relocate and bStats
+    // requires relocation to avoid clashing with other plugins' copies. It is
+    // tiny (~25 KB), so bundling it in the lean jar too doesn't dent "lean".
+    implementation("org.bstats:bstats-bukkit:$bstatsVersion")
 
     testImplementation(project(":spyglass-api"))
     testImplementation("io.papermc.paper:paper-api:$paperApiVersion")
@@ -160,12 +171,23 @@ val leanJar = tasks.register<ShadowJar>("leanJar") {
     archiveClassifier.set("")
     from(sourceSets["main"].output)
     configurations = listOf(project.configurations.runtimeClasspath.get())
-    // Keep only our own modules (spyglass-api / -core). Everything else is
-    // declared under plugin.yml `libraries:` and resolved by Paper at runtime,
-    // so it must not be bundled here.
+    // Keep our own modules (spyglass-api / -core) AND bStats. Everything else is
+    // declared under plugin.yml `libraries:` and resolved by Paper at runtime, so
+    // it must not be bundled here. bStats is the one exception: it can't go
+    // through `libraries:` (the loader can't relocate it), so it travels bundled
+    // and relocated in the lean jar too - it's tiny.
     dependencies {
-        exclude { it.moduleGroup != "net.medievalrp" }
+        exclude { it.moduleGroup != "net.medievalrp" && it.moduleGroup != "org.bstats" }
     }
+}
+
+// bStats must be relocated out of `org.bstats` into our own namespace in EVERY
+// shaded artifact (the lean default jar and the fat fallback alike). bStats
+// refuses to run unrelocated, and an unrelocated copy would collide with any
+// other plugin that also bundles bStats. Applying it to all ShadowJar tasks
+// keeps the rule in one place.
+tasks.withType<ShadowJar>().configureEach {
+    relocate("org.bstats", "net.medievalrp.spyglass.libs.bstats")
 }
 
 tasks.build {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -122,11 +122,20 @@ import net.medievalrp.spyglass.plugin.command.service.tool.ToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.WandInteractListener;
 import net.medievalrp.spyglass.plugin.worldedit.WorldEditLifecycleListener;
 import net.medievalrp.spyglass.plugin.worldedit.WorldEditSubscriber;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class SpyglassPlugin extends JavaPlugin {
+
+    /**
+     * bStats service id for Spyglass, assigned at https://bstats.org when the
+     * plugin was registered. Submission is gated on {@code metrics.enabled} in
+     * config.conf (and on the server-wide bStats opt-out the library writes).
+     */
+    private static final int BSTATS_PLUGIN_ID = 32119;
 
     private AsyncRecorder recorder;
     private RecordStore recordStore;
@@ -154,6 +163,7 @@ public final class SpyglassPlugin extends JavaPlugin {
      */
     private DeferredSerializer deferredSerializer;
     private SpyglassConfig config;
+    private Metrics metrics;
     private WorldEditSubscriber worldEditSubscriber;
     private WorldEditLifecycleListener worldEditLifecycle;
 
@@ -572,6 +582,20 @@ public final class SpyglassPlugin extends JavaPlugin {
                 recorder, support, queryExecutor, this, getLogger(), worldEditSubscriber);
         getServer().getPluginManager().registerEvents(worldEditLifecycle, this);
 
+        // bStats anonymous usage metrics. The org.bstats package is relocated
+        // into net.medievalrp.spyglass.libs.bstats at shade time, so this can't
+        // clash with another plugin's bundled bStats. Opt-out is either
+        // metrics.enabled = false here or the server-wide bStats config the
+        // library writes. One custom chart reports the storage backend in use
+        // (sqlite / mongo / clickhouse); the rest is bStats' default,
+        // non-identifying platform data (server software, player count, Java).
+        if (config.metrics().enabled()) {
+            this.metrics = new Metrics(this, BSTATS_PLUGIN_ID);
+            this.metrics.addCustomChart(new SimplePie("storage_backend",
+                    () -> config.database().backend().name().toLowerCase(java.util.Locale.ROOT)));
+            getLogger().info("Spyglass: bStats metrics enabled (opt out with metrics.enabled=false).");
+        }
+
         getLogger().info("Spyglass enabled; events=" + enabledEvents);
     }
 
@@ -592,7 +616,12 @@ public final class SpyglassPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // Prefer the lifecycle-tracked subscriber — if WE was hot-
+        // Stop the bStats submit scheduler first so it can't fire mid-teardown.
+        if (metrics != null) {
+            metrics.shutdown();
+            metrics = null;
+        }
+        // Prefer the lifecycle-tracked subscriber - if WE was hot-
         // loaded/unloaded during the session, the initial field may be
         // stale.
         WorldEditSubscriber active = worldEditLifecycle != null

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -19,7 +19,8 @@ public record SpyglassConfig(
         Map<String, EventSettings> events,
         java.util.List<String> commandRedact,
         Tool tool,
-        Server server) {
+        Server server,
+        Metrics metrics) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -115,7 +116,8 @@ public record SpyglassConfig(
                 Map.copyOf(events),
                 commandRedact,
                 new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
-                new Server(root.node("server", "name").getString("default")));
+                new Server(root.node("server", "name").getString("default")),
+                parseMetrics(root));
     }
 
     /**
@@ -133,6 +135,19 @@ public record SpyglassConfig(
         return redactNode.getList(String.class, java.util.List.of()).stream()
                 .filter(java.util.Objects::nonNull)
                 .toList();
+    }
+
+    /**
+     * bStats metrics opt-out. The key is absent on configs predating this
+     * option (and on a fresh default that leaves it on), so a missing value
+     * defaults to {@code true} - matching bStats' documented opt-out model.
+     * An explicit {@code metrics.enabled = false} disables Spyglass's own
+     * submission; the server-global {@code plugins/bStats/config.yml} the
+     * library writes is a second, server-wide switch. Static + package-visible
+     * so it's unit-testable headless, like {@link #parseCommandRedact}.
+     */
+    static Metrics parseMetrics(ConfigurationNode root) {
+        return new Metrics(root.node("metrics", "enabled").getBoolean(true));
     }
 
     public boolean enabled(String eventName) {
@@ -312,6 +327,14 @@ public record SpyglassConfig(
                 name = "default";
             }
         }
+    }
+
+    /**
+     * Anonymous usage metrics via bStats (https://bstats.org). {@code enabled}
+     * defaults to {@code true}; set {@code metrics.enabled = false} in
+     * {@code config.conf} to opt this server out of Spyglass's submission.
+     */
+    public record Metrics(boolean enabled) {
     }
 
     private static ConfigurationNode loadBundledDefaults(JavaPlugin plugin) throws IOException {

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -208,6 +208,17 @@ server {
   name = "default"
 }
 
+metrics {
+  # Anonymous usage statistics via bStats (https://bstats.org). When true
+  # (the default), Spyglass reports coarse, non-identifying numbers - server
+  # software/version, player-count bucket, Java version, which storage backend
+  # is in use - so the project can see what to keep compatible with. No world
+  # data, player names, IPs, or recorded events are ever sent. Set false to opt
+  # this server out; the server-wide plugins/bStats/config.yml switch disables
+  # it for every bStats plugin at once.
+  enabled = true
+}
+
 events {
   # Per-event-type recording toggles and display verbs. enabled = false
   # stops Spyglass recording that event entirely: it won't appear in

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -43,4 +43,27 @@ class SpyglassConfigTest {
         assertThat(SpyglassConfig.parseCommandRedact(root))
                 .containsExactly("login");
     }
+
+    @Test
+    void absentMetricsKeyDefaultsToEnabled() {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+
+        assertThat(SpyglassConfig.parseMetrics(root).enabled()).isTrue();
+    }
+
+    @Test
+    void explicitMetricsFalseIsTheOptOut() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("metrics", "enabled").set(false);
+
+        assertThat(SpyglassConfig.parseMetrics(root).enabled()).isFalse();
+    }
+
+    @Test
+    void explicitMetricsTrueKeepsItEnabled() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("metrics", "enabled").set(true);
+
+        assertThat(SpyglassConfig.parseMetrics(root).enabled()).isTrue();
+    }
 }


### PR DESCRIPTION
## What

Two related pieces of work the user asked for in one session.

### 1. bStats usage metrics (opt-out)
- Wires `org.bstats:bstats-bukkit:3.2.1` (service id **32119**) into the plugin bootstrap.
- Reports bStats' default platform data + one custom chart: **storage backend in use** (sqlite / mongo / clickhouse). No world data, player identities, IPs, or recorded events are sent.
- **Opt-out**: `metrics.enabled = false` in `config.conf`, or the server-wide bStats config. Defaults on.
- bStats is **shaded + relocated** (`org.bstats` -> `net.medievalrp.spyglass.libs.bstats`) into **both** shipped jars (lean default + fat fallback). It is *not* placed under `plugin.yml` `libraries:` because Paper's loader can't relocate and bStats requires relocation; at ~25 KB it is negligible in the lean jar.
- **Build**: bumps the spyglass module `com.gradleup.shadow` 8.3.6 -> **9.4.2**. The 8.3.6 Groovy ASM remapper throws on integer/Type constant fields under Gradle 9 the moment any relocate is active (the velocity module was already on 9.x for the same reason). Task package is unchanged, so no import changes.

### 2. Publish the Velocity proxy jar
- `spyglass-velocity` (cross-server search, read-only) was built by `./gradlew build` but never attached to releases. `release.yml` now stages, documents, and uploads `Spyglass-Velocity-<version>.jar`.
- Classifies the velocity plain jar `-thin` so it can't share a filename with the shipped shadowJar (mirrors the spyglass module).

## Tests
- `SpyglassConfig.parseMetrics`: default-on + explicit opt-out (unit).
- `./gradlew :spyglass:check :spyglass-velocity:build` green (incl. jacoco floor).

## Verified live (Paper 1.21.8 boot-smoke)
- Relocated `Metrics` constructs + `storage_backend` chart registers cleanly; clean enable + Done, no errors.
- Jar inspection: **zero** `org/bstats` entries in either jar; lean jar still carries no Mongo/ClickHouse/SQLite (+~30 KB only); shaded jar keeps all heavy deps.

Base branch is **dev** per the dev-integration model (not main).