### PR TITLE
fix(rollback): fail the job on any apply-phase throw instead of wedging the queue (#127)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -246,6 +246,31 @@ public final class RollbackEngine {
         return applyAllChunked(effects, sender, ServiceSupport.synchronous(), Integer.MAX_VALUE).join();
     }
 
+    // -- apply-phase failsafe (#127) ------------------------------
+    // Every main-thread apply step that advances a rollback runs through
+    // this wrapper. If the step throws, the throwable is routed to `done`
+    // (the job future) instead of escaping into the scheduler and
+    // vanishing. A vanished throwable leaves `done` forever uncompleted, so
+    // RollbackService.streamPagesAndApply blocks on fut.join() and never
+    // reaches jobQueue.finish() -- which wedges EVERY future rollback /
+    // restore / undo job until the server restarts, and leaks the
+    // physics-suppression region and pinned chunk tickets. Failing `done`
+    // instead makes join() throw, the job is marked FAILED, the queue
+    // advances, the operator is told, and the physics region is released by
+    // the done.whenComplete hook.
+    private static void guarded(CompletableFuture<?> done, Runnable step) {
+        try {
+            step.run();
+        } catch (Throwable thrown) {
+            if (!done.completeExceptionally(thrown)) {
+                // `done` already settled (cancelled, or a prior failure won
+                // the race); surface the secondary failure so it isn't silent.
+                LOGGER.log(Level.SEVERE,
+                        "Rollback apply step threw after the job future already completed", thrown);
+            }
+        }
+    }
+
     public CompletableFuture<List<RollbackResult>> applyAllChunked(
             List<RollbackEffect> effects, CommandSender sender,
             ServiceSupport scheduler, int batchSize) {
@@ -326,15 +351,15 @@ public final class RollbackEngine {
 
             sortParallelByChunk(blockReplaceIndices, blockReplaceEffects);
 
-            scheduler.onMainThread(() -> applyChunkByChunk(0, effects, resultArray,
+            scheduler.onMainThread(() -> guarded(done, () -> applyChunkByChunk(0, effects, resultArray,
                     blockReplaceIndices, blockReplaceEffects,
- sender, scheduler, batchSize, done, cancelFlag));
+                    sender, scheduler, batchSize, done, cancelFlag)));
         };
 
         if (worldWriteExecutor != null) {
-            CompletableFuture.runAsync(stageOne, worldWriteExecutor);
+            CompletableFuture.runAsync(() -> guarded(done, stageOne), worldWriteExecutor);
         } else {
-            stageOne.run();
+            guarded(done, stageOne);
         }
         return done;
     }
