### PR TITLE
fix(util): schedule FallingBlockTracker.purgeExpired so cascade cells cannot leak (#128)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -120,6 +120,7 @@ import net.medievalrp.spyglass.plugin.command.service.tool.MongoToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.SqliteToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.ToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.WandInteractListener;
+import net.medievalrp.spyglass.plugin.util.FallingBlockTracker;
 import net.medievalrp.spyglass.plugin.worldedit.WorldEditLifecycleListener;
 import net.medievalrp.spyglass.plugin.worldedit.WorldEditSubscriber;
 import org.bstats.bukkit.Metrics;
@@ -148,6 +149,14 @@ public final class SpyglassPlugin extends JavaPlugin {
      * server otherwise).
      */
     private java.util.concurrent.ExecutorService worldWriteExecutor;
+    /**
+     * Repeating async task that sweeps expired entries out of
+     * {@link net.medievalrp.spyglass.plugin.util.FallingBlockTracker}.
+     * Without this, cascade cells whose falling-block entities never
+     * cleanly land (shatter in water/lava, void, /kill, anti-cheat
+     * despawn) accumulate forever -- #128.
+     */
+    private org.bukkit.scheduler.BukkitTask fallingBlockPurgeTask;
     private UndoStack undoStack;
     private ToolStateStore toolStateStore;
     private SalvageStore salvageStore;
@@ -601,6 +610,17 @@ public final class SpyglassPlugin extends JavaPlugin {
             getLogger().info("Spyglass: bStats metrics enabled (opt out with metrics.enabled=false).");
         }
 
+        // #128: sweep expired FallingBlockTracker cells on a repeating async task.
+        // purgeExpired() only touches a ConcurrentHashMap -- no Bukkit world access --
+        // so running it off the main thread is safe. The period (1200 ticks = 60 s)
+        // is 2x the TTL (30 s), meaning every cohort of cascade cells is guaranteed
+        // at least one full sweep opportunity before a second TTL window elapses.
+        // Delay matches the period so the first pass is not immediately at boot.
+        final long PURGE_PERIOD_TICKS = 1200L; // 60 s at 20 TPS
+        this.fallingBlockPurgeTask = getServer().getScheduler()
+                .runTaskTimerAsynchronously(this, FallingBlockTracker::purgeExpired,
+                        PURGE_PERIOD_TICKS, PURGE_PERIOD_TICKS);
+
         getLogger().info("Spyglass enabled; events=" + enabledEvents);
     }
 
