### PR TITLE
fix(query): resolve message/commandLine/recipients on the SQLite residual evaluator (#156)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
@@ -130,6 +132,17 @@ final class PredicateEvaluator {
             // empty. Resolve it from the decoded record so ip: works on every
             // backend.
             case "address" -> record instanceof JoinRecord j ? j.address() : null;
+            // Chat / command text + recipient list, same blob-folding story as
+            // `address` above. ClickHouse keeps these as real columns and Mongo
+            // as BSON fields, so the store pushes the predicate down there; on
+            // SQLite they live inside the per-event blob, so `m:` (an Or over
+            // `message`/`commandLine`) and `rcp:` (Eq/In over `recipients`) fall
+            // back to this residual filter. Without these cases they resolved to
+            // null and never matched, so m:/rcp: silently returned empty on
+            // SQLite. `m:` covers both chat and command lines, so resolve both.
+            case "message" -> record instanceof ChatRecord c ? c.message() : null;
+            case "commandLine" -> record instanceof CommandRecord c ? c.commandLine() : null;
+            case "recipients" -> record instanceof ChatRecord c ? c.recipients() : null;
             default -> itemPathValue(record, field);
         };
     }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluatorTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluatorTest.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.event.JoinRecord;
@@ -82,5 +84,67 @@ class PredicateEvaluatorTest {
     void doesNotMatchWhenItemAbsent() {
         EventRecord record = deposit(null);
         assertThat(PredicateEvaluator.matchesAll(List.of(tagsMatch("anything")), record)).isFalse();
+    }
+
+    @Test
+    void resolvesChatMessageForResidualMessageFilter() {
+        // m: builds Or(Eq("message", pattern), Eq("commandLine", pattern)); on
+        // SQLite both fields live in the blob, so the filter lands here. Without
+        // the "message" case it resolved to null and m: returned empty (#156).
+        EventRecord chat = chat("hello there, friend", List.of());
+        QueryPredicate match = new QueryPredicate.Eq("message",
+                Pattern.compile(Pattern.quote("there"), Pattern.CASE_INSENSITIVE));
+        QueryPredicate miss = new QueryPredicate.Eq("message",
+                Pattern.compile(Pattern.quote("absent"), Pattern.CASE_INSENSITIVE));
+        assertThat(PredicateEvaluator.matchesAll(List.of(match), chat)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(List.of(miss), chat)).isFalse();
+        // A non-chat record carries no message -> never matches.
+        assertThat(PredicateEvaluator.matchesAll(List.of(match), deposit(null))).isFalse();
+    }
+
+    @Test
+    void resolvesCommandLineForResidualMessageFilter() {
+        // The commandLine half of m:'s Or — a CommandRecord, blob-folded on SQLite.
+        EventRecord command = command("/tp Alice Bob");
+        QueryPredicate match = new QueryPredicate.Eq("commandLine",
+                Pattern.compile(Pattern.quote("Alice"), Pattern.CASE_INSENSITIVE));
+        QueryPredicate miss = new QueryPredicate.Eq("commandLine",
+                Pattern.compile(Pattern.quote("Charlie"), Pattern.CASE_INSENSITIVE));
+        assertThat(PredicateEvaluator.matchesAll(List.of(match), command)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(List.of(miss), command)).isFalse();
+    }
+
+    @Test
+    void resolvesRecipientsForResidualRcpFilter() {
+        // rcp: builds Eq/In over "recipients" (a List<UUID>); equalsValue's
+        // list-containment matches when any recipient equals the queried id.
+        UUID alice = UUID.randomUUID();
+        UUID bob = UUID.randomUUID();
+        UUID carol = UUID.randomUUID();
+        EventRecord chat = chat("psst", List.of(alice, bob));
+        assertThat(PredicateEvaluator.matchesAll(
+                List.of(new QueryPredicate.Eq("recipients", alice)), chat)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(
+                List.of(new QueryPredicate.In("recipients", List.of(carol, bob))), chat)).isTrue();
+        assertThat(PredicateEvaluator.matchesAll(
+                List.of(new QueryPredicate.Eq("recipients", carol)), chat)).isFalse();
+    }
+
+    private static EventRecord chat(String message, List<UUID> recipients) {
+        Instant now = Instant.now();
+        return new ChatRecord(
+                UUID.randomUUID(), "say", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(UUID.randomUUID(), "world", 1, 2, 3),
+                "srv", "GLOBAL", message, recipients, java.util.Map.of());
+    }
+
+    private static EventRecord command(String commandLine) {
+        Instant now = Instant.now();
+        return new CommandRecord(
+                UUID.randomUUID(), "command", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(UUID.randomUUID(), "world", 1, 2, 3),
+                "srv", "Alice", commandLine);
     }
 }


### PR DESCRIPTION
Closes #156.

## Problem
On the **SQLite** backend, `m:` (message) and `rcp:` (recipients) search filters returned wrong/empty results. Same root cause as the ip: fix (#150): SQLite folds these fields into the per-event blob, so the predicate falls to `PredicateEvaluator`, which had no `value()` case for them -> they resolved to `null` and never matched. ClickHouse (real columns) and Mongo (BSON) were unaffected.

## Fix
Add the residual `value()` cases in `PredicateEvaluator`. Note `m:` emits `Or(Eq("message"), Eq("commandLine"))`, so a complete fix needs **three** fields, not two:
- `message` -> `ChatRecord.message()`
- `commandLine` -> `CommandRecord.commandLine()` (the command half of `m:`; the issue listed only message/recipients)
- `recipients` -> `ChatRecord.recipients()`

`equalsValue` already handles regex (m: substring `Pattern`) and list-containment (rcp: `List<UUID>`), so this is purely the missing extraction.

## Tests
`PredicateEvaluatorTest`: added cases for message, commandLine, and recipients (Eq + In). Green.

## Verification
`./gradlew check` green; verified on a live SQLite server (see follow-up comment for the in-game m:/rcp: search results).