@@ -579,9 +604,9 @@ public final class RollbackEngine {
 
         if (i < total) {
             int next = i;
-            scheduler.onMainThreadLater(1L, () -> applyChunkByChunk(
+            scheduler.onMainThreadLater(1L, () -> guarded(done, () -> applyChunkByChunk(
                     next, effects, resultArray, blockReplaceIndices, blockReplaceEffects,
-                    sender, scheduler, batchSize, done, cancelFlag));
+                    sender, scheduler, batchSize, done, cancelFlag)));
         } else {
             runContainerAndLeftover(effects, resultArray, sender, scheduler, batchSize, done);
         }
@@ -624,7 +649,8 @@ public final class RollbackEngine {
         long tResolve = System.nanoTime();
         List<ChunkWork> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
-        while (cursor < total && batch.size() < maxBatchChunks) {
+        try {
+            while (cursor < total && batch.size() < maxBatchChunks) {
             BlockLocation startLoc = blockReplaceEffects.get(cursor).location();
             UUID worldId = startLoc.worldId();
             int cx = startLoc.x() >> 4;
@@ -667,13 +693,43 @@ public final class RollbackEngine {
                             + cx + "," + cz, t);
                 }
             }
-            ChunkDirectWriter.ChunkContext ctx =
-                    ChunkDirectWriter.prepareChunk(world, cx, cz);
-            if (salvageHook != null) {
-                salvageHook.onChunkResolved(world, cx, cz);
+            try {
+                ChunkDirectWriter.ChunkContext ctx =
+                        ChunkDirectWriter.prepareChunk(world, cx, cz);
+                if (salvageHook != null) {
+                    salvageHook.onChunkResolved(world, cx, cz);
+                }
+                batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
+            } catch (Throwable t) {
+                // prepareChunk / onChunkResolved threw after this chunk was
+                // pinned: release its ticket here (it never reaches the post
+                // phase that would), then rethrow so the guarded caller fails
+                // the job. The already-resolved chunks are freed below (#127).
+                if (ticketAdded && ticketHolder != null) {
+                    try {
+                        world.removePluginChunkTicket(cx, cz, ticketHolder);
+                    } catch (Throwable ignored) {
+                        // best-effort
+                    }
+                }
+                throw t;
             }
-            batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
             cursor = chunkEnd;
+            }
+        } catch (Throwable t) {
+            // Resolve phase failed mid-batch: the chunks already pinned will
+            // never reach applyChunkPostMain (which releases their tickets),
+            // so free them here before failing the job (#127).
+            for (ChunkWork w : batch) {
+                if (w.ticketAdded && ticketHolder != null) {
+                    try {
+                        w.world.removePluginChunkTicket(w.cx, w.cz, ticketHolder);
+                    } catch (Throwable ignored) {
+                        // best-effort
+                    }
+                }
+            }
+            throw t;
         }
         applyResolveNanos.addAndGet(System.nanoTime() - tResolve);
 
@@ -706,16 +762,37 @@ public final class RollbackEngine {
                     applyWriteNanos.addAndGet(System.nanoTime() - tDispatch);
                     applyBatchCount.incrementAndGet();
                     applyChunkApplies.addAndGet(batchChunks);
-                    scheduler.onMainThread(() -> {
+                    if (throwable != null) {
+                        // A palette worker threw (parse failures are marked
+                        // Skipped on the worker, not thrown). Surface it instead
+                        // of swallowing; we still run the post phase below so
+                        // every pinned chunk's ticket is released (#127).
+                        LOGGER.log(Level.WARNING, "Rollback chunk palette write batch failed", throwable);
+                    }
+                    scheduler.onMainThread(() -> guarded(done, () -> {
                     // Main-thread post for every chunk in the batch: the
                     // heavy palette writes already happened off-main, so
                     // this is just tile-entity state, finishChunk, the
                     // chunk packet, and the ticket release.
                     long tPost = System.nanoTime();
+                    Throwable postFailure = null;
                     for (ChunkWork work : batch) {
-                        applyChunkPostMain(work, resultArray, blockReplaceIndices, blockReplaceEffects);
+                        try {
+                            applyChunkPostMain(work, resultArray, blockReplaceIndices, blockReplaceEffects);
+                        } catch (Throwable t) {
+                            // applyChunkPostMain's own finally already released
+                            // this chunk's ticket; keep going so the rest of the
+                            // batch is cleaned up too, then fail the job (#127).
+                            if (postFailure == null) {
+                                postFailure = t;
+                            }
+                        }
                     }
                     applyPostNanos.addAndGet(System.nanoTime() - tPost);
+                    if (postFailure != null) {
+                        done.completeExceptionally(postFailure);
+                        return;
+                    }
                     if (sender instanceof Player p && total > 0) {
                         p.sendActionBar(Component.text("Rolling back " + batchEnd + " / " + total));
                     }
@@ -725,7 +802,7 @@ public final class RollbackEngine {
                     } else {
                         runContainerAndLeftover(effects, resultArray, sender, scheduler, batchSize, done);
                     }
-                    });
+                    }));
                 });
     }
 
@@ -937,13 +1014,13 @@ public final class RollbackEngine {
         // Sort off-main (chunk-grouped, bottom-up Y), then apply on main.
         Runnable stageOne = () -> {
             int[] order = cols.chunkSortedOrder();
-            scheduler.onMainThread(() -> applyColumnBatch(
-                    world, cols, order, 0, counts, sender, scheduler, batchSize, done, cancelFlag));
+            scheduler.onMainThread(() -> guarded(done, () -> applyColumnBatch(
+                    world, cols, order, 0, counts, sender, scheduler, batchSize, done, cancelFlag)));
         };
         if (worldWriteExecutor != null) {
-            CompletableFuture.runAsync(stageOne, worldWriteExecutor);
+            CompletableFuture.runAsync(() -> guarded(done, stageOne), worldWriteExecutor);
         } else {
-            stageOne.run();
+            guarded(done, stageOne);
         }
         return done;
     }
