### PR TITLE
perf(listener): defer block-path BlockData.getAsString() off the main thread (#154)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -316,13 +316,13 @@ public final class SpyglassPlugin extends JavaPlugin {
         // names each emits; we register with Bukkit only when at least one is
         // enabled in config.
         List<RecordingListener> listeners = List.of(
-                new BlockBreakListener(recorder, support),
+                new BlockBreakListener(recorder, support, deferredSerializer),
                 new MultiBlockBreakListener(recorder, support),
                 new DependantBreakListener(recorder, support),
                 new BlockExplodeListener(recorder, support, this, deferredSerializer),
                 new EntityExplodeListener(recorder, support, deferredSerializer),
                 new BlockBurnListener(recorder, support, this),
-                new BlockPlaceListener(recorder, support),
+                new BlockPlaceListener(recorder, support, deferredSerializer),
                 new BlockMultiPlaceListener(recorder, support),
                 new FallingBlockLandListener(recorder, support),
                 new ContainerTransactionListener(recorder, support, deferredSerializer),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListener.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.plugin.listener.block;
 
 import java.util.Set;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
 import net.medievalrp.spyglass.api.event.RecordContext;
@@ -15,15 +16,38 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Records block-break events. The BlockData string (the "minecraft:stone[...]"
+ * representation) is the dominant per-event main-thread cost (~19% of
+ * Spyglass's tick budget at 5000 ev/s per JFR). We defer it off the server
+ * tick by using the captureRaw / finishCapture split (#154):
+ *
+ * <ul>
+ *   <li>Main thread: call {@link BlockSnapshots#captureRaw} - reads live Bukkit
+ *       state and carries an immutable {@code BlockData} copy. Build the
+ *       {@link RecordContext} (stamps occurred + time-ordered id at event time).
+ *   <li>Serializer thread: call {@link BlockSnapshots#finishCapture} - calls
+ *       {@code getAsString()} on the detached {@code BlockData} and serializes
+ *       any container contents, then hands the finished record to the recorder.
+ * </ul>
+ *
+ * <p>Correctness: {@code BlockBreakRecord} is {@link net.medievalrp.spyglass.api.rollback.Rollbackable}.
+ * The flush barrier ({@link net.medievalrp.spyglass.plugin.pipeline.DeferredSerializer#awaitQuiescence})
+ * is wired as the recorder's pre-flush hook (#98), so a rollback read-your-writes
+ * flush drains this stage before it drains the recorder queue - records broken
+ * in a burst are visible to an immediately-following rollback.
+ */
 @ApiStatus.Internal
 public final class BlockBreakListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor serializer;
 
-    public BlockBreakListener(Recorder recorder, RecordingSupport support) {
+    public BlockBreakListener(Recorder recorder, RecordingSupport support, Executor serializer) {
         this.recorder = recorder;
         this.support = support;
+        this.serializer = serializer;
     }
 
     @Override
@@ -33,11 +57,19 @@ public final class BlockBreakListener implements RecordingListener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        BlockSnapshot original = BlockSnapshots.capture(event.getBlock().getState());
+        // captureRaw carries the immutable BlockData; getAsString() is deferred
+        // to finishCapture on the serializer thread (#154).
+        BlockSnapshots.RawCapture rawOriginal = BlockSnapshots.captureRaw(event.getBlock().getState());
         BlockSnapshot after = BlockSnapshots.air();
         BlockLocation location = BlockLocations.fromBlock(event.getBlock());
+        // Build context (stamps occurred + time-ordered id) on the main thread
+        // so the record reflects event time, not serialization time (#98).
         RecordContext ctx = support.playerContext(event.getPlayer(), location);
-        recorder.record(BlockBreakRecord.of(ctx, "break", original.material().name(), original, after));
+        String target = rawOriginal.type().name();
+        serializer.execute(() -> {
+            BlockSnapshot original = BlockSnapshots.finishCapture(rawOriginal);
+            recorder.record(BlockBreakRecord.of(ctx, "break", target, original, after));
+        });
         // Cascade: if breaking this block knocks out the support of a
         // gravity-affected column above (sand, gravel, anvil, concrete
         // powder, etc.), pre-emptively log the column's breaks tagged

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListener.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.plugin.listener.block;
 
 import java.util.Set;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
 import net.medievalrp.spyglass.api.event.RecordContext;
@@ -10,20 +11,47 @@ import net.medievalrp.spyglass.plugin.listener.RecordingListener;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Records block-place events. Applies the same deferred getAsString() strategy
+ * as {@link BlockBreakListener} (#154): captureRaw on the main thread carries
+ * an immutable BlockData object, finishCapture on the serializer thread calls
+ * getAsString() off-tick.
+ *
+ * <p>A place event captures twice: the replaced state (before) and the placed
+ * state (after). Both getAsString() calls are deferred to the serializer thread.
+ *
+ * <p>Allocation trims vs the old path (#116):
+ * <ul>
+ *   <li>When the replaced state is AIR (placing into empty space - the common
+ *       case), the shared {@link BlockSnapshots#air()} constant is used instead
+ *       of a full captureRaw, skipping the BlockState read, BlockData copy, and
+ *       eventual getAsString() call entirely.</li>
+ *   <li>{@link BlockLocations#fromBlock} replaces the old
+ *       {@code fromLocation(block.getLocation())} which allocated a throwaway
+ *       {@code Location} object.</li>
+ * </ul>
+ *
+ * <p>Correctness: {@link BlockPlaceRecord} is {@link net.medievalrp.spyglass.api.rollback.Rollbackable}.
+ * The flush barrier ({@link net.medievalrp.spyglass.plugin.pipeline.DeferredSerializer#awaitQuiescence})
+ * is wired as the recorder's pre-flush hook (#98), keeping read-your-writes safe.
+ */
 @ApiStatus.Internal
 public final class BlockPlaceListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor serializer;
 
-    public BlockPlaceListener(Recorder recorder, RecordingSupport support) {
+    public BlockPlaceListener(Recorder recorder, RecordingSupport support, Executor serializer) {
         this.recorder = recorder;
         this.support = support;
+        this.serializer = serializer;
     }
 
     @Override
@@ -33,10 +61,35 @@ public final class BlockPlaceListener implements RecordingListener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
-        BlockSnapshot before = BlockSnapshots.capture(event.getBlockReplacedState());
-        BlockSnapshot after = BlockSnapshots.capture(event.getBlock().getState());
-        BlockLocation location = BlockLocations.fromLocation(event.getBlock().getLocation());
+        // Allocation trim (#116): skip a full captureRaw for the replaced state
+        // when it is AIR - placing into empty space is the common path. The
+        // shared air() constant is immutable and identity-safe.
+        BlockSnapshots.RawCapture rawBefore = event.getBlockReplacedState().getType() == Material.AIR
+                ? null
+                : BlockSnapshots.captureRaw(event.getBlockReplacedState());
+
+        // captureRaw carries the immutable BlockData; getAsString() is deferred
+        // to finishCapture on the serializer thread (#154).
+        BlockSnapshots.RawCapture rawAfter = BlockSnapshots.captureRaw(event.getBlock().getState());
+
+        // Allocation trim (#116): fromBlock avoids a throwaway Location allocation.
+        BlockLocation location = BlockLocations.fromBlock(event.getBlock());
+
+        // Build context (stamps occurred + time-ordered id) on the main thread
+        // so the record reflects event time, not serialization time (#98).
         RecordContext ctx = support.playerContext(event.getPlayer(), location);
-        recorder.record(BlockPlaceRecord.of(ctx, "place", after.material().name(), before, after));
+        String target = rawAfter.type().name();
+
+        // rawBefore is either null (air fast-path) or a full RawCapture.
+        // Capture the null-ness here for the lambda; the lambda resolves it
+        // off-thread without touching the main thread.
+        boolean beforeIsAir = rawBefore == null;
+        serializer.execute(() -> {
+            BlockSnapshot before = beforeIsAir
+                    ? BlockSnapshots.air()
+                    : BlockSnapshots.finishCapture(rawBefore);
+            BlockSnapshot after = BlockSnapshots.finishCapture(rawAfter);
+            recorder.record(BlockPlaceRecord.of(ctx, "place", target, before, after));
+        });
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockSnapshots.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockSnapshots.java
@@ -15,6 +15,7 @@ import org.bukkit.block.DecoratedPot;
 import org.bukkit.block.Jukebox;
 import org.bukkit.block.Sign;
 import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.sign.Side;
 import org.bukkit.inventory.ItemStack;
 
@@ -40,14 +41,23 @@ public final class BlockSnapshots {
 
     /**
      * Cheap intermediate from {@link #captureRaw}. Holds everything a
-     * {@link BlockSnapshot} needs <em>except</em> the serialized item blobs:
-     * the container contents and jukebox disc are kept as <b>cloned</b>
-     * {@link ItemStack}s (detached from the live world), so {@link #finishCapture}
-     * can run the expensive {@code serializeAsBytes()} off the main thread.
+     * {@link BlockSnapshot} needs <em>except</em> the serialized item blobs
+     * and the blockdata string:
+     * <ul>
+     *   <li>The container contents and jukebox disc are kept as <b>cloned</b>
+     *       {@link ItemStack}s (detached from the live world).</li>
+     *   <li>The block's data is carried as the <b>immutable</b> {@link BlockData}
+     *       copy returned by {@link BlockState#getBlockData()} - it is already
+     *       world-detached and safe to hand across threads. {@link #finishCapture}
+     *       calls {@code getAsString()} on it off the main thread, deferring the
+     *       string allocation away from the server tick (#154).</li>
+     * </ul>
+     * {@link #finishCapture} can therefore run both the expensive
+     * {@code serializeAsBytes()} AND {@code getAsString()} off-thread.
      */
     public record RawCapture(
             Material type,
-            String blockData,
+            BlockData blockData,           // immutable copy; getAsString() deferred to finishCapture
             ItemStack[] containerContents, // cloned; null when the state isn't a Container
             List<String> signFront,
             List<String> signBack,
@@ -122,9 +132,14 @@ public final class BlockSnapshots {
             potSherds = List.copyOf(names);
         }
 
+        // Carry the immutable BlockData copy rather than calling getAsString()
+        // here on the main thread. getAsString() builds the "minecraft:stone[...]"
+        // string and accounts for ~19% of Spyglass's per-event tick cost.
+        // BlockData returned by getBlockData() is an immutable, world-detached
+        // snapshot - it is safe to hand to finishCapture() on an off-thread.
         return new RawCapture(
                 state.getType(),
-                state.getBlockData().getAsString(),
+                state.getBlockData(),
                 containerContents,
                 signFront,
                 signBack,
@@ -134,19 +149,28 @@ public final class BlockSnapshots {
     }
 
     /**
-     * Off-thread half of {@link #capture}: serialize the cloned container
-     * contents and jukebox disc held in {@code raw} into the final
-     * {@link BlockSnapshot}. Touches only world-detached cloned stacks, so it
-     * is safe off the main thread.
+     * Off-thread half of {@link #capture}: calls {@code getAsString()} on the
+     * immutable {@link BlockData} carried by {@code raw}, serializes the cloned
+     * container contents and jukebox disc, and assembles the final
+     * {@link BlockSnapshot}. Everything it touches is world-detached, so it is
+     * safe to run off the main thread.
+     *
+     * <p>{@code getAsString()} is the deferred call (#154): it was previously
+     * called in {@link #captureRaw} on the server tick and accounts for ~19% of
+     * Spyglass's per-event main-thread cost for plain break/place events. Moving
+     * it here yields the same string with no behavior change - just a different
+     * thread.
      */
     public static BlockSnapshot finishCapture(RawCapture raw) {
+        // getAsString() deferred off the main thread (#154).
+        String blockDataString = raw.blockData().getAsString();
         List<StoredItem> items = raw.containerContents() == null
                 ? List.of()
                 : serializeContents(raw.containerContents());
         String jukeboxRecord = ItemSerialization.encode(raw.jukeboxRecord());
         return new BlockSnapshot(
                 raw.type(),
-                raw.blockData(),
+                blockDataString,
                 items,
                 raw.signFront(),
                 raw.signBack(),

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListenerTest.java
@@ -1,0 +1,209 @@
+package net.medievalrp.spyglass.plugin.listener.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the deferred getAsString() strategy for BlockBreakListener (#154):
+ *
+ * <ul>
+ *   <li>captureRaw runs on the handling thread (main); getAsString() does NOT.</li>
+ *   <li>finishCapture runs on the serializer thread; getAsString() runs there.</li>
+ *   <li>The finished snapshot's blockData string is byte-identical to the value
+ *       getAsString() returns - same as the old inline path.</li>
+ *   <li>The RecordContext (occurred + id) is stamped at event time on the
+ *       handling thread, not at serialization time (#98 read-your-writes).</li>
+ *   <li>The after-snapshot uses the shared air() constant (no allocation).</li>
+ * </ul>
+ */
+class BlockBreakListenerTest {
+
+    private static final UUID PLAYER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD_ID  = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support   = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Bukkit's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void serializationIsDeferredToTheExecutorNotInline() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockBreakListener listener = new BlockBreakListener(recorder, support, deferred::add);
+
+        listener.onBlockBreak(stoneBreakEvent(mock(BlockData.class)));
+
+        // Nothing recorded inline - heavy build deferred.
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        BlockBreakRecord record = (BlockBreakRecord) recorder.records.get(0);
+        assertThat(record.event()).isEqualTo("break");
+        assertThat(record.target()).isEqualTo("STONE");
+    }
+
+    /**
+     * #154: getAsString() must NOT be called on the handling thread (inside
+     * captureRaw). It must only be called when the deferred task runs
+     * (inside finishCapture).
+     */
+    @Test
+    void getAsStringIsNotCalledOnHandlingThreadButIsCalledOnSerializerThread() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockBreakListener listener = new BlockBreakListener(recorder, support, deferred::add);
+        BlockData blockData = mock(BlockData.class);
+        when(blockData.getAsString()).thenReturn("minecraft:stone");
+
+        listener.onBlockBreak(stoneBreakEvent(blockData));
+
+        // Not yet - deferred to the serializer thread.
+        verify(blockData, never()).getAsString();
+
+        deferred.get(0).run();
+
+        // Now it ran exactly once.
+        verify(blockData).getAsString();
+    }
+
+    /**
+     * #154: the blockData string in the finished record must be byte-identical
+     * to the value getAsString() returns - same as the old inline path.
+     */
+    @Test
+    void finishedRecordCarriesTheSameBlockDataStringAsGetAsString() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockBreakListener listener = new BlockBreakListener(recorder, support, deferred::add);
+        BlockData blockData = mock(BlockData.class);
+        when(blockData.getAsString()).thenReturn("minecraft:stone[waterlogged=false]");
+
+        listener.onBlockBreak(stoneBreakEvent(blockData));
+        deferred.get(0).run();
+
+        BlockBreakRecord record = (BlockBreakRecord) recorder.records.get(0);
+        assertThat(record.originalBlock().blockData())
+                .isEqualTo("minecraft:stone[waterlogged=false]");
+    }
+
+    /**
+     * #98 read-your-writes: occurred and id must be stamped at event time on
+     * the handling thread, not at serialization time on the executor thread.
+     * Even when the executor delays execution, the record's occurred timestamp
+     * must fall inside the event-handling window.
+     */
+    @Test
+    void occurredAndIdAreStampedAtEventTimeNotAtSerializationTime() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockBreakListener listener = new BlockBreakListener(recorder, support, deferred::add);
+
+        Instant before = Instant.now();
+        listener.onBlockBreak(stoneBreakEvent(mock(BlockData.class)));
+        Instant after = Instant.now();
+
+        // Simulate delayed executor (the record is built strictly after the event window).
+        deferred.get(0).run();
+
+        BlockBreakRecord record = (BlockBreakRecord) recorder.records.get(0);
+        assertThat(record.occurred())
+                .as("occurred must be stamped at event time, not serialization time")
+                .isBetween(before, after);
+        assertThat(record.id()).isNotNull();
+    }
+
+    /**
+     * After-snapshot must be the shared air() constant - break always leaves air.
+     */
+    @Test
+    void afterSnapshotIsTheSharedAirConstant() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockBreakListener listener = new BlockBreakListener(recorder, support, deferred::add);
+
+        listener.onBlockBreak(stoneBreakEvent(mock(BlockData.class)));
+        deferred.get(0).run();
+
+        BlockBreakRecord record = (BlockBreakRecord) recorder.records.get(0);
+        assertThat(record.newBlock().material()).isEqualTo(Material.AIR);
+        assertThat(record.newBlock().blockData()).isEqualTo("minecraft:air");
+        assertThat(record.newBlock().isAir()).isTrue();
+    }
+
+    // ── fixtures ────────────────────────────────────────────────
+
+    /**
+     * A mocked BlockBreakEvent for a STONE block with the given BlockData.
+     * FallingBlockCascade reads the block's world/x/y/z to scan above -
+     * we mock those minimally so the cascade finds no gravity-affected
+     * blocks (world.getMaxHeight() returns 0 by default in mocks, which
+     * exits the loop immediately).
+     */
+    private BlockBreakEvent stoneBreakEvent(BlockData blockData) {
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        // getMaxHeight() returns 0 by default from Mockito, so the cascade
+        // loop exits immediately (y >= maxHeight).
+        when(world.getMaxHeight()).thenReturn(0);
+
+        BlockState state = mock(BlockState.class);
+        when(state.getType()).thenReturn(Material.STONE);
+        when(state.getBlockData()).thenReturn(blockData);
+
+        Block block = mock(Block.class);
+        when(block.getState()).thenReturn(state);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(10);
+        when(block.getY()).thenReturn(64);
+        when(block.getZ()).thenReturn(20);
+        when(block.getType()).thenReturn(Material.STONE);
+
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListenerTest.java
@@ -1,0 +1,259 @@
+package net.medievalrp.spyglass.plugin.listener.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the deferred getAsString() strategy for BlockPlaceListener (#154) and
+ * the place-path allocation trims (#116):
+ *
+ * <ul>
+ *   <li>getAsString() is NOT called on the handling thread for either capture
+ *       (replaced or placed state); it is deferred to the serializer thread.</li>
+ *   <li>When the replaced state is AIR the air() fast-path is taken, skipping
+ *       captureRaw entirely for that snapshot (no getAsString() call at all).</li>
+ *   <li>The finished record's blockData strings are byte-identical to the values
+ *       getAsString() returns - same as the old inline path.</li>
+ *   <li>occurred + id are stamped at event time (#98 read-your-writes).</li>
+ * </ul>
+ */
+class BlockPlaceListenerTest {
+
+    private static final UUID PLAYER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD_ID  = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support   = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Bukkit's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void serializationIsDeferredToTheExecutorNotInline() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+        BlockData replacedData = airBlockData();
+        BlockData placedData   = stoneBlockData();
+
+        listener.onBlockPlace(placeEvent(Material.AIR, replacedData, Material.STONE, placedData));
+
+        // Nothing recorded inline.
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.event()).isEqualTo("place");
+        assertThat(record.target()).isEqualTo("STONE");
+    }
+
+    /**
+     * #154: getAsString() must NOT be called for either snapshot during
+     * the handling (main) thread call. It runs only when the deferred task
+     * executes.
+     */
+    @Test
+    void getAsStringIsNotCalledOnHandlingThreadForPlacedState() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+        BlockData replacedData = airBlockData();
+        BlockData placedData   = stoneBlockData();
+
+        listener.onBlockPlace(placeEvent(Material.AIR, replacedData, Material.STONE, placedData));
+
+        // Neither call must have happened on the main (handling) thread.
+        verify(placedData, never()).getAsString();
+        // replacedData is AIR - captureRaw is skipped entirely via the fast-path.
+        verify(replacedData, never()).getAsString();
+
+        deferred.get(0).run();
+
+        // After deferral: placed state's getAsString ran once.
+        verify(placedData).getAsString();
+        // Air fast-path: still zero calls on the replaced state's BlockData.
+        verify(replacedData, never()).getAsString();
+    }
+
+    /**
+     * When the replaced block is non-AIR, getAsString() for the replaced
+     * state is also deferred (not called on the handling thread).
+     */
+    @Test
+    void getAsStringForNonAirReplacedStateIsAlsoDeferred() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+        BlockData replacedData = mock(BlockData.class);
+        when(replacedData.getAsString()).thenReturn("minecraft:dirt");
+        BlockData placedData = stoneBlockData();
+
+        listener.onBlockPlace(placeEvent(Material.DIRT, replacedData, Material.STONE, placedData));
+
+        // Neither called on main thread.
+        verify(replacedData, never()).getAsString();
+        verify(placedData, never()).getAsString();
+
+        deferred.get(0).run();
+
+        // Both called exactly once on the serializer thread.
+        verify(replacedData).getAsString();
+        verify(placedData).getAsString();
+
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.originalBlock().blockData()).isEqualTo("minecraft:dirt");
+        assertThat(record.newBlock().blockData()).isEqualTo("minecraft:stone");
+    }
+
+    /**
+     * #116 allocation trim: when the replaced state is AIR, the before-snapshot
+     * must be the shared air() constant - not a newly captured RawCapture.
+     * This skips the entire captureRaw path for the replaced state.
+     */
+    @Test
+    void airReplacedStateUsesTheSharedAirConstant() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+
+        listener.onBlockPlace(placeEvent(Material.AIR, airBlockData(), Material.STONE, stoneBlockData()));
+        deferred.get(0).run();
+
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        // The before-snapshot must be the air() constant: AIR material, "minecraft:air".
+        assertThat(record.originalBlock().material()).isEqualTo(Material.AIR);
+        assertThat(record.originalBlock().blockData()).isEqualTo("minecraft:air");
+        assertThat(record.originalBlock().isAir()).isTrue();
+        // Same instance as the shared constant.
+        assertThat(record.originalBlock()).isSameAs(BlockSnapshots.air());
+    }
+
+    /**
+     * #154 + #116: the after-snapshot's blockData string is byte-identical to
+     * getAsString() for both AIR-replaced and non-AIR-replaced places.
+     */
+    @Test
+    void finishedRecordCarriesTheSameBlockDataStringsAsGetAsString() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+        BlockData placedData = mock(BlockData.class);
+        when(placedData.getAsString()).thenReturn("minecraft:stone[waterlogged=false]");
+
+        listener.onBlockPlace(placeEvent(Material.AIR, airBlockData(), Material.STONE, placedData));
+        deferred.get(0).run();
+
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.newBlock().blockData()).isEqualTo("minecraft:stone[waterlogged=false]");
+    }
+
+    /**
+     * #98 read-your-writes: occurred + id must be stamped at event time on the
+     * handling thread, not at serialization time.
+     */
+    @Test
+    void occurredAndIdAreStampedAtEventTimeNotAtSerializationTime() {
+        List<Runnable> deferred = new ArrayList<>();
+        BlockPlaceListener listener = new BlockPlaceListener(recorder, support, deferred::add);
+
+        Instant before = Instant.now();
+        listener.onBlockPlace(placeEvent(Material.AIR, airBlockData(), Material.STONE, stoneBlockData()));
+        Instant after = Instant.now();
+
+        // Simulate a delayed executor.
+        deferred.get(0).run();
+
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.occurred())
+                .as("occurred must be stamped at event time, not serialization time")
+                .isBetween(before, after);
+        assertThat(record.id()).isNotNull();
+    }
+
+    // ── fixtures ────────────────────────────────────────────────
+
+    private BlockPlaceEvent placeEvent(Material replacedMaterial, BlockData replacedData,
+                                       Material placedMaterial, BlockData placedData) {
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+
+        // The replaced state (before).
+        BlockState replacedState = mock(BlockState.class);
+        when(replacedState.getType()).thenReturn(replacedMaterial);
+        when(replacedState.getBlockData()).thenReturn(replacedData);
+
+        // The placed state (after).
+        BlockState placedState = mock(BlockState.class);
+        when(placedState.getType()).thenReturn(placedMaterial);
+        when(placedState.getBlockData()).thenReturn(placedData);
+
+        // The block after placing (for fromBlock and getState()).
+        Block block = mock(Block.class);
+        when(block.getState()).thenReturn(placedState);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(5);
+        when(block.getY()).thenReturn(64);
+        when(block.getZ()).thenReturn(10);
+        when(block.getType()).thenReturn(placedMaterial);
+
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+
+        BlockPlaceEvent event = mock(BlockPlaceEvent.class);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getBlockReplacedState()).thenReturn(replacedState);
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+
+    private static BlockData airBlockData() {
+        BlockData bd = mock(BlockData.class);
+        when(bd.getAsString()).thenReturn("minecraft:air");
+        return bd;
+    }
+
+    private static BlockData stoneBlockData() {
+        BlockData bd = mock(BlockData.class);
+        when(bd.getAsString()).thenReturn("minecraft:stone");
+        return bd;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockSnapshotsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockSnapshotsTest.java
@@ -28,6 +28,14 @@ import org.junit.jupiter.api.Test;
  * tests pin that the clone happens at capture time and the {@code
  * serializeAsBytes()} is deferred to finish time, and that {@code capture()}
  * (their composition) still produces the full inline snapshot.
+ *
+ * <p>#154: {@code captureRaw} now carries the immutable {@link BlockData}
+ * object (not the string), and {@code finishCapture} calls
+ * {@code getAsString()} off the main thread. Tests pin that
+ * {@code getAsString()} is NOT called during {@code captureRaw} and IS called
+ * during {@code finishCapture}, and that the resulting snapshot's
+ * {@code blockData()} string is byte-identical to what the old inline path
+ * would have produced.
  */
 class BlockSnapshotsTest {
 
@@ -70,7 +78,40 @@ class BlockSnapshotsTest {
         // Slots preserved, including the empty middle slot.
         assertThat(raw.containerContents()).containsExactly(f.clone0, null, f.clone2);
         assertThat(raw.type()).isEqualTo(Material.CHEST);
-        assertThat(raw.blockData()).isEqualTo("minecraft:chest");
+        // #154: blockData() now returns the BlockData object, not the string.
+        // The string is deferred to finishCapture - verify the object is present.
+        assertThat(raw.blockData()).isNotNull().isSameAs(f.blockData);
+    }
+
+    /**
+     * #154: {@code getAsString()} must NOT be called during {@code captureRaw}
+     * (that is the main-thread call we are deferring) and MUST be called during
+     * {@code finishCapture} (the off-thread call).
+     */
+    @Test
+    void getAsStringIsNotCalledOnCaptureRawButIsCalledOnFinishCapture() {
+        Fixture f = containerFixture();
+
+        BlockSnapshots.RawCapture raw = BlockSnapshots.captureRaw(f.state);
+        // Not yet: getAsString() deferred to finishCapture (#154).
+        verify(f.blockData, never()).getAsString();
+
+        BlockSnapshots.finishCapture(raw);
+        // Now it runs - exactly once.
+        verify(f.blockData).getAsString();
+    }
+
+    /**
+     * #154: the blockData string in the finished snapshot must be
+     * byte-identical to the value {@code getAsString()} returns - same as the
+     * old inline path that called it in {@code captureRaw}.
+     */
+    @Test
+    void finishCaptureProducesTheSameBlockDataStringAsTheOldInlinePath() {
+        Fixture f = containerFixture();
+        // The mock returns "minecraft:chest" from getAsString().
+        BlockSnapshot snapshot = BlockSnapshots.finishCapture(BlockSnapshots.captureRaw(f.state));
+        assertThat(snapshot.blockData()).isEqualTo("minecraft:chest");
     }
 
     @Test
@@ -100,6 +141,7 @@ class BlockSnapshotsTest {
         BlockSnapshot snapshot = BlockSnapshots.capture(f.state);
 
         assertThat(snapshot.material()).isEqualTo(Material.CHEST);
+        assertThat(snapshot.blockData()).isEqualTo("minecraft:chest");
         assertThat(snapshot.containerItems())
                 .extracting(StoredItem::material)
                 .containsExactly(Material.DIAMOND.name(), Material.GOLD_INGOT.name());
@@ -124,7 +166,7 @@ class BlockSnapshotsTest {
         when(blockData.getAsString()).thenReturn("minecraft:chest");
         when(state.getBlockData()).thenReturn(blockData);
 
-        return new Fixture(state, slot0, slot2, clone0, clone2);
+        return new Fixture(state, slot0, slot2, clone0, clone2, blockData);
     }
 
     private static ItemStack stack(Material material) {
@@ -136,6 +178,6 @@ class BlockSnapshotsTest {
     }
 
     private record Fixture(BlockState state, ItemStack slot0, ItemStack slot2,
-                           ItemStack clone0, ItemStack clone2) {
+                           ItemStack clone0, ItemStack clone2, BlockData blockData) {
     }
 }


### PR DESCRIPTION
Closes #154.

## Summary
Per the ingest-MSPT profile (#153), ~19% of Spyglass per-event main-thread cost for the common plain-block break/place is `CraftBlockData.getAsString()`, run synchronously on the server thread (twice per place). This moves it off-thread.

## Change
- `BlockSnapshots.RawCapture` now carries the immutable `BlockData` object (not the string); `getAsString()` runs in `finishCapture()` on the `DeferredSerializer` thread.
- `BlockBreakListener` / `BlockPlaceListener` switch to `captureRaw()` on main + deferred `finishCapture()`+`record()`, mirroring the container path. `occurred`/`id` are stamped at **event time** on the main thread (time-ordered v7 id), so concurrent serialization cannot reorder the stored sequence.
- **Read-your-writes** is preserved: the listeners use the same `DeferredSerializer` whose `awaitQuiescence` is wired as `recorder.setFlushBarrier(...)`, so a rollback right after a burst drains these tasks first. `execute()` is `newVirtualThreadPerTaskExecutor` so it never blocks the tick.
- Folds in the #116 place-path trims: `air()` constant for AIR-replaced placements, `fromBlock` instead of `fromLocation`.

The recorded blockdata string is byte-identical to before - only the thread it is built on changes.

## Tests
`BlockSnapshotsTest` (string identity), new `BlockBreakListenerTest` (5) + `BlockPlaceListenerTest` (6) incl. event-time id/occurred stamping. Green (incl. `:spyglass:check`).

## Verification
`./gradlew check` green; live ingest correctness + rollback read-your-writes verification in progress (follow-up comment). MAJOR change (hot ingest path) - live-gated.