### PR TITLE
perf(pipeline): pool the DeferredSerializer to fix the #154 regression and deliver its high-load win

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializer.java
@@ -4,9 +4,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import java.util.logging.Logger;
 import net.medievalrp.spyglass.api.util.Duration;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,17 +16,34 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Off-main-thread serialization stage for listeners whose per-record cost
  * is dominated by item serialization (NBT -&gt; bytes -&gt; base64 plus
- * Adventure text extraction). A listener captures a cheap snapshot on the
- * main thread and hands the heavy build to {@link #execute}, which runs it
- * on a virtual thread and calls {@code Recorder.record()} from there.
+ * Adventure text extraction) or by the block-data string (#154). A listener
+ * captures a cheap snapshot on the main thread and hands the heavy build to
+ * {@link #execute}, which runs it on a worker and calls
+ * {@code Recorder.record()} from there.
+ *
+ * <h2>Why a pooled executor (not virtual-thread-per-task)</h2>
+ *
+ * <p>The block break/place listeners (#154) submit a task <em>per event</em>
+ * (thousands per second under load). A JFR profile showed that
+ * {@code newVirtualThreadPerTaskExecutor} spawning a fresh virtual thread for
+ * each of those events, plus a {@code ReentrantLock} acquisition on the
+ * in-flight counter, cost more main-thread CPU than the cheap
+ * {@code getAsString()} call they were deferring -- a net regression at high
+ * event rates. This stage therefore uses a small <b>reused thread pool</b>
+ * (no per-event thread creation) and a <b>lock-free</b> {@link AtomicLong}
+ * in-flight counter, so the only main-thread cost per submission is one atomic
+ * increment plus a queue offer. The pool's queue is unbounded, so
+ * {@link #execute} never blocks the server thread; the block listeners only
+ * fire on real gameplay block events (WorldEdit edits bypass Bukkit events),
+ * so the queue is bounded by gameplay rate in practice.
  *
  * <h2>Flush coordination (rollbackable records)</h2>
  *
  * <p>Pickups are forensic-only, but this stage is also used for
- * <em>rollbackable</em> container records (#98). Those sit in front of the
- * recorder queue, so a rollback's read-your-writes flush must drain this
- * stage <em>first</em>: {@link #awaitQuiescence} blocks until every task
- * submitted before the call has finished handing its record to the
+ * <em>rollbackable</em> container and block records (#98, #154). Those sit in
+ * front of the recorder queue, so a rollback's read-your-writes flush must
+ * drain this stage <em>first</em>: {@link #awaitQuiescence} blocks until every
+ * task submitted before the call has finished handing its record to the
  * recorder. Wire it as the recorder's pre-flush barrier
  * ({@link AsyncRecorder#setFlushBarrier}) so
  * {@code flush()} = drain this stage, then drain the queue.
@@ -33,25 +52,25 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>A task in flight here has been snapshotted off the live world but not
  * yet enqueued, so it sits <b>outside</b> the recorder's no-drop/WAL
- * guarantee — a hard JVM crash in that window (the few ms of
- * serialization) loses it. For pickups this is irrelevant (never rolled
- * back); for rollbackable container records it is a small, deliberate
- * weakening of rollback completeness, accepted for the tick-latency win
- * (#98). {@code flush()} still guarantees correctness for an
- * <em>orderly</em> rollback — only an unclean crash mid-serialization can
- * lose a deferred record.
+ * guarantee -- a hard JVM crash in that window (the few ms of serialization)
+ * loses it. For pickups this is irrelevant (never rolled back); for
+ * rollbackable records it is a small, deliberate weakening of rollback
+ * completeness, accepted for the tick-latency win. {@code flush()} still
+ * guarantees correctness for an <em>orderly</em> rollback -- only an unclean
+ * crash mid-serialization can lose a deferred record.
  */
 @ApiStatus.Internal
 public final class DeferredSerializer implements Executor {
 
     private final ExecutorService executor;
     private final Logger logger;
-    private final ReentrantLock lock = new ReentrantLock();
-    private final Condition idle = lock.newCondition();
-    private long inFlight;
+    // Lock-free in-flight count: incremented on the main thread at submit,
+    // decremented on the worker at completion. awaitQuiescence (rare, only on
+    // a rollback flush) polls it, so the hot path never takes a lock.
+    private final AtomicLong inFlight = new AtomicLong();
 
     public DeferredSerializer(Logger logger) {
-        this(Executors.newVirtualThreadPerTaskExecutor(), logger);
+        this(defaultPool(), logger);
     }
 
     /** Visible for tests: inject a deterministic executor (e.g. same-thread). */
@@ -60,14 +79,20 @@ public final class DeferredSerializer implements Executor {
         this.logger = logger;
     }
 
+    private static ExecutorService defaultPool() {
+        int threads = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+        AtomicInteger idx = new AtomicInteger();
+        ThreadFactory factory = runnable -> {
+            Thread thread = new Thread(runnable, "spyglass-deferred-serializer-" + idx.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+        return Executors.newFixedThreadPool(threads, factory);
+    }
+
     @Override
     public void execute(Runnable task) {
-        lock.lock();
-        try {
-            inFlight++;
-        } finally {
-            lock.unlock();
-        }
+        inFlight.incrementAndGet();
         try {
             executor.execute(() -> run(task));
         } catch (RejectedExecutionException rejected) {
@@ -87,14 +112,7 @@ public final class DeferredSerializer implements Executor {
             logger.warning("Spyglass deferred record serialization failed;"
                     + " record skipped: " + ex);
         } finally {
-            lock.lock();
-            try {
-                if (--inFlight == 0) {
-                    idle.signalAll();
-                }
-            } finally {
-                lock.unlock();
-            }
+            inFlight.decrementAndGet();
         }
     }
 
@@ -105,27 +123,24 @@ public final class DeferredSerializer implements Executor {
      * contract the rollback flush relies on is that nothing submitted
      * before the call is still in flight on success.
      *
+     * <p>Implemented by polling the lock-free counter; the flush is rare
+     * (only on a rollback), so a short poll interval costs nothing on the
+     * hot path while keeping submit lock-free.
+     *
      * @return {@code true} if the stage reached quiescence, {@code false} on timeout
      */
     public boolean awaitQuiescence(Duration timeout) {
         long deadlineNanos = System.nanoTime()
                 + TimeUnit.SECONDS.toNanos(Math.max(0L, timeout.seconds()));
-        lock.lock();
-        try {
-            while (inFlight > 0) {
-                long remaining = deadlineNanos - System.nanoTime();
-                if (remaining <= 0) {
-                    return false;
-                }
-                idle.awaitNanos(remaining);
+        while (inFlight.get() > 0) {
+            if (System.nanoTime() - deadlineNanos >= 0) {
+                return false;
             }
-            return true;
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            return false;
-        } finally {
-            lock.unlock();
+            // 0.2 ms poll: a flush waiting on a few ms of serialization wakes
+            // promptly without busy-spinning.
+            LockSupport.parkNanos(200_000L);
         }
+        return true;
     }
 
     /**

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/DeferredSerializerTest.java
@@ -76,6 +76,38 @@ class DeferredSerializerTest {
     }
 
     @Test
+    void poolsThreadsAndStaysCorrectUnderManySubmissions() {
+        // The block break/place listeners (#154) submit a task per event. This
+        // pins the two things the pooled rework changed: (1) the lock-free
+        // in-flight counter settles to zero after a flood of concurrent
+        // submissions (else a rollback flush would hang), and (2) tasks run on
+        // a small reused pool, NOT one freshly-spawned thread per task (the
+        // per-event spawn was the measured regression).
+        DeferredSerializer serializer = new DeferredSerializer(logger);
+        int n = 2000;
+        java.util.Set<String> workerThreads = java.util.concurrent.ConcurrentHashMap.newKeySet();
+        java.util.concurrent.atomic.AtomicInteger ran = new java.util.concurrent.atomic.AtomicInteger();
+
+        for (int i = 0; i < n; i++) {
+            serializer.execute(() -> {
+                workerThreads.add(Thread.currentThread().getName());
+                ran.incrementAndGet();
+            });
+        }
+
+        assertThat(serializer.awaitQuiescence(Duration.parse("10s")))
+                .as("lock-free counter must settle to zero after all submissions complete")
+                .isTrue();
+        assertThat(ran.get()).isEqualTo(n);
+        assertThat(workerThreads)
+                .allSatisfy(name -> assertThat(name).startsWith("spyglass-deferred-serializer-"));
+        assertThat(workerThreads.size())
+                .as("a fixed pool reuses a bounded number of threads, not one per task")
+                .isLessThanOrEqualTo(Math.max(2, Runtime.getRuntime().availableProcessors()));
+        serializer.shutdown(Duration.parse("2s"));
+    }
+
+    @Test
     void executeAfterShutdownRunsInlineSoRecordsAreNotDropped() {
         DeferredSerializer serializer = new DeferredSerializer(logger);
         serializer.shutdown(Duration.parse("1s"));


### PR DESCRIPTION
Follow-up to #154 (which is merged to `dev`).

## Problem
A clean same-machine ingest-MSPT A/B showed the merged #154 (defer `getAsString` off the main thread) **regressed** mean per-tick cost at every rate (+0.07 to +0.26 ms, worse with rate). A JFR pinned the cause to the deferral **mechanism**, not the off-loading: `DeferredSerializer` spawned a **virtual thread per event** (`newVirtualThreadPerTaskExecutor`) plus took a **`ReentrantLock`** on the in-flight counter, thousands of times a second. For a cheap `getAsString` on a plain block, that overhead exceeded the work it deferred.

## Fix
Rework `DeferredSerializer`:
- **Small fixed thread pool** (`availableProcessors()/2`, min 2, daemon, named) instead of a thread per task -> no per-event thread creation; the only submit cost is a queue offer.
- **Lock-free `AtomicLong`** in-flight counter; `awaitQuiescence` (rare, only on a rollback flush) polls it, so the hot path never takes a lock.
- Queue is unbounded so `execute` never blocks the server thread; the block listeners only fire on real gameplay events (WorldEdit bypasses Bukkit events), so it is gameplay-bounded.

## Result (added mean MSPT over vanilla, same machine, 0 anomalies)
| rate | old-SG (pre-#154) | vthread-SG (#154) | **pooled-SG** | CoreProtect |
|---|---|---|---|---|
| 600 | 0.082 | 0.150 | 0.133 | 0.020 |
| 1200 | 0.199 | 0.286 | 0.203 | 0.144 |
| 2400 | 0.314 | 0.494 | 0.315 | 0.221 |
| 5000 | 0.642 | 0.902 | **0.547** | 0.452 |

- Beats the merged #154 at **every** rate (5000: **-39%**).
- vs old-SG (does deferral now help?): **-15% at 5000** (the stress rate that matters), tie at 1200/2400, tiny loss at 600 (deferring a cheap call is not worth it at low volume).
- Still ~1.2x CoreProtect at 5000 (CP logs less per event) but narrows the gap from ~2x.

## Tests + verification
- `DeferredSerializerTest`: existing flush/quiescence/exception/shutdown cases stay green + a new case pinning the pooled behavior (2000 submissions settle the lock-free counter to quiescence; tasks run on a bounded set of reused `spyglass-deferred-serializer-*` threads, not one per task). `./gradlew check` green (jacoco floors hold).
- Live: read-your-writes verified on a throwaway SQLite server - 12 dug blocks, immediate rollback reversed all 12 (the polling flush barrier drains the pool before the rollback reads). Ingest 1:1 confirmed by the benchmark.

This is strictly better than the merged #154 and delivers the high-load win #154 was meant to provide.