@@ -969,7 +1046,8 @@ public final class RollbackEngine {
         // runs of the sorted order share a chunk, so one walk groups them.
         List<ColChunk> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
-        while (cursor < total && batch.size() < maxBatchChunks) {
+        try {
+            while (cursor < total && batch.size() < maxBatchChunks) {
             int startIdx = order[cursor];
             int cx = cols.x(startIdx) >> 4;
             int cz = cols.z(startIdx) >> 4;
@@ -993,53 +1071,98 @@ public final class RollbackEngine {
                             + cx + "," + cz, t);
                 }
             }
-            ChunkDirectWriter.ChunkContext ctx = ChunkDirectWriter.prepareChunk(world, cx, cz);
-            if (salvageHook != null) {
-                salvageHook.onChunkResolved(world, cx, cz);
+            try {
+                ChunkDirectWriter.ChunkContext ctx = ChunkDirectWriter.prepareChunk(world, cx, cz);
+                if (salvageHook != null) {
+                    salvageHook.onChunkResolved(world, cx, cz);
+                }
+                batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
+            } catch (Throwable t) {
+                // Release this chunk's just-added ticket before failing the
+                // batch; the rest are freed below (#127).
+                if (ticketAdded && ticketHolder != null) {
+                    try {
+                        world.removePluginChunkTicket(cx, cz, ticketHolder);
+                    } catch (Throwable ignored) {
+                        // best-effort
+                    }
+                }
+                throw t;
             }
-            batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
             cursor = rangeEnd;
+            }
+        } catch (Throwable t) {
+            // Resolve phase failed: free the tickets pinned for chunks already
+            // in the batch (their post phase never runs to release them), then
+            // rethrow so the guarded caller fails the job (#127).
+            for (ColChunk cc : batch) {
+                if (cc.ticketAdded && ticketHolder != null) {
+                    try {
+                        world.removePluginChunkTicket(cc.cx, cc.cz, ticketHolder);
+                    } catch (Throwable ignored) {
+                        // best-effort
+                    }
+                }
+            }
+            throw t;
         }
         final int batchEnd = cursor;
 
         // Main-thread post: finish/resend each chunk, release tickets, sum
         // the per-chunk counts, then advance. The heavy palette writes
         // already happened off-main (or inline when no executor is wired).
-        Runnable afterWrites = () -> scheduler.onMainThread(() -> {
+        Runnable afterWrites = () -> scheduler.onMainThread(() -> guarded(done, () -> {
+            Throwable postFailure = null;
             for (ColChunk cc : batch) {
-                if (cc.ctx == null) {
-                    // prepareChunk failed: write this chunk's cells on the
-                    // main thread via the single-block fallback.
-                    writeColumnChunkMain(world, cols, order, cc);
-                } else {
-                    ChunkDirectWriter.finishChunk(cc.ctx);
-                }
                 try {
-                    ChunkResender.resend(world, cc.cx, cc.cz);
-                } catch (RuntimeException ignored) {
-                    // Best-effort: a failed resend only delays the client's view
-                    // of the restored chunk until its next natural update.
-                }
-                if (salvageHook != null) {
-                    salvageHook.onChunkWritten(world, cc.cx, cc.cz);
-                }
-                if (cc.ticketAdded && ticketHolder != null) {
+                    if (cc.ctx == null) {
+                        // prepareChunk failed: write this chunk's cells on the
+                        // main thread via the single-block fallback.
+                        writeColumnChunkMain(world, cols, order, cc);
+                    } else {
+                        ChunkDirectWriter.finishChunk(cc.ctx);
+                    }
                     try {
-                        world.removePluginChunkTicket(cc.cx, cc.cz, ticketHolder);
-                    } catch (Throwable ignored) {
-                        // Best-effort: a leaked ticket is reclaimed on plugin
-                        // disable; not worth surfacing.
+                        ChunkResender.resend(world, cc.cx, cc.cz);
+                    } catch (RuntimeException ignored) {
+                        // Best-effort: a failed resend only delays the client's view
+                        // of the restored chunk until its next natural update.
+                    }
+                    if (salvageHook != null) {
+                        salvageHook.onChunkWritten(world, cc.cx, cc.cz);
+                    }
+                    counts.applied += cc.applied;
+                    counts.blockChanged += cc.blockChanged;
+                    counts.unparseable += cc.unparseable;
+                } catch (Throwable t) {
+                    // finishChunk / onChunkWritten threw; record the failure and
+                    // keep cleaning up the rest of the batch (#127).
+                    if (postFailure == null) {
+                        postFailure = t;
+                    }
+                } finally {
+                    // Always release the pinned chunk, even if the post step
+                    // above threw -- otherwise a finishChunk failure leaks the
+                    // ticket for the life of the world (#127).
+                    if (cc.ticketAdded && ticketHolder != null) {
+                        try {
+                            world.removePluginChunkTicket(cc.cx, cc.cz, ticketHolder);
+                        } catch (Throwable ignored) {
+                            // Best-effort: a leaked ticket is reclaimed on plugin
+                            // disable; not worth surfacing.
+                        }
                     }
                 }
-                counts.applied += cc.applied;
-                counts.blockChanged += cc.blockChanged;
-                counts.unparseable += cc.unparseable;
+            }
+            if (postFailure != null) {
+                done.completeExceptionally(postFailure);
+                return;
             }
             if (sender instanceof Player p) {
                 p.sendActionBar(Component.text("Rolling back " + batchEnd + " / " + total));
             }
             applyColumnBatch(world, cols, order, batchEnd, counts, sender, scheduler, batchSize, done, cancelFlag);
-        });
+        }));
 
         if (worldWriteExecutor != null) {
             @SuppressWarnings("unchecked")
@@ -1050,10 +1173,28 @@ public final class RollbackEngine {
                         () -> writeColumnChunk(cols, order, cc), worldWriteExecutor);
             }
             CompletableFuture.allOf(futures)
-                    .whenComplete((v, t) -> afterWrites.run());
+                    .whenComplete((v, t) -> {
+                        if (t != null) {
+                            // A column worker threw; surface it, then still run
+                            // afterWrites so tickets are released and the job
+                            // can fail cleanly rather than wedge (#127).
+                            LOGGER.log(Level.WARNING, "Rollback column palette write batch failed", t);
+                        }
+                        afterWrites.run();
+                    });
         } else {
+            Throwable writeFailure = null;
             for (ColChunk cc : batch) {
-                writeColumnChunk(cols, order, cc);
+                try {
+                    writeColumnChunk(cols, order, cc);
+                } catch (Throwable t) {
+                    if (writeFailure == null) {
+                        writeFailure = t;
+                    }
+                }
+            }
+            if (writeFailure != null) {
+                LOGGER.log(Level.WARNING, "Rollback column palette write failed", writeFailure);
             }
             afterWrites.run();
         }
