### PR TITLE
fix(salvage): track in-flight removals so /sg inventory take cannot dupe across a Back re-read (#132)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/InFlightTracker.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/InFlightTracker.java
@@ -1,0 +1,62 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks salvage-item removals that have been dispatched to the async store
+ * write but whose acknowledgement has not yet arrived. Prevents a dupe exploit
+ * where a player takes an item, presses Back (which re-reads the DB before the
+ * write lands), and takes the same item a second time.
+ *
+ * <p>Identity key: {@code snapshotId + "|" + containerSlot}. The container
+ * slot ({@link net.medievalrp.spyglass.api.event.StoredItem#slot()}) is the
+ * original physical chest slot and is stable across re-reads from the DB.
+ *
+ * <p>Thread-safety: all methods are safe to call from both the Bukkit main
+ * thread (GUI click handler) and the async store executor (write continuation).
+ */
+final class InFlightTracker {
+
+    private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Mark a slot as in-flight. Call on the main thread before dispatching the
+     * async write. Returns {@code true} if the slot was not already in-flight
+     * (i.e. the mark was accepted). Returns {@code false} if the slot is
+     * already tracked - the caller should refuse the take to prevent duplication.
+     */
+    boolean markInFlight(UUID snapshotId, int containerSlot) {
+        return inFlight.add(key(snapshotId, containerSlot));
+    }
+
+    /**
+     * Clear the in-flight mark for a slot. Call from the async write continuation
+     * once the store write has succeeded or definitively failed.
+     */
+    void clear(UUID snapshotId, int containerSlot) {
+        inFlight.remove(key(snapshotId, containerSlot));
+    }
+
+    /**
+     * Returns {@code true} if the slot is currently in-flight (write dispatched,
+     * not yet acknowledged).
+     */
+    boolean isInFlight(UUID snapshotId, int containerSlot) {
+        return inFlight.contains(key(snapshotId, containerSlot));
+    }
+
+    /**
+     * Remove all in-flight marks for the given snapshot. Call when a snapshot is
+     * fully deleted so stale marks do not accumulate.
+     */
+    void clearAll(UUID snapshotId) {
+        String prefix = snapshotId.toString() + "|";
+        inFlight.removeIf(k -> k.startsWith(prefix));
+    }
+
+    private static String key(UUID snapshotId, int containerSlot) {
+        return snapshotId.toString() + "|" + containerSlot;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageGui.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageGui.java
@@ -30,6 +30,11 @@ import org.bukkit.inventory.meta.ItemMeta;
  * the top 45 slots are content. Every click is cancelled and item movement is
  * performed manually for takes only, which blocks shift-insert, number-key
  * swaps, drags, double-click collect, and hopper pulls.
+ *
+ * <p>Dupe prevention: {@link #inFlight} tracks slots whose async store write
+ * has been dispatched but not yet acknowledged. A slot in that set is treated
+ * as already-taken in any re-read from the DB (the Back navigation path), and
+ * a second take() on the same slot is refused outright.
  */
 public final class SalvageGui implements Listener {
 
@@ -49,6 +54,8 @@ public final class SalvageGui implements Listener {
     private final SalvageWithdrawLogger withdrawLogger;
     private final int rollbackListLimit;
     private final Logger logger;
+    /** Tracks slots whose async store write is in progress but not yet acknowledged. */
+    final InFlightTracker inFlight = new InFlightTracker();
 
     /**
      * @param storeExecutor async pool for blocking store reads/writes (never the main thread)
@@ -112,20 +119,31 @@ public final class SalvageGui implements Listener {
         if (!player.isOnline()) {
             return;
         }
-        if (snaps.isEmpty()) {
+        // Filter in-flight slots from each re-read snapshot so a stale DB result
+        // cannot surface an already-taken item during the async-write window.
+        List<SalvageSnapshot> visible = new ArrayList<>(snaps.size());
+        for (SalvageSnapshot snap : snaps) {
+            List<StoredItem> visibleItems = snap.items().stream()
+                    .filter(item -> !inFlight.isInFlight(snap.id(), item.slot()))
+                    .toList();
+            if (!visibleItems.isEmpty()) {
+                visible.add(snap.withItems(visibleItems));
+            }
+        }
+        if (visible.isEmpty()) {
             openRollbacks(player, 0); // this rollback was fully recovered
             return;
         }
-        int pages = pageCount(snaps.size());
+        int pages = pageCount(visible.size());
         page = clamp(page, pages);
-        SalvageHolder holder = SalvageHolder.chests(rollbackId, snaps, page);
+        SalvageHolder holder = SalvageHolder.chests(rollbackId, visible, page);
         Inventory inv = Bukkit.createInventory(holder, SIZE,
-                Component.text(snaps.size() + " container(s) — by " + snaps.get(0).operatorName(),
+                Component.text(visible.size() + " container(s) - by " + visible.get(0).operatorName(),
                         NamedTextColor.GOLD));
         holder.setInventory(inv);
         int base = page * CONTENT;
-        for (int s = 0; s < CONTENT && base + s < snaps.size(); s++) {
-            inv.setItem(s, chestIcon(snaps.get(base + s)));
+        for (int s = 0; s < CONTENT && base + s < visible.size(); s++) {
+            inv.setItem(s, chestIcon(visible.get(base + s)));
         }
         navBar(inv, true, page, pages);
         player.openInventory(inv);
@@ -151,7 +169,13 @@ public final class SalvageGui implements Listener {
     }
 
     private void openItems(Player player, UUID rollbackId, SalvageSnapshot snap, int page) {
-        List<StoredItem> items = snap.items();
+        // Filter in-flight slots before rendering - defense-in-depth for the case
+        // where the caller passes a stale snap from a DB re-read.
+        UUID snapId = snap.id();
+        List<StoredItem> items = snap.items().stream()
+                .filter(item -> !inFlight.isInFlight(snapId, item.slot()))
+                .toList();
+        snap = snap.withItems(items);
         int pages = pageCount(Math.max(1, items.size()));
         page = clamp(page, pages);
         SalvageHolder holder = SalvageHolder.items(rollbackId, snap, page);
@@ -241,14 +265,28 @@ public final class SalvageGui implements Listener {
         if (index < 0 || index >= items.size()) {
             return;
         }
-        ItemStack stack = ItemSerialization.decode(items.get(index).data());
+        StoredItem storedItem = items.get(index);
+        int containerSlot = storedItem.slot();
+
+        // Defense-in-depth: refuse a take on a slot whose write is still in-flight.
+        // The primary protection is showChests/openItems filtering, but this blocks
+        // a race where two rapid clicks arrive before the first completes.
+        if (!inFlight.markInFlight(snap.id(), containerSlot)) {
+            logger.fine("Spyglass salvage take refused: slot " + containerSlot
+                    + " of snapshot " + snap.id() + " is already in-flight");
+            return;
+        }
+
+        ItemStack stack = ItemSerialization.decode(storedItem.data());
         if (stack == null || stack.getType() == Material.AIR) {
+            inFlight.clear(snap.id(), containerSlot);
             return;
         }
         Map<Integer, ItemStack> overflow = player.getInventory().addItem(stack.clone());
         ItemStack remaining = overflow.isEmpty() ? null : overflow.values().iterator().next();
         int taken = stack.getAmount() - (remaining == null ? 0 : remaining.getAmount());
         if (taken <= 0) {
+            inFlight.clear(snap.id(), containerSlot);
             player.sendMessage(Component.text("Your inventory is full.", NamedTextColor.RED));
             return;
         }
@@ -267,18 +305,22 @@ public final class SalvageGui implements Listener {
         if (remaining == null) {
             updated.remove(index);
         } else {
-            updated.set(index, ItemSerialization.storedItem(items.get(index).slot(), remaining));
+            updated.set(index, ItemSerialization.storedItem(containerSlot, remaining));
         }
         UUID id = snap.id();
         storeExecutor.execute(() -> {
             try {
                 if (updated.isEmpty()) {
                     store.delete(id);
+                    inFlight.clearAll(id);
                 } else {
                     store.replaceItems(id, updated);
+                    inFlight.clear(id, containerSlot);
                 }
             } catch (RuntimeException ex) {
                 logger.warning("Spyglass salvage persist failed: " + ex.getMessage());
+                // Clear on failure too so the slot does not stay locked forever.
+                inFlight.clear(id, containerSlot);
             }
         });
         if (updated.isEmpty()) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/InFlightTrackerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/InFlightTrackerTest.java
@@ -1,0 +1,207 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link InFlightTracker} and the dupe-prevention logic it
+ * enables in {@link SalvageGui}.
+ *
+ * <p>The GUI itself cannot be tested headlessly because it calls into Bukkit
+ * (inventory creation, player.openInventory). We isolate the de-dupe logic in
+ * {@link InFlightTracker} and test that directly, plus the filtering helpers
+ * that {@code showChests} / {@code openItems} apply against a list of
+ * {@link SalvageSnapshot}s to verify that the in-flight set correctly suppresses
+ * stale DB items.
+ */
+class InFlightTrackerTest {
+
+    // ---- InFlightTracker unit tests ------------------------------------
+
+    @Test
+    void markInFlightReturnsTrueFirstTime() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        assertThat(tracker.markInFlight(snapId, 5)).isTrue();
+    }
+
+    @Test
+    void markInFlightReturnsFalseWhenAlreadyTracked() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        tracker.markInFlight(snapId, 5);
+        // Second call on the same key must be refused - this is the dupe gate.
+        assertThat(tracker.markInFlight(snapId, 5)).isFalse();
+    }
+
+    @Test
+    void differentSlotsAreIndependent() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        tracker.markInFlight(snapId, 5);
+        // A different container slot on the same snapshot is a distinct key.
+        assertThat(tracker.markInFlight(snapId, 6)).isTrue();
+    }
+
+    @Test
+    void differentSnapshotsAreIndependent() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapA = UUID.randomUUID();
+        UUID snapB = UUID.randomUUID();
+
+        tracker.markInFlight(snapA, 5);
+        // Same slot number on a different snapshot is a distinct key.
+        assertThat(tracker.markInFlight(snapB, 5)).isTrue();
+    }
+
+    @Test
+    void clearAllowsRetake() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        tracker.markInFlight(snapId, 5);
+        tracker.clear(snapId, 5);
+
+        // After the async write acked, the slot is available again.
+        assertThat(tracker.isInFlight(snapId, 5)).isFalse();
+        assertThat(tracker.markInFlight(snapId, 5)).isTrue();
+    }
+
+    @Test
+    void clearAllRemovesEverySlotOfSnapshot() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        tracker.markInFlight(snapId, 0);
+        tracker.markInFlight(snapId, 1);
+        tracker.markInFlight(snapId, 27);
+
+        tracker.clearAll(snapId);
+
+        assertThat(tracker.isInFlight(snapId, 0)).isFalse();
+        assertThat(tracker.isInFlight(snapId, 1)).isFalse();
+        assertThat(tracker.isInFlight(snapId, 27)).isFalse();
+    }
+
+    @Test
+    void clearAllDoesNotAffectOtherSnapshots() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapA = UUID.randomUUID();
+        UUID snapB = UUID.randomUUID();
+
+        tracker.markInFlight(snapA, 3);
+        tracker.markInFlight(snapB, 3);
+
+        tracker.clearAll(snapA);
+
+        // snapB's slot must still be tracked.
+        assertThat(tracker.isInFlight(snapA, 3)).isFalse();
+        assertThat(tracker.isInFlight(snapB, 3)).isTrue();
+    }
+
+    // ---- Snapshot-filtering logic (mirrors showChests / openItems) ------
+
+    /**
+     * Simulate the filter that {@code showChests} applies to a DB re-read list:
+     * items whose containerSlot is in-flight are stripped; snapshots that become
+     * empty are excluded entirely. This is the core dupe-prevention path.
+     */
+    @Test
+    void inFlightSlotsAreFilteredFromReReadSnapshots() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+        StoredItem takenItem = new StoredItem(5, "DIAMOND", "data");
+        StoredItem otherItem = new StoredItem(10, "EMERALD", "data2");
+
+        SalvageSnapshot snap = snap(snapId, List.of(takenItem, otherItem));
+
+        // Mark slot 5 (the diamond) as in-flight.
+        tracker.markInFlight(snapId, 5);
+
+        // Apply the same filter showChests uses.
+        List<SalvageSnapshot> visible = applyChestFilter(tracker, List.of(snap));
+
+        assertThat(visible).hasSize(1);
+        assertThat(visible.get(0).items()).hasSize(1);
+        assertThat(visible.get(0).items().get(0).slot()).isEqualTo(10); // only the emerald
+    }
+
+    @Test
+    void snapshotWithAllSlotsInFlightIsExcludedFromChestList() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+        StoredItem onlyItem = new StoredItem(0, "DIAMOND", "data");
+
+        SalvageSnapshot snap = snap(snapId, List.of(onlyItem));
+        tracker.markInFlight(snapId, 0);
+
+        List<SalvageSnapshot> visible = applyChestFilter(tracker, List.of(snap));
+
+        // Snapshot fully in-flight - acts as if the rollback was fully recovered.
+        assertThat(visible).isEmpty();
+    }
+
+    @Test
+    void afterAckClearSnapshotAppearsAgainInReRead() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+        StoredItem item = new StoredItem(7, "GOLD_INGOT", "data");
+
+        SalvageSnapshot snap = snap(snapId, List.of(item));
+        tracker.markInFlight(snapId, 7);
+
+        // Before ack: filtered out.
+        assertThat(applyChestFilter(tracker, List.of(snap))).isEmpty();
+
+        // After ack: visible again (the store write landed, DB now reflects the removal).
+        tracker.clear(snapId, 7);
+        assertThat(applyChestFilter(tracker, List.of(snap))).hasSize(1);
+    }
+
+    @Test
+    void takeRefusedWhenSlotAlreadyInFlight() {
+        InFlightTracker tracker = new InFlightTracker();
+        UUID snapId = UUID.randomUUID();
+
+        // First take marks the slot.
+        assertThat(tracker.markInFlight(snapId, 3)).isTrue();
+
+        // Immediate second attempt (e.g. double-click) is refused.
+        assertThat(tracker.markInFlight(snapId, 3)).isFalse();
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    private static SalvageSnapshot snap(UUID id, List<StoredItem> items) {
+        return new SalvageSnapshot(id, UUID.randomUUID(), UUID.randomUUID(),
+                "world", 0, 64, 0, "CHEST", "operator", Instant.EPOCH, items);
+    }
+
+    /**
+     * Applies the same filter that {@code showChests} applies to a DB result:
+     * strips in-flight slots from each snapshot and drops empty snapshots.
+     */
+    private static List<SalvageSnapshot> applyChestFilter(InFlightTracker tracker,
+                                                           List<SalvageSnapshot> snaps) {
+        List<SalvageSnapshot> out = new ArrayList<>(snaps.size());
+        for (SalvageSnapshot snap : snaps) {
+            List<StoredItem> visibleItems = snap.items().stream()
+                    .filter(item -> !tracker.isInFlight(snap.id(), item.slot()))
+                    .toList();
+            if (!visibleItems.isEmpty()) {
+                out.add(snap.withItems(visibleItems));
+            }
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
Closes #132.

## Problem
`SalvageGui.take()` gives the item immediately but persists the removal **asynchronously**. Navigating Back re-reads from the DB (`listByRollback`); during the async-write window the re-read still shows the already-taken item, so a fast/scripted admin (or one under store latency) can take it again -> dupe while the DB records one removal.

## Fix (keeps the write async - does not regress #151)
`InFlightTracker` records `(snapshotId, slot)` removals dispatched but not yet acked. Three guards:
1. `take()` marks in-flight before dispatch and **refuses** a slot already in-flight (double-click guard); clears on async ack (success or failure, with a warning log on failure).
2. `showChests()` filters in-flight slots out of every DB re-read (the Back path) -> the primary protection.
3. `openItems()` filters too (defense-in-depth).

Index alignment verified: `openItems` stores the **filtered** snapshot into the holder, and `take()` reads `holder.snapshot().items()` with the same `page*CONTENT + slot` index, so display and take stay aligned. No main-thread I/O added.

## Tests
`InFlightTrackerTest` (8) + filter logic. Green (incl. `:spyglass:check`).

## Verification
`./gradlew check` green; live take/Back/re-take refusal verified (follow-up comment).