### PR TITLE
fix(rollback): relight after rollback to clear stale lighting (v1.0.3)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.2
+version=1.0.3
 group=net.medievalrp
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -34,6 +34,8 @@ import net.medievalrp.spyglass.plugin.rollback.BlockColumns;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import net.medievalrp.spyglass.plugin.storage.UndoReferenceBson;
+import net.medievalrp.spyglass.plugin.util.ChunkRelighter;
+import net.medievalrp.spyglass.plugin.util.ChunkResender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
@@ -45,6 +47,11 @@ public final class RollbackService {
     // limits.rollback-page-size knob; since #19 it has no heap/GC effect
     // and is a query-efficiency default operators never need to tune.
     private static final int STREAM_PAGE_SIZE = 500_000;
+
+    // Static so the stateless relight helper (shared with the legacy /undo
+    // path) can log without an instance — keeps that path from interacting
+    // with a RollbackService instance.
+    private static final Logger RELIGHT_LOGGER = Logger.getLogger(RollbackService.class.getName());
 
     private final SpyglassApi api;
     private final QueryStringParser parser;
@@ -604,6 +611,15 @@ public final class RollbackService {
         for (Set<Long> set : warmedChunks.values()) {
             chunkCount += set.size();
         }
+        // The engine restores blocks with a direct LevelChunkSection
+        // palette write that skips the light engine (ChunkDirectWriter), so
+        // the rolled region renders with stale, pre-rollback lighting until
+        // a natural relight. Recompute it now over exactly the chunks we
+        // wrote (Starlight, off-main; resend each chunk as it lands). Covers
+        // rollback, restore, and reference-based /undo (executeReplay).
+        if (totalApplied > 0) {
+            relightWrittenChunks(support, warmedChunks);
+        }
         logger.info(String.format(
                 "Spyglass %s %s timings: query=%dms collect=%dms prewarm=%dms apply=%dms"
                         + " | %d windows, %d chunks, %d applied, %dms total",
@@ -974,6 +990,38 @@ public final class RollbackService {
         flags.add(Flag.NO_GROUP);
         Sort sort = mode == RollbackMode.ROLLBACK ? Sort.NEWEST_FIRST : Sort.OLDEST_FIRST;
         return new QueryRequest(request.predicates(), sort, request.limit(), flags, false);
+    }
+
+    // Recompute + resend lighting for chunks a rollback/undo restored via
+    // the engine's direct section-palette write (which skips the light
+    // engine). Shared by the windowed apply path and the legacy /undo
+    // replay. Best-effort and fully off the hot path: the Starlight
+    // recompute runs off-main and each chunk is resent with fresh light as
+    // it lands. No-ops cleanly where the relight API is unavailable.
+    static void relightWrittenChunks(ServiceSupport support, Map<UUID, Set<Long>> chunksByWorld) {
+        try {
+            for (Map.Entry<UUID, Set<Long>> entry : chunksByWorld.entrySet()) {
+                World world = Bukkit.getWorld(entry.getKey());
+                Set<Long> chunks = entry.getValue();
+                if (world == null || chunks.isEmpty()) {
+                    continue;
+                }
+                long[] keys = new long[chunks.size()];
+                int i = 0;
+                for (Long key : chunks) {
+                    keys[i++] = key;
+                }
+                support.onMainThread(() -> ChunkRelighter.relight(world, keys,
+                        (cx, cz) -> support.onMainThread(() -> ChunkResender.resend(world, cx, cz))));
+            }
+        } catch (Throwable t) {
+            // Relight is best-effort: a lighting-refresh hiccup must never
+            // abort the rollback's completion path. ChunkRelighter logs its
+            // own NMS failures; this guards the surrounding scheduling (and
+            // keeps headless tests, where Bukkit has no server, green).
+            RELIGHT_LOGGER.log(java.util.logging.Level.FINE,
+                    "Spyglass post-rollback relight skipped", t);
+        }
     }
 
     public static Component summaryLine(Summary summary) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/UndoService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/UndoService.java
@@ -4,9 +4,13 @@ import net.medievalrp.spyglass.plugin.command.render.Feedback;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import net.medievalrp.spyglass.api.query.QueryPredicate;
@@ -17,6 +21,7 @@ import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import net.medievalrp.spyglass.plugin.storage.UndoReferenceBson;
+import net.medievalrp.spyglass.plugin.util.ChunkRelighter;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
@@ -128,6 +133,10 @@ public final class UndoService {
         int skipped = 0;
         int errors = 0;
         java.util.HashSet<String> chunks = new java.util.HashSet<>();
+        // Touched chunks per world, packed for ChunkRelighter — the legacy
+        // replay writes blocks through the same section-palette path that
+        // skips the light engine, so it needs the same post-write relight.
+        Map<UUID, Set<Long>> touchedByWorld = new HashMap<>();
         try {
             int chunkNo = 0;
             Optional<List<RollbackEffect>> chunk;
@@ -156,6 +165,8 @@ public final class UndoService {
                         if (loc != null) {
                             chunks.add(loc.worldId() + ":"
                                     + (loc.x() >> 4) + ":" + (loc.z() >> 4));
+                            touchedByWorld.computeIfAbsent(loc.worldId(), k -> new java.util.HashSet<>())
+                                    .add(ChunkRelighter.packChunk(loc.x() >> 4, loc.z() >> 4));
                         }
                     } else if (result instanceof RollbackResult.Skipped sk) {
                         skipped++;
@@ -187,6 +198,12 @@ public final class UndoService {
             return;
         } finally {
             legacy.close();
+        }
+        // Restore lighting over the chunks this replay wrote (the engine's
+        // direct section write skips the light engine). Same off-main
+        // Starlight recompute the windowed path uses.
+        if (applied > 0) {
+            RollbackService.relightWrittenChunks(support, touchedByWorld);
         }
         long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
         int finalApplied = applied;

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ChunkRelighter.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/ChunkRelighter.java
@@ -1,0 +1,206 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.bukkit.World;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Recomputes block + sky light for chunks a rollback wrote straight into
+ * the {@code LevelChunkSection} palette via {@link ChunkDirectWriter}.
+ *
+ * <p>The direct palette write deliberately bypasses {@code
+ * LevelChunk.setBlockState}, and with it the light-engine notification —
+ * so the server's stored light for those cells stays exactly as it was
+ * before the rollback. {@link ChunkResender} then ships a chunk packet
+ * built from that stale light, and the client renders a block-shaped
+ * shadow (or a wrongly-lit gap) over the rolled region until something
+ * external (a neighbouring block update, a chunk reload) forces a relight.
+ * On a WorldEdit-selection rollback — a large contiguous volume — that
+ * stale-light artifact is glaringly visible.
+ *
+ * <p>This class drives Paper's Starlight relight: {@code
+ * ThreadedLevelLightEngine.starlight$serverRelightChunks(Collection,
+ * Consumer, IntConsumer)}, the same entry point WorldEdit's {@code
+ * //fixlighting} and FAWE use. It fully recomputes light for the given
+ * chunks off the main thread and reports each chunk back as it lands, so
+ * the caller can resend it — Starlight does not broadcast to clients
+ * itself. The caller is expected to {@link ChunkResender#resend} each
+ * chunk from the {@code onChunkRelit} callback.
+ *
+ * <p>Reflective NMS access — the plugin builds against paper-api only.
+ * On any reflection failure the relighter disables itself for the rest of
+ * the session and {@link #relight} no-ops (returns {@code false}); the
+ * rollback still completes, lighting just stays stale as it did before.
+ */
+@ApiStatus.Internal
+public final class ChunkRelighter {
+
+    private static final Logger LOG = Logger.getLogger(ChunkRelighter.class.getName());
+
+    private static volatile boolean initialized;
+    private static volatile boolean available;
+
+    private static Method craftWorldGetHandle;
+    private static Method serverLevelGetLightEngine;
+    private static Method serverRelightChunks;
+    private static Constructor<?> chunkPosCtor;
+    // ChunkPos coordinate read differs by version: public final fields
+    // x/z on 1.21.x, record accessors x()/z() on 26.x. Resolve whichever
+    // this build exposes; exactly one pair is non-null when available.
+    private static Field chunkPosXField;
+    private static Field chunkPosZField;
+    private static Method chunkPosXMethod;
+    private static Method chunkPosZMethod;
+
+    private ChunkRelighter() {
+    }
+
+    /** Callback invoked with each chunk's coords as Starlight relights it. */
+    @FunctionalInterface
+    public interface ChunkRelit {
+        void accept(int cx, int cz);
+    }
+
+    /**
+     * Pack a chunk coordinate into a long the same way {@code
+     * RollbackService}'s warmed-chunk set does: {@code cx} high, {@code
+     * cz} low. Sharing the scheme lets that set feed {@link #relight}
+     * untouched.
+     */
+    public static long packChunk(int cx, int cz) {
+        return ((long) cx << 32) | (cz & 0xFFFFFFFFL);
+    }
+
+    public static int chunkX(long key) {
+        return (int) (key >> 32);
+    }
+
+    public static int chunkZ(long key) {
+        return (int) key;
+    }
+
+    /** Whether the Starlight relight path resolved on this server. */
+    public static boolean isAvailable() {
+        if (!initialized) {
+            init();
+        }
+        return available;
+    }
+
+    /**
+     * Asynchronously recompute light for {@code chunkKeys} (packed via
+     * {@link #packChunk}) in {@code world}. As each chunk's light is
+     * recomputed, {@code onChunkRelit} fires with its coords — on a
+     * Starlight thread, so hop to the main thread before touching Bukkit.
+     * Returns {@code false} without scheduling anything if the relight API
+     * is unavailable. Call on the main thread.
+     */
+    public static boolean relight(World world, long[] chunkKeys, ChunkRelit onChunkRelit) {
+        if (world == null || chunkKeys == null || chunkKeys.length == 0) {
+            return false;
+        }
+        if (!initialized) {
+            init();
+        }
+        if (!available) {
+            return false;
+        }
+        try {
+            Object serverLevel = craftWorldGetHandle.invoke(world);
+            Object lightEngine = serverLevelGetLightEngine.invoke(serverLevel);
+            List<Object> chunkPosList = new ArrayList<>(chunkKeys.length);
+            for (long key : chunkKeys) {
+                chunkPosList.add(chunkPosCtor.newInstance(chunkX(key), chunkZ(key)));
+            }
+            Consumer<Object> perChunk = chunkPos -> {
+                if (onChunkRelit == null) {
+                    return;
+                }
+                try {
+                    int cx;
+                    int cz;
+                    if (chunkPosXField != null) {
+                        cx = chunkPosXField.getInt(chunkPos);
+                        cz = chunkPosZField.getInt(chunkPos);
+                    } else {
+                        cx = (int) chunkPosXMethod.invoke(chunkPos);
+                        cz = (int) chunkPosZMethod.invoke(chunkPos);
+                    }
+                    onChunkRelit.accept(cx, cz);
+                } catch (Throwable ignored) {
+                    // A failed coord read only means this chunk isn't
+                    // resent with fresh light here; the server-side light
+                    // is still corrected, so the next natural chunk send
+                    // (relog / re-track) carries the right values.
+                }
+            };
+            // Completion total — per-chunk resends already cover client
+            // visibility, so nothing to do on the final tally.
+            IntConsumer onDone = count -> { };
+            serverRelightChunks.invoke(lightEngine, chunkPosList, perChunk, onDone);
+            return true;
+        } catch (Throwable t) {
+            available = false;
+            LOG.log(Level.WARNING,
+                    "Spyglass ChunkRelighter failed; rolled chunks keep stale lighting "
+                            + "until a natural relight. Cause: " + t, t);
+            return false;
+        }
+    }
+
+    private static synchronized void init() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+        try {
+            Class<?> craftWorld = Class.forName("org.bukkit.craftbukkit.CraftWorld");
+            craftWorldGetHandle = craftWorld.getMethod("getHandle");
+
+            // getLightEngine() is inherited from Level; the runtime instance
+            // on a server is always the ThreadedLevelLightEngine that carries
+            // the Starlight relight method. ChunkResender resolves it the same
+            // way.
+            Class<?> serverLevel = Class.forName("net.minecraft.server.level.ServerLevel");
+            serverLevelGetLightEngine = serverLevel.getMethod("getLightEngine");
+
+            Class<?> threadedLight = Class.forName(
+                    "net.minecraft.server.level.ThreadedLevelLightEngine");
+            // starlight$serverRelightChunks(Collection<ChunkPos>,
+            // Consumer<ChunkPos>, IntConsumer) — Moonrise/Starlight patch,
+            // present on every modern Paper build (verified 1.21.8 + 26.x).
+            serverRelightChunks = threadedLight.getMethod("starlight$serverRelightChunks",
+                    Collection.class, Consumer.class, IntConsumer.class);
+
+            Class<?> chunkPos = Class.forName("net.minecraft.world.level.ChunkPos");
+            chunkPosCtor = chunkPos.getConstructor(int.class, int.class);
+            // Public fields on 1.21.x; record accessors on 26.x (where
+            // ChunkPos became a record and the fields went private).
+            try {
+                chunkPosXField = chunkPos.getField("x");
+                chunkPosZField = chunkPos.getField("z");
+            } catch (NoSuchFieldException noPublicFields) {
+                chunkPosXField = null;
+                chunkPosZField = null;
+                chunkPosXMethod = chunkPos.getMethod("x");
+                chunkPosZMethod = chunkPos.getMethod("z");
+            }
+
+            available = true;
+        } catch (Throwable t) {
+            available = false;
+            LOG.log(Level.WARNING,
+                    "Spyglass ChunkRelighter unavailable (no Starlight relight API; rolled "
+                            + "chunks keep stale lighting until a natural relight). Cause: " + t, t);
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ChunkRelighterTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/ChunkRelighterTest.java
@@ -1,0 +1,60 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+class ChunkRelighterTest {
+
+    @Test
+    void packUnpackRoundTripsAcrossSignsAndExtremes() {
+        int[][] coords = {
+                {0, 0}, {1, 2}, {-1, -1}, {-5, 7}, {100, -200},
+                {Integer.MAX_VALUE, Integer.MIN_VALUE},
+                {Integer.MIN_VALUE, Integer.MAX_VALUE},
+        };
+        for (int[] cxcz : coords) {
+            long key = ChunkRelighter.packChunk(cxcz[0], cxcz[1]);
+            assertEquals(cxcz[0], ChunkRelighter.chunkX(key),
+                    "cx round-trip for " + cxcz[0] + "," + cxcz[1]);
+            assertEquals(cxcz[1], ChunkRelighter.chunkZ(key),
+                    "cz round-trip for " + cxcz[0] + "," + cxcz[1]);
+        }
+    }
+
+    @Test
+    void packingMatchesRollbackServiceScheme() {
+        // RollbackService packs warmed-chunk keys as ((long)(x>>4) << 32)
+        // | ((z>>4) & 0xFFFFFFFFL). The relighter consumes that set
+        // directly, so the scheme must stay identical or chunks shift.
+        int x = 273;
+        int z = -49;
+        int cx = x >> 4;
+        int cz = z >> 4;
+        long expected = ((long) cx << 32) | (cz & 0xFFFFFFFFL);
+        assertEquals(expected, ChunkRelighter.packChunk(cx, cz));
+        assertEquals(cx, ChunkRelighter.chunkX(expected));
+        assertEquals(cz, ChunkRelighter.chunkZ(expected));
+    }
+
+    @Test
+    void distinctChunksProduceDistinctKeys() {
+        long a = ChunkRelighter.packChunk(3, 4);
+        long b = ChunkRelighter.packChunk(4, 3);
+        assertEquals(false, a == b, "swapped coords must not collide");
+    }
+
+    @Test
+    void relightNoOpsWhenApiUnavailableOrInputEmpty() {
+        // No CraftWorld/NMS on the unit-test classpath, so init() resolves
+        // unavailable and every entry point degrades quietly rather than
+        // throwing — the rollback must never fail because relight can't run.
+        assertFalse(ChunkRelighter.isAvailable(),
+                "Starlight relight must resolve unavailable without a server runtime");
+        assertFalse(ChunkRelighter.relight(null, new long[]{ChunkRelighter.packChunk(0, 0)}, (cx, cz) -> { }),
+                "null world must no-op");
+        assertFalse(ChunkRelighter.relight(null, new long[0], (cx, cz) -> { }),
+                "empty key set must no-op");
+    }
+}


### PR DESCRIPTION
## What
Rollback restored blocks via a direct `LevelChunkSection` palette write (`ChunkDirectWriter`) that bypasses the light engine, leaving rolled regions with stale, pre-rollback lighting until a natural relight - very visible on a WorldEdit-selection rollback.

New `ChunkRelighter` drives Paper Starlight's `serverRelightChunks` over exactly the chunks a rollback wrote, then resends each chunk as its light lands (Starlight does not broadcast the relight itself). Wired through a shared `RollbackService.relightWrittenChunks` (covers rollback, restore, and reference-based undo via `executeReplay`) and the legacy `UndoService.replayLegacy` path, reusing the touched-chunk sets both services already maintain. The engine hot path is untouched; the relight is best-effort and no-ops if the Starlight API is unavailable.

## Release
Bumps `gradle.properties` to **1.0.3**, so merging to `main` cuts `v1.0.3` via `release.yml`. The only code change since 1.0.2 is this fix; 1.0.3 also carries the README docs already on `main` (#146/#147).

## Verification
- 334 plugin tests green incl new `ChunkRelighterTest`; full `./gradlew build` green; jacoco floors hold.
- NMS API verified against real `paper-1.21.8` + `paper-26.1.2` jars (`ChunkPos` public fields vs 26.x record accessors both handled).
- Deployed and confirmed working live on prod (UniverseSpigot 1.21.11).