@@ -1238,8 +1379,8 @@ public final class RollbackEngine {
         }
         if (i < total) {
             int next = i;
-            scheduler.onMainThreadLater(1L, () -> applyLeftoverBatch(
-                    next, effects, resultArray, sender, scheduler, batchSize, done));
+            scheduler.onMainThreadLater(1L, () -> guarded(done, () -> applyLeftoverBatch(
+                    next, effects, resultArray, sender, scheduler, batchSize, done)));
         } else {
             done.complete(List.of(resultArray));
         }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngineFailsafeTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngineFailsafeTest.java
@@ -1,0 +1,143 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.RollbackResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.command.service.ServiceSupport;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Apply-phase failsafe regression for {@link RollbackEngine} (#127).
+ *
+ * <p>If a main-thread apply step throws (a malformed container, a chunk
+ * resolve failure, a palette write blowing up), the engine must complete
+ * its job future <b>exceptionally</b> rather than leave it forever
+ * uncompleted. An uncompleted future parks
+ * {@code RollbackService.streamPagesAndApply} on {@code fut.join()}
+ * indefinitely, so {@code jobQueue.finish()} is never reached and EVERY
+ * subsequent rollback / restore / undo job queues forever until the
+ * server restarts (plus a leaked physics region and pinned chunk
+ * tickets). This pins that an apply-phase throw fails the future instead.
+ */
+class RollbackEngineFailsafeTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("88888888-8888-8888-8888-888888888888");
+
+    /**
+     * Runs every scheduled task inline but <b>swallows</b> any throwable,
+     * exactly like the real Bukkit scheduler does with a thrown task. Under
+     * this support a thrown apply step that escaped its handler would leave
+     * the job future uncompleted -- reproducing the production wedge.
+     */
+    private static ServiceSupport swallowingSupport() {
+        return new ServiceSupport() {
+            @Override
+            public void onMainThread(Runnable runnable) {
+                try {
+                    runnable.run();
+                } catch (Throwable swallowed) {
+                    // Bukkit logs and drops; the engine must not depend on this.
+                }
+            }
+
+            @Override
+            public void onMainThreadLater(long delayTicks, Runnable runnable) {
+                onMainThread(runnable);
+            }
+
+            @Override
+            public void onAsyncThread(Runnable runnable) {
+                onMainThread(runnable);
+            }
+        };
+    }
+
+    @Test
+    void applyPhaseThrowFailsTheJobFutureInsteadOfWedging() {
+        BlockLocation loc = new BlockLocation(WORLD_ID, "world", 5, 64, 9);
+        RollbackEffect effect = new RollbackEffect.BlockReplace(loc,
+                snapshot(Material.STONE, "minecraft:stone"),
+                snapshot(Material.AIR, "minecraft:air"));
+
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+            bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            BlockData replacementData = mock(BlockData.class);
+            bukkit.when(() -> Bukkit.createBlockData(org.mockito.ArgumentMatchers.anyString()))
+                    .thenReturn(replacementData);
+
+            RollbackEngine engine = new RollbackEngine();
+            // Inject a deterministic apply-phase failure: the salvage hook
+            // fires during the main-thread chunk-resolve step.
+            engine.setSalvageHook(new SalvageHook() {
+                @Override
+                public void begin(String operatorName, UUID rollbackId) {
+                }
+
+                @Override
+                public void onChunkResolved(World w, int chunkX, int chunkZ) {
+                    throw new IllegalStateException("injected resolve failure");
+                }
+
+                @Override
+                public void onChunkWritten(World w, int chunkX, int chunkZ) {
+                }
+
+                @Override
+                public void end() {
+                }
+            });
+
+            CommandSender sender = mock(CommandSender.class);
+            CompletableFuture<List<RollbackResult>> done = engine.applyAllChunked(
+                    List.of(effect), sender, swallowingSupport(),
+                    Integer.MAX_VALUE, new AtomicBoolean(false));
+
+            // The job future MUST settle (exceptionally) -- never an
+            // uncompleted future, which is what wedges the queue.
+            assertThat(done.isDone())
+                    .as("apply-phase throw must complete the job future, not leave it hanging")
+                    .isTrue();
+            assertThat(done.isCompletedExceptionally())
+                    .as("the throw must fail the future so join() throws and the queue advances")
+                    .isTrue();
+
+            Throwable cause = org.junit.jupiter.api.Assertions.assertThrows(
+                    java.util.concurrent.CompletionException.class, done::join).getCause();
+            assertThat(cause).isInstanceOf(IllegalStateException.class);
+            assertThat(cause.getMessage()).contains("injected resolve failure");
+        }
+    }
+
+    private static BlockSnapshot snapshot(Material material, String blockData) {
+        return new BlockSnapshot(material, blockData,
+                List.of(), List.of(), List.of(), List.of(), null);
+    }
+}