@@ -621,6 +641,12 @@ public final class SpyglassPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        // Cancel the FallingBlockTracker purge task before touching any other
+        // state so it cannot fire concurrently with teardown.
+        if (fallingBlockPurgeTask != null) {
+            fallingBlockPurgeTask.cancel();
+            fallingBlockPurgeTask = null;
+        }
         // Stop the bStats submit scheduler first so it can't fire mid-teardown.
         if (metrics != null) {
             metrics.shutdown();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockTracker.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockTracker.java
@@ -59,6 +59,17 @@ public final class FallingBlockTracker {
     }
 
     /**
+     * Package-private overload for tests: inserts a cell with an
+     * explicit {@code expiresAt} epoch-millis value so tests can
+     * simulate already-expired entries without sleeping.
+     */
+    static void track(UUID worldId, int x, int y, int z,
+                      UUID playerId, String playerName, long expiresAt) {
+        CELLS.put(new Key(worldId, x, y, z),
+                new Cell(playerId, playerName, expiresAt));
+    }
+
+    /**
      * Look up and remove the tracker entry for {@code (worldId, x, y,
      * z)}. Returns empty if not tracked, expired, or already consumed
      * — duplicate landings of the same origin (e.g. block lands, gets

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockTrackerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockTrackerTest.java
@@ -1,0 +1,144 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FallingBlockTracker#purgeExpired()} -- #128.
+ *
+ * <p>CELLS is static, so each test clears it in {@link #reset()} to prevent
+ * bleed between test methods. Expired entries are injected via the
+ * package-private {@code track(..., expiresAt)} overload so tests never have
+ * to sleep or manipulate wall-clock time.
+ */
+class FallingBlockTrackerTest {
+
+    private static final UUID WORLD = UUID.randomUUID();
+    private static final UUID PLAYER = UUID.randomUUID();
+
+    @BeforeEach
+    void reset() {
+        FallingBlockTracker.clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // purgeExpired() -- core contract
+    // -----------------------------------------------------------------------
+
+    @Test
+    void purgeExpired_removesOnlyExpiredEntries() {
+        long now = System.currentTimeMillis();
+        long alreadyExpired = now - 1L;   // expired 1 ms ago
+        long stillFresh = now + 30_000L;  // expires in 30 s
+
+        // Insert two expired cells and two fresh cells.
+        FallingBlockTracker.track(WORLD, 0, 64, 0, PLAYER, "Alice", alreadyExpired);
+        FallingBlockTracker.track(WORLD, 1, 64, 0, PLAYER, "Alice", alreadyExpired);
+        FallingBlockTracker.track(WORLD, 2, 64, 0, PLAYER, "Bob", stillFresh);
+        FallingBlockTracker.track(WORLD, 3, 64, 0, PLAYER, "Bob", stillFresh);
+
+        assertThat(FallingBlockTracker.size()).isEqualTo(4);
+
+        FallingBlockTracker.purgeExpired();
+
+        assertThat(FallingBlockTracker.size())
+                .as("only the two expired entries should be removed")
+                .isEqualTo(2);
+
+        // Fresh entries must still be consumable.
+        assertThat(FallingBlockTracker.consume(WORLD, 2, 64, 0)).isPresent();
+        assertThat(FallingBlockTracker.consume(WORLD, 3, 64, 0)).isPresent();
+    }
+
+    @Test
+    void purgeExpired_removesAllEntriesWhenAllExpired() {
+        long expired = System.currentTimeMillis() - 1L;
+
+        FallingBlockTracker.track(WORLD, 10, 10, 10, PLAYER, "Alice", expired);
+        FallingBlockTracker.track(WORLD, 20, 20, 20, PLAYER, "Bob", expired);
+
+        FallingBlockTracker.purgeExpired();
+
+        assertThat(FallingBlockTracker.size()).isZero();
+    }
+
+    @Test
+    void purgeExpired_doesNotRemoveFreshEntries() {
+        long fresh = System.currentTimeMillis() + 30_000L;
+
+        FallingBlockTracker.track(WORLD, 5, 5, 5, PLAYER, "Charlie", fresh);
+
+        FallingBlockTracker.purgeExpired();
+
+        assertThat(FallingBlockTracker.size()).isEqualTo(1);
+        assertThat(FallingBlockTracker.consume(WORLD, 5, 5, 5)).isPresent();
+    }
+
+    @Test
+    void purgeExpired_isIdempotentOnEmptyMap() {
+        // Must not throw when there is nothing to purge.
+        FallingBlockTracker.purgeExpired();
+        FallingBlockTracker.purgeExpired();
+
+        assertThat(FallingBlockTracker.size()).isZero();
+    }
+
+    // -----------------------------------------------------------------------
+    // consume() -- TTL check on read (existing contract, regression guard)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void consume_returnsEmptyForExpiredEntry() {
+        long expired = System.currentTimeMillis() - 1L;
+        FallingBlockTracker.track(WORLD, 0, 0, 0, PLAYER, "Alice", expired);
+
+        assertThat(FallingBlockTracker.consume(WORLD, 0, 0, 0)).isEmpty();
+        // The expired entry must have been removed by consume().
+        assertThat(FallingBlockTracker.size()).isZero();
+    }
+
+    @Test
+    void consume_returnsTrackedForFreshEntry() {
+        // Use the normal (wall-clock) track so this exercises the real path.
+        FallingBlockTracker.track(WORLD, 7, 64, 7, PLAYER, "Dave");
+
+        assertThat(FallingBlockTracker.consume(WORLD, 7, 64, 7))
+                .isPresent()
+                .hasValueSatisfying(t -> {
+                    assertThat(t.playerId()).isEqualTo(PLAYER);
+                    assertThat(t.playerName()).isEqualTo("Dave");
+                });
+    }
+
+    @Test
+    void consume_returnsEmptyForUnknownKey() {
+        assertThat(FallingBlockTracker.consume(WORLD, 99, 0, 99)).isEmpty();
+    }
+
+    @Test
+    void consume_isOneShot() {
+        FallingBlockTracker.track(WORLD, 1, 1, 1, PLAYER, "Eve");
+
+        assertThat(FallingBlockTracker.consume(WORLD, 1, 1, 1)).isPresent();
+        // Second consume of the same key must return empty.
+        assertThat(FallingBlockTracker.consume(WORLD, 1, 1, 1)).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Interaction: purge before consume
+    // -----------------------------------------------------------------------
+
+    @Test
+    void purgeExpired_thenConsumeReturnsEmpty() {
+        long expired = System.currentTimeMillis() - 1L;
+        FallingBlockTracker.track(WORLD, 0, 64, 0, PLAYER, "Fiona", expired);
+
+        FallingBlockTracker.purgeExpired();
+
+        // Entry was purged; consume must not find it.
+        assertThat(FallingBlockTracker.consume(WORLD, 0, 64, 0)).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #128.

## Problem
`FallingBlockTracker.CELLS` is populated by the gravity-cascade path and drained only by `consume()` on a clean landing. `purgeExpired()` existed but was **never called** (the TTL only bounds attribution staleness, not memory). Any cascade cell whose falling block never cleanly lands at its origin (shatters in water/lava, falls into the void, killed by /kill or anti-cheat, despawns) leaks forever - constant during WorldEdit terrain work -> unbounded heap growth.

## Fix
Schedule `purgeExpired()` on a repeating **async** task (1200 ticks = 60s, 2x the 30s TTL), cancelled on disable. `purgeExpired()` only mutates a `ConcurrentHashMap` (no Bukkit access), so off-main is safe.

## Tests
`FallingBlockTrackerTest` (8): purge removes expired, keeps fresh; package-private `track(..., expiresAt)` seam for deterministic expiry. Green (incl. `:spyglass:check` jacoco).

## Verification
`./gradlew check` green; the integration build boots clean (the scheduled task registers without error).