### PR TITLE
feat(search): add before: upper time-bound key for window queries (#157)

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -54,7 +54,8 @@ Root: `/spyglass`. Short alias: `/sg`.
 | `m` | `message` | Chat / sign / book text |
 | `rcp` | `recipient` | Private-message recipient |
 | `r` | `radius` | Radius in blocks. Default applies if omitted |
-| `t` | `since` | Time window. Default 4h |
+| `t` | `since` | Lower time bound (how far back). Default 4h |
+| `before` | - | Upper time bound. `t:12h before:6h` = events between 12h and 6h ago |
 | `w` | `world` | World name |
 | `srv` | `server` | Server name (multi-server) |
 | `trg` | `target` | Block coords `x,y,z` |

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParser.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParser.java
@@ -105,6 +105,12 @@ public final class ProxyQueryStringParser {
                         predicates.add(new QueryPredicate.Range("occurred", lower, null));
                         sawTime = true;
                     }
+                    case "before" -> {
+                        // Upper bound only - does NOT set sawTime, so the default
+                        // lower floor is still applied when no t:/since: is present.
+                        Instant upper = parseDuration(value);
+                        predicates.add(new QueryPredicate.Range("occurred", null, upper));
+                    }
                     case "m", "message" -> predicates.add(
                             new QueryPredicate.Eq("message",
                                     java.util.regex.Pattern.compile(

--- a/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParserTest.java
+++ b/spyglass-velocity/src/test/java/net/medievalrp/spyglass/proxy/command/ProxyQueryStringParserTest.java
@@ -3,6 +3,7 @@ package net.medievalrp.spyglass.proxy.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -52,5 +53,77 @@ class ProxyQueryStringParserTest {
         QueryRequest request = parser.parse("p:Alice t:1h", false);
 
         assertThat(request.predicates()).isNotEmpty();
+    }
+
+    // ---- before: upper time bound ----
+
+    /**
+     * {@code before:6h} emits a Range with null lower and non-null upper.
+     * Because before: does NOT set sawTime, the default lower floor is also
+     * added, so the result has two predicates total.
+     */
+    @Test
+    void beforeAloneEmitsUpperOnlyRangeAndPreservesDefaultLower() throws Exception {
+        ProxyQueryStringParser parser = parser(ip -> List.of());
+
+        Instant testStart = Instant.now();
+        QueryRequest request = parser.parse("before:6h", false);
+
+        // Default lower + explicit upper = two Range predicates
+        assertThat(request.predicates()).hasSize(2);
+
+        // The before: predicate: null lower, non-null upper
+        QueryPredicate.Range upperRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.upperInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected Range with non-null upper from before:"));
+        assertThat(upperRange.field()).isEqualTo("occurred");
+        assertThat(upperRange.lowerInclusive()).isNull();
+        Instant upper = (Instant) upperRange.upperInclusive();
+        assertThat(upper).isBefore(testStart);
+
+        // The injected default lower: non-null lower, null upper
+        QueryPredicate.Range lowerRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.lowerInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected default Range with non-null lower"));
+        assertThat(lowerRange.upperInclusive()).isNull();
+    }
+
+    /**
+     * {@code t:12h before:6h} - bounded window. The two ranges must together
+     * express lower (12h ago) before upper (6h ago).
+     */
+    @Test
+    void tAndBeforeTogetherProduceBoundedWindow() throws Exception {
+        ProxyQueryStringParser parser = parser(ip -> List.of());
+
+        Instant testStart = Instant.now();
+        QueryRequest request = parser.parse("t:12h before:6h", false);
+
+        // Exactly two predicates: t: lower + before: upper (sawTime=true, no default added)
+        assertThat(request.predicates()).hasSize(2);
+
+        QueryPredicate.Range lowerRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.lowerInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected Range with non-null lower from t:"));
+
+        QueryPredicate.Range upperRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.upperInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected Range with non-null upper from before:"));
+
+        Instant lower = (Instant) lowerRange.lowerInclusive();
+        Instant upper = (Instant) upperRange.upperInclusive();
+
+        // lower (12h ago) must be before upper (6h ago)
+        assertThat(lower).isBefore(upper);
+        assertThat(lower).isBefore(testStart);
+        assertThat(upper).isBefore(testStart);
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -32,6 +32,7 @@ import net.medievalrp.spyglass.plugin.command.param.RadiusParam;
 import net.medievalrp.spyglass.plugin.command.param.RecipientParam;
 import net.medievalrp.spyglass.plugin.command.param.ServerParam;
 import net.medievalrp.spyglass.plugin.command.param.TargetParam;
+import net.medievalrp.spyglass.plugin.command.param.BeforeParam;
 import net.medievalrp.spyglass.plugin.command.param.TimeParam;
 import net.medievalrp.spyglass.plugin.command.param.WorldParam;
 import net.medievalrp.spyglass.plugin.command.render.ResultRenderer;
@@ -388,6 +389,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         apiImpl.registerQueryParamHandler(new EventParam(enabledEvents));
         apiImpl.registerQueryParamHandler(new RadiusParam());
         apiImpl.registerQueryParamHandler(new TimeParam());
+        apiImpl.registerQueryParamHandler(new BeforeParam());
         apiImpl.registerQueryParamHandler(new BlockParam());
         apiImpl.registerQueryParamHandler(new EntityParam());
         apiImpl.registerQueryParamHandler(new WorldParam());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BeforeParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BeforeParam.java
@@ -1,0 +1,51 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import java.time.Instant;
+import java.util.List;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.Duration;
+import org.bukkit.command.CommandSender;
+
+/**
+ * {@code before:<duration>} - upper time bound on {@code occurred}.
+ *
+ * <p>Emits {@code Range("occurred", null, upper)} where {@code upper}
+ * is {@code now minus duration}. Use with {@code t:}/{@code since:} to
+ * express a historical window: {@code t:12h before:6h} = events between
+ * 12h and 6h ago.
+ *
+ * <p>This param intentionally does NOT set the parser's {@code sawTime}
+ * flag. {@code sawTime} suppresses the default lower-bound; {@code before:}
+ * is an upper bound, so leaving the flag alone means {@code before:6h}
+ * alone still gets the default floor applied (default-time .. 6h ago),
+ * which is the correct bounded window.
+ */
+public final class BeforeParam implements QueryParamHandler {
+
+    @Override
+    public List<String> aliases() {
+        return List.of("before");
+    }
+
+    @Override
+    public QueryPredicate parse(String alias, String value, ParamContext context) throws ParamParseException {
+        Duration duration;
+        try {
+            duration = Duration.parse(value);
+        } catch (IllegalArgumentException | ArithmeticException ex) {
+            throw new ParamParseException("Invalid duration: " + value, ex);
+        }
+        Instant upper = duration.before(Instant.now());
+        return new QueryPredicate.Range("occurred", null, upper);
+    }
+
+    @Override
+    public List<String> suggestions(CommandSender sender, String input) {
+        if (input.isEmpty()) {
+            return List.of("10m", "1h", "6h", "1d", "3d", "1w");
+        }
+        return List.of();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/BeforeParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/BeforeParamTest.java
@@ -1,0 +1,120 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link BeforeParam} unit tests. Mirrors {@link TimeParamTest} style.
+ * Wall-clock tests bracket with +/-2s tolerance (no clock seam needed).
+ *
+ * <p>Key invariants:
+ * <ul>
+ *   <li>Emits {@code Range("occurred", null, non-null)} - upper bound only</li>
+ *   <li>Does NOT set sawTime (verified indirectly: lowerInclusive is null)</li>
+ *   <li>Does not suppress default radius</li>
+ * </ul>
+ */
+class BeforeParamTest {
+
+    @Test
+    void sixHourBeforeProducesUpperOnlyRange() throws Exception {
+        Instant before = Instant.now();
+        QueryPredicate predicate = new BeforeParam().parse("before", "6h", ctx());
+        Instant after = Instant.now();
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.Range.class);
+        QueryPredicate.Range range = (QueryPredicate.Range) predicate;
+        assertThat(range.field()).isEqualTo("occurred");
+
+        // Lower bound must be null - before: is an upper bound only
+        assertThat(range.lowerInclusive()).isNull();
+
+        // Upper bound is now-minus-6h
+        Instant upper = (Instant) range.upperInclusive();
+        assertThat(upper).isBetween(
+                before.minusSeconds(3600 * 6 + 2),
+                after.minusSeconds(3600 * 6 - 2));
+    }
+
+    @Test
+    void tenMinuteBeforeProducesUpperBound() throws Exception {
+        assertUpperBoundAtRoughly("10m", 600);
+    }
+
+    @Test
+    void oneDayBeforeProducesUpperBound() throws Exception {
+        assertUpperBoundAtRoughly("1d", 86_400);
+    }
+
+    @Test
+    void oneWeekBeforeProducesUpperBound() throws Exception {
+        assertUpperBoundAtRoughly("1w", 7 * 86_400);
+    }
+
+    @Test
+    void compositeDurationAddsSegments() throws Exception {
+        // 1d12h = 86400 + 43200 = 129600
+        assertUpperBoundAtRoughly("1d12h", 129_600);
+    }
+
+    @Test
+    void invalidDurationRejected() {
+        assertThatThrownBy(() -> new BeforeParam().parse("before", "huge", ctx()))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Invalid duration");
+        assertThatThrownBy(() -> new BeforeParam().parse("before", "", ctx()))
+                .isInstanceOf(ParamParseException.class);
+        assertThatThrownBy(() -> new BeforeParam().parse("before", "10x", ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void overflowingDurationRejected() {
+        assertThatThrownBy(() -> new BeforeParam().parse("before", "99999999999999w", ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void doesNotSuppressDefaultRadius() {
+        assertThat(new BeforeParam().suppressesDefaultRadius("before")).isFalse();
+    }
+
+    @Test
+    void aliasIsBeforeOnly() {
+        assertThat(new BeforeParam().aliases()).containsExactly("before");
+    }
+
+    @Test
+    void suggestionsReturnTimeHintsWhenInputEmpty() {
+        assertThat(new BeforeParam().suggestions(null, "")).isNotEmpty();
+    }
+
+    @Test
+    void suggestionsReturnEmptyWhenInputNonEmpty() {
+        assertThat(new BeforeParam().suggestions(null, "6")).isEmpty();
+    }
+
+    private static void assertUpperBoundAtRoughly(String input, long expectedSeconds) throws Exception {
+        Instant before = Instant.now();
+        QueryPredicate predicate = new BeforeParam().parse("before", input, ctx());
+        Instant after = Instant.now();
+
+        QueryPredicate.Range range = (QueryPredicate.Range) predicate;
+        assertThat(range.lowerInclusive()).isNull();
+
+        Instant upper = (Instant) range.upperInclusive();
+        assertThat(upper).isBetween(
+                before.minusSeconds(expectedSeconds + 2),
+                after.minusSeconds(expectedSeconds - 2));
+    }
+
+    private static ParamContext ctx() {
+        return new ParamContext(null, null, 100);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -12,6 +13,7 @@ import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.param.ParamParseException;
 import net.medievalrp.spyglass.api.query.QueryPredicate;
 import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.util.Duration;
 import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
 import org.junit.jupiter.api.Test;
 
@@ -141,6 +143,89 @@ class QueryStringParserTest {
         assertThat(in.field()).isEqualTo("source.playerId");
         assertThat(in.values()).hasSize(1);
         assertThat(in.values().iterator().next()).isEqualTo(resolved);
+    }
+
+    // ---- before: upper time bound ----
+
+    /**
+     * {@code t:12h before:6h} - the two params AND together into a bounded
+     * window: lower from t: (12h ago) and upper from before: (6h ago).
+     * Both bounds must be non-null and lower must be earlier than upper.
+     */
+    @Test
+    void tAndBeforeTogetherProduceBoundedWindow() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.queryParam("t")).thenReturn(Optional.of(new TimeParam()));
+        when(api.queryParam("before")).thenReturn(Optional.of(new BeforeParam()));
+
+        Instant testStart = Instant.now();
+        QueryRequest request = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "t:12h before:6h", 0);
+
+        // Two explicit predicates (t: and before:); defaults disabled so nothing extra
+        assertThat(request.predicates()).hasSize(2);
+
+        QueryPredicate.Range lowerRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.lowerInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected a Range with non-null lower"));
+
+        QueryPredicate.Range upperRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.upperInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected a Range with non-null upper"));
+
+        Instant lower = (Instant) lowerRange.lowerInclusive();
+        Instant upper = (Instant) upperRange.upperInclusive();
+
+        assertThat(lower).isNotNull();
+        assertThat(upper).isNotNull();
+        // lower (12h ago) must be before upper (6h ago)
+        assertThat(lower).isBefore(upper);
+        // sanity: both are in the past
+        assertThat(lower).isBefore(testStart);
+        assertThat(upper).isBefore(testStart);
+    }
+
+    /**
+     * {@code before:6h} alone - sawTime must NOT be set by BeforeParam, so
+     * the default lower floor is applied by the parser (defaults.enabled=true).
+     * The result must have a non-null lower bound (the default) in addition
+     * to the non-null upper bound from before:.
+     */
+    @Test
+    void beforeAloneStillGetsDefaultLowerBound() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.queryParam("before")).thenReturn(Optional.of(new BeforeParam()));
+
+        // Defaults enabled with a 4h time floor
+        SpyglassConfig config = mock(SpyglassConfig.class);
+        when(config.defaults()).thenReturn(new SpyglassConfig.Defaults(true, 0, Duration.parse("4h")));
+        when(config.limits()).thenReturn(new SpyglassConfig.Limits(100, 50, 0, 0, null, 0));
+
+        QueryRequest request = new QueryStringParser(api, config)
+                .parse(null, "before:6h", 0);
+
+        // Two predicates: the explicit before: upper range + the injected default lower range
+        assertThat(request.predicates()).hasSize(2);
+
+        // The explicit before: predicate has null lower, non-null upper
+        QueryPredicate.Range beforeRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.upperInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected Range with non-null upper from before:"));
+        assertThat(beforeRange.lowerInclusive()).isNull();
+
+        // The injected default has non-null lower, null upper
+        QueryPredicate.Range defaultRange = request.predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && r.lowerInclusive() != null)
+                .map(p -> (QueryPredicate.Range) p)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected default Range with non-null lower"));
+        assertThat(defaultRange.upperInclusive()).isNull();
     }
 
     /**


### PR DESCRIPTION
Closes #157.

## Summary
Adds `before:<duration>`, an **upper** bound on `occurred`, complementing `t:`/`since:` (lower bound). Together they express a historical window: `t:12h before:6h` = events 12h..6h ago.

## Implementation
- New `BeforeParam` (alias `before`) emits `Range("occurred", null, now-duration)` (upper only), mirroring `TimeParam`. Registered next to `TimeParam` in `SpyglassPlugin`.
- Critically does **not** set the parser `sawTime` flag (it is not a `TimeParam`), so `before:` alone keeps the default lower floor -> stays a bounded window.
- Velocity parity: `ProxyQueryStringParser` handles `before`.
- Backend support is free: `Range("occurred", ...)` already pushes down on all three backends.

## Tests
`BeforeParamTest` (upper-only Range), `QueryStringParserTest` (t:+before: window; before: alone keeps the floor), `ProxyQueryStringParserTest`. Green.

## Verification
`./gradlew check` green; live before:-window search verified (follow-up comment).