### PR TITLE
docs(readme): AI policy, Crusalis spark profile, drop Distribution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A 2,000,376-block rollback, measured five ways: Spyglass on each of its three ba
 | Worst single tick | ~50 ms | ~100 ms | **~37 ms** | ~670 ms | ~270 ms |
 | On-disk footprint (data + index) | **~11 MiB** | ~145 MiB | ~156 MiB | ~160 MiB | ~180 MiB |
 
+A live [spark profile](https://spark.lucko.me/5JzJrfOmaM) of Spyglass running in production on [Crusalis](https://crusalis.net) (1,500+ players).
+
 > **Why MongoDB?** the60th asks me the same question. I really just like using MongoDB. Although we recommend servers utilize ClickHouse for performance and efficient disk space usage. MySQL will not come to Spyglass. 
 
 ## Features
@@ -77,15 +79,6 @@ Spyglass runs on SQLite, MongoDB, or ClickHouse. The embedded SQLite backend nee
   - MongoDB (set `database.backend = "mongo"`) at `mongodb://localhost:27017`
   - ClickHouse (set `database.backend = "clickhouse"`)
 - Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for WorldEdit-edit capture and `-we` queries. Capture hooks the edit-session pipeline, not command names, so every block-mutating operation is recorded - `//set`, `//replace`, `//walls`, `//overlay`, `//paste`, schematic paste, brushes, generation, `//move`/`//stack`, and `//undo`/`//redo` alike - for player and non-player (console/plugin) edits
-
-## Distribution
-
-Each [GitHub release](https://github.com/medievalrp-net/Spyglass/releases/latest) ships two jars:
-
-- **`Spyglass.jar`** (recommended) - lean build, ~0.7 MB. Its third-party libraries (the MongoDB / ClickHouse / SQLite drivers, the Cloud command framework, Configurate) are **not** bundled: Paper's library loader fetches them from Maven Central on first start and caches them under `<server>/libraries/`. This needs outbound internet the first time the plugin loads (and after a version bump).
-- **`Spyglass-shaded.jar`** - fat fallback, ~30 MB, with every dependency bundled and no library-loader requirement. Use it on hosts with no outbound network at boot, or if you hit a library-loader issue. Behavior is identical.
-
-Both are built from one source: the lean jar's `plugin.yml` `libraries:` block and the shaded jar are produced by `./gradlew :spyglass:leanJar` and `:spyglass:shadowJar` respectively (`./gradlew build` makes both).
 
 ## Commands
 
@@ -248,6 +241,10 @@ If the server crashes mid-rollback, the job comes back as resumable on the next 
 - `spyglass-core/` holds the shared internals (codecs, storage glue).
 - `spyglass/` is the Paper plugin.
 - `spyglass-velocity/` is an optional Velocity proxy companion for cross-server search. It is read-only by design: it never writes records and never rolls back.
+
+## AI policy
+
+Spyglass is human-led. We make the architectural and design decisions, and we will defend every line that ships. AI assists with boilerplate, testing, and drafting issues. Nothing merges to main without a review and a passing test suite, and every performance claim here is measured on a real server.
 
 ## License
 


### PR DESCRIPTION
Docs-only. Adds an AI-policy section (human-led, AI assists with boilerplate/testing/issues), links the live Crusalis spark profile in Performance, and removes the Distribution section. No version change - no release build.