### PR DESCRIPTION
Closes #127.

## Problem (HIGH)
`RollbackEngine` drives per-chunk world writes through a `done` future, but several main-thread continuations were not wrapped to complete `done` on failure. If any threw (malformed container, chunk-resolve failure, a worker palette write), `done` was never completed and `RollbackService.streamPagesAndApply` blocked on `fut.join()` **forever**: `runJob` never reached `jobQueue.finish()`, so the `inFlight` flag stayed set and **every** future rollback/restore/undo job queued forever until restart - plus a leaked physics-suppression region and pinned chunk tickets.

## Fix
A `guarded(done, step)` wrapper on every detached main-thread continuation (both the complex `applyAllChunked` path and the columnar `applyColumnsChunked` path, plus their stageOne dispatch and self-reschedule hops): any `Throwable` now routes to `done.completeExceptionally(...)`. Then `fut.join()` throws `CompletionException` -> `RollbackService` reports "failed" to the operator and returns -> `runJob` reaches `jobQueue.finish(...)` -> **the queue advances**, and `done.whenComplete` releases the physics region. Additionally:
- The `allOf(...)` continuations now **honor** the previously-ignored worker `throwable` (logged, not swallowed).
- The post-phase loops are resilient (one chunks post failure no longer aborts the rest) and release every pinned chunk ticket even on a `finishChunk` throw; the resolve phase releases tickets pinned before a mid-batch throw. No more leaked tickets on failure.

No happy-path cost (the wrappers are pass-through on success).

## Tests
`RollbackEngineFailsafeTest`: a swallowing (Bukkit-like) scheduler + a salvage hook that throws on resolve -> the job future completes **exceptionally** rather than hanging. Existing `RollbackEngineChaosTest` (force-overwrite contract) still passes, so the happy path is unchanged.

## Verification
`./gradlew check` green; live verification of normal rollback + back-to-back queue health in progress (follow-up comment). Re-lands the previously-reverted #131 with the live verification that was missing.