### PR TITLE
feat(analytics): opt-in ingest analytics mode (#168)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -12,6 +12,9 @@ import net.medievalrp.spyglass.api.event.RecordCommittedEvent;
 import net.medievalrp.spyglass.api.util.Duration;
 import net.medievalrp.spyglass.plugin.api.SpyglassApiImpl;
 import net.medievalrp.spyglass.plugin.command.SpyglassCommands;
+import net.medievalrp.spyglass.plugin.command.service.StatsService;
+import net.medievalrp.spyglass.plugin.pipeline.IngestStats;
+import net.medievalrp.spyglass.plugin.pipeline.IngestStatsReporter;
 import net.medievalrp.spyglass.plugin.command.SpyglassSuggestions;
 import net.medievalrp.spyglass.plugin.command.PageCache;
 import net.medievalrp.spyglass.plugin.command.param.BlockParam;
@@ -158,6 +161,9 @@ public final class SpyglassPlugin extends JavaPlugin {
      * despawn) accumulate forever -- #128.
      */
     private org.bukkit.scheduler.BukkitTask fallingBlockPurgeTask;
+    // #168: repeating async task that logs the ingest analytics report. Null
+    // unless analytics.enabled; cancelled in onDisable.
+    private org.bukkit.scheduler.BukkitTask analyticsTask;
     private UndoStack undoStack;
     private ToolStateStore toolStateStore;
     private SalvageStore salvageStore;
@@ -308,6 +314,17 @@ public final class SpyglassPlugin extends JavaPlugin {
         java.util.List<net.medievalrp.spyglass.api.event.EventRecord> recovered = wal.recover();
         for (net.medievalrp.spyglass.api.event.EventRecord record : recovered) {
             recorder.record(record);
+        }
+
+        // #168: opt-in ingest analytics. Created AFTER WAL replay (so recovered
+        // records aren't counted as live ingest) and BEFORE listeners come
+        // online (so every live event is tallied). Null - and zero hot-path
+        // overhead - when analytics.enabled = false.
+        IngestStats ingestStats = null;
+        if (config.analytics().enabled()) {
+            ingestStats = new IngestStats(
+                    recorder::queueDepth, recorder::drainedCount, recorder::droppedCount);
+            recorder.setIngestStats(ingestStats);
         }
 
         Set<String> enabledEvents = config.events().entrySet().stream()
@@ -564,6 +581,9 @@ public final class SpyglassPlugin extends JavaPlugin {
         }
         SalvageService salvageService = new SalvageService(
                 salvageStore, salvageGui, config.limits().searchResult(), serviceSupport);
+        // #168: /spyglass stats. Null ingestStats (analytics off) => the command
+        // explains how to enable it.
+        StatsService statsService = new StatsService(ingestStats);
 
         SpyglassCommands commands = new SpyglassCommands(
                 this,
@@ -577,6 +597,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 toolService,
                 teleportService,
                 salvageService,
+                statsService,
                 suggestions);
         commands.register();
 
@@ -623,6 +644,17 @@ public final class SpyglassPlugin extends JavaPlugin {
                 .runTaskTimerAsynchronously(this, FallingBlockTracker::purgeExpired,
                         PURGE_PERIOD_TICKS, PURGE_PERIOD_TICKS);
 
+        // #168: periodic ingest analytics report (off the main thread; only
+        // reads concurrent counters + cheap gauges). Off unless analytics.enabled.
+        if (ingestStats != null) {
+            long intervalTicks = Math.max(20L, config.analytics().interval().seconds() * 20L);
+            this.analyticsTask = getServer().getScheduler().runTaskTimerAsynchronously(
+                    this, new IngestStatsReporter(ingestStats, getLogger()),
+                    intervalTicks, intervalTicks);
+            getLogger().info("Spyglass analytics enabled: ingest report every "
+                    + config.analytics().interval().seconds() + "s and via /spyglass stats.");
+        }
+
         getLogger().info("Spyglass enabled; events=" + enabledEvents);
     }
 
@@ -648,6 +680,11 @@ public final class SpyglassPlugin extends JavaPlugin {
         if (fallingBlockPurgeTask != null) {
             fallingBlockPurgeTask.cancel();
             fallingBlockPurgeTask = null;
+        }
+        // #168: stop the analytics report task before teardown.
+        if (analyticsTask != null) {
+            analyticsTask.cancel();
+            analyticsTask = null;
         }
         // Stop the bStats submit scheduler first so it can't fire mid-teardown.
         if (metrics != null) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -10,6 +10,7 @@ import net.medievalrp.spyglass.plugin.command.service.RollbackMode;
 import net.medievalrp.spyglass.plugin.command.service.RollbackService;
 import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.SearchService;
+import net.medievalrp.spyglass.plugin.command.service.StatsService;
 import net.medievalrp.spyglass.plugin.command.service.TeleportService;
 import net.medievalrp.spyglass.plugin.command.service.ToolService;
 import net.medievalrp.spyglass.plugin.command.service.UndoService;
@@ -40,6 +41,7 @@ public final class SpyglassCommands {
     private final ToolService tool;
     private final TeleportService teleport;
     private final SalvageService salvage;
+    private final StatsService stats;
     private final SpyglassSuggestions suggestions;
 
     public SpyglassCommands(JavaPlugin plugin,
@@ -53,6 +55,7 @@ public final class SpyglassCommands {
                         ToolService tool,
                         TeleportService teleport,
                         SalvageService salvage,
+                        StatsService stats,
                         SpyglassSuggestions suggestions) {
         this.plugin = plugin;
         this.api = api;
@@ -65,6 +68,7 @@ public final class SpyglassCommands {
         this.tool = tool;
         this.teleport = teleport;
         this.salvage = salvage;
+        this.stats = stats;
         this.suggestions = suggestions;
     }
 
@@ -83,6 +87,7 @@ public final class SpyglassCommands {
     private static final List<String> HELP_ALIASES = List.of("help", "h", "?");
     private static final List<String> INVENTORY_ALIASES = List.of("inventory", "inv", "salvage");
     private static final List<String> VERSION_ALIASES = List.of("version", "ver");
+    private static final List<String> STATS_ALIASES = List.of("stats", "analytics");
 
     public CommandManager<CommandSender> register() {
         LegacyPaperCommandManager<CommandSender> manager = LegacyPaperCommandManager.createNative(
@@ -108,6 +113,13 @@ public final class SpyglassCommands {
                 manager.command(manager.commandBuilder(root).literal(name)
                         .permission("spyglass.use")
                         .handler(ctx -> sendVersion(ctx.sender())));
+            }
+
+            // #168: /spyglass stats - on-demand ingest analytics snapshot.
+            for (String name : STATS_ALIASES) {
+                manager.command(manager.commandBuilder(root).literal(name)
+                        .permission("spyglass.use")
+                        .handler(ctx -> stats.execute(ctx.sender())));
             }
 
             for (String name : SEARCH_ALIASES) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/StatsService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/StatsService.java
@@ -1,0 +1,43 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import net.medievalrp.spyglass.plugin.command.render.Feedback;
+import net.medievalrp.spyglass.plugin.pipeline.IngestStats;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Renders the on-demand ingest analytics snapshot for {@code /spyglass stats}
+ * (#168). A {@code null} {@link IngestStats} means analytics is disabled, in
+ * which case the command explains how to turn it on.
+ *
+ * <p>Rates are reported as the average since analytics was enabled (a stable
+ * figure that needs no main-thread sleep); the periodic console report carries
+ * the live per-interval rates. Gauges (queue depth, totals, allocation) are the
+ * current values either way.
+ */
+@ApiStatus.Internal
+public final class StatsService {
+
+    private final IngestStats stats;             // null when analytics is disabled
+    private final IngestStats.Snapshot baseline; // captured at enable time
+
+    public StatsService(@Nullable IngestStats stats) {
+        this.stats = stats;
+        this.baseline = stats == null ? null : stats.capture(System.nanoTime());
+    }
+
+    public void execute(CommandSender sender) {
+        if (stats == null) {
+            sender.sendMessage(Feedback.warn(
+                    "Spyglass analytics is disabled. Set analytics.enabled = true in "
+                            + "config.conf and restart to collect ingest stats."));
+            return;
+        }
+        IngestStats.Snapshot now = stats.capture(System.nanoTime());
+        sender.sendMessage(Feedback.success("Spyglass ingest analytics (avg since enabled):"));
+        for (String line : IngestStats.describe(baseline, now)) {
+            sender.sendMessage(Feedback.bonus(line));
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -20,7 +20,8 @@ public record SpyglassConfig(
         java.util.List<String> commandRedact,
         Tool tool,
         Server server,
-        Metrics metrics) {
+        Metrics metrics,
+        Analytics analytics) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -117,7 +118,8 @@ public record SpyglassConfig(
                 commandRedact,
                 new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
                 new Server(root.node("server", "name").getString("default")),
-                parseMetrics(root));
+                parseMetrics(root),
+                parseAnalytics(root));
     }
 
     /**
@@ -148,6 +150,28 @@ public record SpyglassConfig(
      */
     static Metrics parseMetrics(ConfigurationNode root) {
         return new Metrics(root.node("metrics", "enabled").getBoolean(true));
+    }
+
+    /**
+     * Ingest analytics mode (#168). Opt-in: {@code analytics.enabled} defaults
+     * to {@code false} (absent key = off), so a default config carries zero
+     * counting overhead. {@code analytics.interval} is how often the console
+     * report fires; it defaults to 60s and is floored at 5s if someone sets it
+     * absurdly low. Static + package-visible so it's unit-testable headless,
+     * like {@link #parseMetrics}.
+     */
+    static Analytics parseAnalytics(ConfigurationNode root) {
+        boolean enabled = root.node("analytics", "enabled").getBoolean(false);
+        Duration interval;
+        try {
+            interval = Duration.parse(root.node("analytics", "interval").getString("60s"));
+        } catch (RuntimeException malformed) {
+            interval = Duration.parse("60s");
+        }
+        if (interval.seconds() < 5L) {
+            interval = Duration.parse("5s");
+        }
+        return new Analytics(enabled, interval);
     }
 
     public boolean enabled(String eventName) {
@@ -335,6 +359,16 @@ public record SpyglassConfig(
      * {@code config.conf} to opt this server out of Spyglass's submission.
      */
     public record Metrics(boolean enabled) {
+    }
+
+    /**
+     * Ingest analytics mode (#168). {@code enabled} defaults to {@code false}
+     * (opt-in, zero overhead off); {@code interval} is the console report
+     * period (default 60s, floored at 5s). When on, Spyglass tallies recorded
+     * events per second by type plus pipeline load, logs a periodic report, and
+     * answers {@code /spyglass stats}.
+     */
+    public record Analytics(boolean enabled, Duration interval) {
     }
 
     private static ConfigurationNode loadBundledDefaults(JavaPlugin plugin) throws IOException {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -111,6 +111,10 @@ public final class AsyncRecorder implements Recorder {
     private int consecutiveFailures = 0;
     private volatile Consumer<EventRecord> committedHook = r -> {};
     private volatile FlushBarrier flushBarrier = timeout -> true;
+    // Opt-in analytics counter (#168). Null unless analytics.enabled, so the
+    // hot path is a single volatile read + null check when off - the same shape
+    // as committedHook above. Set once at startup via setIngestStats.
+    private volatile IngestStats ingestStats = null;
 
     /**
      * Pre-flush gate. {@link #flush} awaits this before snapshotting the
@@ -229,6 +233,31 @@ public final class AsyncRecorder implements Recorder {
         this.flushBarrier = barrier == null ? (timeout -> true) : barrier;
     }
 
+    /**
+     * Install the opt-in analytics counter (#168). When set, every intake is
+     * tallied by event type. Null (the default) leaves the hot path a single
+     * volatile read + null check. Set once at startup, after WAL replay so
+     * recovered records don't count as live ingest.
+     */
+    public void setIngestStats(IngestStats stats) {
+        this.ingestStats = stats;
+    }
+
+    /** Live recorder queue depth (analytics gauge, #168). O(1) counter read. */
+    public int queueDepth() {
+        return queue.size();
+    }
+
+    /** Cumulative records persisted to the store (analytics gauge, #168). */
+    public long drainedCount() {
+        return drained.get();
+    }
+
+    /** Cumulative records lost to shutdown-flush exhaustion (analytics gauge, #168). */
+    public long droppedCount() {
+        return dropped.get();
+    }
+
     @Override
     public void record(EventRecord record) {
         // Backpressure an off-main firehose (FAWE worker threads reach the
@@ -238,6 +267,11 @@ public final class AsyncRecorder implements Recorder {
         // the gate guarantees room the record always lands.
         awaitCapacityIfBlockable();
         queue.offer(record);
+        // Analytics intake count (#168): null unless analytics.enabled.
+        IngestStats stats = ingestStats;
+        if (stats != null) {
+            stats.onRecord(record.event());
+        }
         try {
             committedHook.accept(record);
         } catch (RuntimeException hookFailure) {
@@ -250,6 +284,15 @@ public final class AsyncRecorder implements Recorder {
     public void recordAll(List<EventRecord> records) {
         if (records.isEmpty()) {
             return;
+        }
+        // Analytics intake count (#168): tally every record in the bulk batch
+        // (WorldEdit/FAWE/rollback-audit) before it queues or spills, so the
+        // analytics view shows bulk-edit load too. Null unless analytics.enabled.
+        IngestStats stats = ingestStats;
+        if (stats != null) {
+            for (EventRecord record : records) {
+                stats.onRecord(record.event());
+            }
         }
         // Bulk intake for the WorldEdit build stage and the rollback audit
         // trail. The WorldEdit path is the firehose this whole ceiling exists

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/IngestStats.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/IngestStats.java
@@ -1,0 +1,134 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Opt-in ingest counters for the analytics mode (#168). When wired into the
+ * recorder via {@link AsyncRecorder#setIngestStats}, every recorded event
+ * increments a per-type counter; a {@link Snapshot} captures the cumulative
+ * counts plus live pipeline gauges, and two snapshots taken apart in time give
+ * per-second rates ({@link #describe}).
+ *
+ * <p>Cheap on the hot path: {@link #onRecord} is one concurrent-map lookup plus
+ * a {@link LongAdder} increment, with no allocation after a type is first seen.
+ * Counters are concurrent because records arrive from the main thread, the
+ * deferred-serializer pool, and WorldEdit/FAWE worker threads. The gauges are
+ * read through suppliers so this stays decoupled from the recorder and
+ * unit-testable headless.
+ */
+@ApiStatus.Internal
+public final class IngestStats {
+
+    private final ConcurrentHashMap<String, LongAdder> perType = new ConcurrentHashMap<>();
+    private final LongAdder total = new LongAdder();
+    private final IntSupplier queueDepth;
+    private final LongSupplier drained;
+    private final LongSupplier dropped;
+    private final LongSupplier allocatedBytes;
+
+    /**
+     * @param queueDepth     live recorder queue depth.
+     * @param drained        cumulative records persisted to the store.
+     * @param dropped        cumulative records lost (shutdown flush exhaustion).
+     * @param allocatedBytes cumulative bytes allocated by Spyglass background
+     *                       threads, or a constant negative value when the JVM
+     *                       can't report it (rendered as "n/a").
+     */
+    public IngestStats(IntSupplier queueDepth, LongSupplier drained,
+                       LongSupplier dropped, LongSupplier allocatedBytes) {
+        this.queueDepth = queueDepth;
+        this.drained = drained;
+        this.dropped = dropped;
+        this.allocatedBytes = allocatedBytes;
+    }
+
+    /**
+     * Production wiring: the allocation gauge is the built-in best-effort
+     * {@link ThreadAllocation} sampler (Spyglass background threads' churn, or
+     * n/a when the JVM can't report it). The four-arg constructor stays for
+     * tests that inject a deterministic allocation supplier.
+     */
+    public IngestStats(IntSupplier queueDepth, LongSupplier drained, LongSupplier dropped) {
+        this(queueDepth, drained, dropped, ThreadAllocation::spyglassAllocatedBytes);
+    }
+
+    /** Hot path: count one recorded event by its type name (e.g. "break"). */
+    public void onRecord(String eventType) {
+        String key = eventType == null || eventType.isEmpty() ? "?" : eventType;
+        perType.computeIfAbsent(key, k -> new LongAdder()).increment();
+        total.increment();
+    }
+
+    /** Immutable capture of the cumulative counters plus live gauges. */
+    public Snapshot capture(long nowNanos) {
+        Map<String, Long> counts = new TreeMap<>();
+        perType.forEach((k, v) -> counts.put(k, v.sum()));
+        return new Snapshot(nowNanos, total.sum(), counts,
+                queueDepth.getAsInt(), drained.getAsLong(),
+                dropped.getAsLong(), allocatedBytes.getAsLong());
+    }
+
+    /** Cumulative counters and gauges at one instant. */
+    public record Snapshot(long nanoTime, long total, Map<String, Long> counts,
+                           int queueDepth, long drained, long dropped, long allocatedBytes) {
+    }
+
+    /**
+     * Human-readable per-second report for the window between {@code prev} (the
+     * older snapshot) and {@code now}. Returns a summary line followed by one
+     * line per active event type, busiest first. Rates are over the window;
+     * gauges (queue depth, totals) are the latest values. A negative
+     * {@code allocatedBytes} renders the allocation figure as "n/a".
+     */
+    public static List<String> describe(Snapshot prev, Snapshot now) {
+        // Floor the window at 1s: a /spyglass stats issued microseconds after
+        // analytics is enabled would otherwise divide a few events by a tiny
+        // elapsed and print an absurd rate. The periodic reporter's windows are
+        // always >= the configured interval (>= 5s), so this never affects it.
+        double secs = Math.max(1.0, (now.nanoTime() - prev.nanoTime()) / 1_000_000_000.0);
+        double totalRate = (now.total() - prev.total()) / secs;
+        double drainRate = (now.drained() - prev.drained()) / secs;
+        String alloc = now.allocatedBytes() < 0
+                ? "n/a"
+                : String.format(Locale.ROOT, "%.1f MB/s",
+                        Math.max(0L, now.allocatedBytes() - prev.allocatedBytes()) / secs / 1_048_576.0);
+
+        List<String> lines = new ArrayList<>();
+        // Same %.1f precision on the headline as the per-type lines, so a sub-1/s
+        // rate never rounds to a "0" headline above non-zero detail.
+        lines.add(String.format(Locale.ROOT,
+                "ingest %.1f ev/s over %.0fs | queue=%d | persisted %.1f/s (total %d) | dropped %d | spyglass-threads alloc %s",
+                totalRate, secs, now.queueDepth(), drainRate, now.drained(), now.dropped(), alloc));
+
+        List<Map.Entry<String, Long>> byType = new ArrayList<>(now.counts().entrySet());
+        byType.sort((a, b) -> Long.compare(delta(b, prev), delta(a, prev)));
+        for (Map.Entry<String, Long> entry : byType) {
+            long count = delta(entry, prev);
+            if (count <= 0) {
+                continue;
+            }
+            // Show the rate AND the raw count for the window, so a low-traffic
+            // type that rounds to "0.0 /s" over a long window is still visibly
+            // distinct from a truly idle one.
+            lines.add(String.format(Locale.ROOT, "  %-24s %8.1f /s (%d)",
+                    entry.getKey(), count / secs, count));
+        }
+        if (lines.size() == 1) {
+            lines.add("  (no events recorded in this window)");
+        }
+        return lines;
+    }
+
+    private static long delta(Map.Entry<String, Long> entry, Snapshot prev) {
+        return entry.getValue() - prev.counts().getOrDefault(entry.getKey(), 0L);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsReporter.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsReporter.java
@@ -1,0 +1,54 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import java.util.List;
+import java.util.function.LongSupplier;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Periodic analytics reporter (#168). Scheduled by the plugin as a repeating
+ * async task; each run captures a fresh {@link IngestStats.Snapshot} and logs
+ * the per-second ingest rates over the window since its previous run, so the
+ * console shows a live load trail (events/sec by type, queue depth, drain
+ * throughput, background allocation rate).
+ *
+ * <p>Runs off the main thread: {@link IngestStats#capture} only reads
+ * concurrent counters and cheap gauges.
+ */
+@ApiStatus.Internal
+public final class IngestStatsReporter implements Runnable {
+
+    private final IngestStats stats;
+    private final Logger logger;
+    private final LongSupplier nanoTime;
+    // Written at the end of each run(), read at the start of the next. The async
+    // scheduler may run consecutive ticks on different pool threads, so volatile
+    // makes the cross-run handoff of this reference explicit (one ref write/run).
+    private volatile IngestStats.Snapshot last;
+
+    public IngestStatsReporter(IngestStats stats, Logger logger) {
+        this(stats, logger, System::nanoTime);
+    }
+
+    /** Visible for tests: inject a deterministic clock. */
+    IngestStatsReporter(IngestStats stats, Logger logger, LongSupplier nanoTime) {
+        this.stats = stats;
+        this.logger = logger;
+        this.nanoTime = nanoTime;
+        // Baseline at construction (analytics-enable time) so the first run
+        // reports rates over [enable, +interval], not since the JVM epoch.
+        this.last = stats.capture(nanoTime.getAsLong());
+    }
+
+    @Override
+    public void run() {
+        IngestStats.Snapshot now = stats.capture(nanoTime.getAsLong());
+        List<String> lines = IngestStats.describe(last, now);
+        StringBuilder out = new StringBuilder("Spyglass analytics: ").append(lines.get(0));
+        for (int i = 1; i < lines.size(); i++) {
+            out.append(System.lineSeparator()).append(lines.get(i));
+        }
+        logger.info(out.toString());
+        last = now;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/ThreadAllocation.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/ThreadAllocation.java
@@ -1,0 +1,111 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import com.sun.management.ThreadMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Locale;
+
+/**
+ * Best-effort sampler of cumulative bytes allocated by Spyglass's own
+ * background threads, for the analytics allocation-rate line (#168). A
+ * real-server spark profile flagged heavy async allocation on the storage write
+ * path, so this lets operators watch Spyglass's attributable churn from inside
+ * the plugin.
+ *
+ * <h2>Scope (read before trusting the number)</h2>
+ *
+ * It sums {@code getThreadAllocatedBytes} over live threads whose name starts
+ * (case-insensitively) with {@code spyglass-}: the ingest drain thread
+ * ({@code spyglass-drain}), the deferred-serializer pool
+ * ({@code spyglass-deferred-serializer-*}), and the rollback executors
+ * ({@code Spyglass-WorldWriter-*}, {@code Spyglass-RollbackRead}). It does
+ * <b>not</b> attribute:
+ * <ul>
+ *   <li>the storage driver's own internal threads (the ClickHouse HTTP client
+ *       pool, the Mongo driver pool) - so a backend that encodes/compresses on
+ *       its own threads will under-report here; cross-check spark for those;</li>
+ *   <li>WorldEdit/FAWE intake threads, which are owned by WorldEdit and cannot
+ *       be attributed to Spyglass.</li>
+ * </ul>
+ *
+ * <p>Returns {@code -1} when the JVM doesn't expose per-thread allocation
+ * accounting (non-HotSpot, or a restricted context); callers render that as
+ * "n/a". Read-only sampling. The periodic reporter calls it off the main thread;
+ * {@code /spyglass stats} reaches it on the main thread, where it does one
+ * bounded full-thread-table walk (acceptable for an operator-gated command).
+ */
+final class ThreadAllocation {
+
+    private static final ThreadMXBean BEAN = resolve();
+    private static final String PREFIX = "spyglass-";
+
+    private ThreadAllocation() {
+    }
+
+    private static ThreadMXBean resolve() {
+        try {
+            java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            if (bean instanceof ThreadMXBean sun && sun.isThreadAllocatedMemorySupported()) {
+                sun.setThreadAllocatedMemoryEnabled(true);
+                return sun;
+            }
+        } catch (RuntimeException | LinkageError unsupported) {
+            // Non-HotSpot JVM or restricted context: allocation accounting off.
+        }
+        return null;
+    }
+
+    /** Whether a thread name belongs to a Spyglass-owned background thread. */
+    static boolean isSpyglassThread(String name) {
+        return name != null && name.toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    /** Cumulative bytes allocated by live Spyglass-owned threads, or -1. */
+    static long spyglassAllocatedBytes() {
+        ThreadMXBean bean = BEAN;
+        if (bean == null) {
+            return -1L;
+        }
+        try {
+            long sum = 0L;
+            for (Thread thread : liveThreads()) {
+                if (thread != null && isSpyglassThread(thread.getName())) {
+                    long bytes = bean.getThreadAllocatedBytes(thread.threadId());
+                    if (bytes > 0L) {
+                        sum += bytes;
+                    }
+                }
+            }
+            return sum;
+        } catch (RuntimeException sampleFailure) {
+            return -1L;
+        }
+    }
+
+    /**
+     * Snapshot of the live threads. Re-enumerates into a larger array while the
+     * result saturates the buffer, so a thread count that grows mid-walk never
+     * silently truncates (the standard {@link ThreadGroup#enumerate} idiom).
+     */
+    private static Thread[] liveThreads() {
+        ThreadGroup root = rootGroup();
+        int size = root.activeCount() * 2 + 64;
+        while (true) {
+            Thread[] threads = new Thread[size];
+            int count = root.enumerate(threads, true);
+            if (count < threads.length) {
+                Thread[] exact = new Thread[count];
+                System.arraycopy(threads, 0, exact, 0, count);
+                return exact;
+            }
+            size *= 2; // saturated: the table grew past our buffer, retry larger.
+        }
+    }
+
+    private static ThreadGroup rootGroup() {
+        ThreadGroup group = Thread.currentThread().getThreadGroup();
+        while (group.getParent() != null) {
+            group = group.getParent();
+        }
+        return group;
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -219,6 +219,19 @@ metrics {
   enabled = true
 }
 
+analytics {
+  # Opt-in ingest analytics for tuning and capacity review. OFF by default,
+  # and when off it adds zero overhead. When on, Spyglass counts the events
+  # it records per second (broken down by type), tracks the recorder queue
+  # depth, how many records per second reach the database, any drops, and how
+  # much memory its own background threads are allocating - then logs a short
+  # report every `interval` and answers `/spyglass stats` on demand. This is
+  # local to your console/log; nothing is sent anywhere (that is `metrics`).
+  enabled = false
+  # How often the periodic report is logged. Floored at 5s.
+  interval = "60s"
+}
+
 events {
   # Per-event-type recording toggles and display verbs. enabled = false
   # stops Spyglass recording that event entirely: it won't appear in

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/StatsServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/StatsServiceTest.java
@@ -1,0 +1,41 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import net.kyori.adventure.text.Component;
+import net.medievalrp.spyglass.plugin.pipeline.IngestStats;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #168: /spyglass stats rendering. A null {@link IngestStats} (analytics off)
+ * sends one "disabled" message; an enabled stats object sends a header plus the
+ * snapshot lines.
+ */
+class StatsServiceTest {
+
+    @Test
+    void disabledStatsSendsASingleEnableHint() {
+        CommandSender sender = mock(CommandSender.class);
+        new StatsService(null).execute(sender);
+        verify(sender, times(1)).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void enabledStatsSendsHeaderPlusSnapshotLines() {
+        IngestStats stats = new IngestStats(() -> 3, () -> 42L, () -> 0L, () -> -1L);
+        stats.onRecord("break");
+        stats.onRecord("place");
+        StatsService service = new StatsService(stats);
+
+        CommandSender sender = mock(CommandSender.class);
+        service.execute(sender);
+
+        // Header + at least the summary line (>= 2 messages).
+        verify(sender, atLeast(2)).sendMessage(any(Component.class));
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -66,4 +66,42 @@ class SpyglassConfigTest {
 
         assertThat(SpyglassConfig.parseMetrics(root).enabled()).isTrue();
     }
+
+    // #168: analytics is opt-in (default off), with a 60s default interval
+    // floored at 5s.
+    @Test
+    void absentAnalyticsDefaultsToDisabledWith60sInterval() {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        SpyglassConfig.Analytics analytics = SpyglassConfig.parseAnalytics(root);
+        assertThat(analytics.enabled()).isFalse();
+        assertThat(analytics.interval().seconds()).isEqualTo(60L);
+    }
+
+    @Test
+    void explicitAnalyticsEnabledWithCustomInterval() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("analytics", "enabled").set(true);
+        root.node("analytics", "interval").set("30s");
+        SpyglassConfig.Analytics analytics = SpyglassConfig.parseAnalytics(root);
+        assertThat(analytics.enabled()).isTrue();
+        assertThat(analytics.interval().seconds()).isEqualTo(30L);
+    }
+
+    @Test
+    void tinyAnalyticsIntervalIsFlooredAtFiveSeconds() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("analytics", "enabled").set(true);
+        root.node("analytics", "interval").set("1s");
+        assertThat(SpyglassConfig.parseAnalytics(root).interval().seconds()).isEqualTo(5L);
+    }
+
+    @Test
+    void malformedAnalyticsIntervalFallsBackToSixtySeconds() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        root.node("analytics", "enabled").set(true);
+        root.node("analytics", "interval").set("nonsense");
+        // A typo in the interval must degrade to the 60s default, not abort the
+        // whole config load.
+        assertThat(SpyglassConfig.parseAnalytics(root).interval().seconds()).isEqualTo(60L);
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -43,6 +43,35 @@ class AsyncRecorderTest {
                 "127.0.0.1");
     }
 
+    /**
+     * #168: when an {@link IngestStats} is installed, both {@link
+     * AsyncRecorder#record} and {@link AsyncRecorder#recordAll} tally each
+     * intake by event type. Without it (the default), the hot path is unaffected
+     * (covered by every other test here, which never set it).
+     */
+    @Test
+    @Timeout(10)
+    void ingestStatsCountsRecordAndRecordAll() throws Exception {
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        IngestStats stats = new IngestStats(
+                recorder::queueDepth, recorder::drainedCount, recorder::droppedCount, () -> -1L);
+        recorder.setIngestStats(stats);
+        try {
+            recorder.record(sampleRecord());
+            recorder.record(sampleRecord());
+            recorder.recordAll(List.of(sampleRecord(), sampleRecord(), sampleRecord()));
+
+            IngestStats.Snapshot snap = stats.capture(0L);
+            assertThat(snap.total())
+                    .as("record() x2 + recordAll() of 3 = 5 intakes counted")
+                    .isEqualTo(5L);
+            assertThat(snap.counts()).containsEntry("join", 5L);
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
     @Test
     void drainsBatchesToStore() throws Exception {
         CapturingStore store = new CapturingStore();

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsReporterTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsReporterTest.java
@@ -1,0 +1,54 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #168: the periodic reporter captures a snapshot, describes the window since
+ * its previous run, and logs it. Driven with a deterministic clock so the rate
+ * math is exact.
+ */
+class IngestStatsReporterTest {
+
+    @Test
+    void runLogsAnIngestReportForTheWindow() {
+        IngestStats stats = new IngestStats(() -> 0, () -> 0L, () -> 0L, () -> -1L);
+        long[] clock = {1_000_000_000L};
+
+        List<String> logged = new ArrayList<>();
+        Logger logger = Logger.getLogger("ingest-reporter-test");
+        logger.setUseParentHandlers(false);
+        logger.addHandler(new Handler() {
+            @Override public void publish(LogRecord record) {
+                if (record.getLevel().intValue() >= Level.INFO.intValue()) {
+                    logged.add(record.getMessage());
+                }
+            }
+            @Override public void flush() { }
+            @Override public void close() { }
+        });
+
+        // Baseline captured at t=1s.
+        IngestStatsReporter reporter = new IngestStatsReporter(stats, logger, () -> clock[0]);
+
+        stats.onRecord("break");
+        stats.onRecord("break");
+        stats.onRecord("place");
+        clock[0] = 3_000_000_000L; // +2s window
+
+        reporter.run();
+
+        assertThat(logged).hasSize(1);
+        assertThat(logged.get(0))
+                .contains("Spyglass analytics:")
+                .contains("ingest")
+                .contains("break");
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/IngestStatsTest.java
@@ -1,0 +1,88 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #168: the opt-in analytics counter. Pins that {@link IngestStats#onRecord}
+ * tallies per type, {@link IngestStats#capture} reflects the counters plus the
+ * live gauges, and {@link IngestStats#describe} computes correct per-second
+ * rates over a window (busiest type first, allocation "n/a" when unsupported).
+ */
+class IngestStatsTest {
+
+    @Test
+    void onRecordTalliesPerTypeAndTotal() {
+        IngestStats stats = new IngestStats(() -> 7, () -> 100L, () -> 0L, () -> 12_345L);
+        stats.onRecord("break");
+        stats.onRecord("break");
+        stats.onRecord("break");
+        stats.onRecord("place");
+        stats.onRecord("place");
+
+        IngestStats.Snapshot snap = stats.capture(0L);
+        assertThat(snap.total()).isEqualTo(5L);
+        assertThat(snap.counts()).containsEntry("break", 3L).containsEntry("place", 2L);
+        // Gauges are read through the suppliers at capture time.
+        assertThat(snap.queueDepth()).isEqualTo(7);
+        assertThat(snap.drained()).isEqualTo(100L);
+        assertThat(snap.dropped()).isEqualTo(0L);
+        assertThat(snap.allocatedBytes()).isEqualTo(12_345L);
+    }
+
+    @Test
+    void nullOrEmptyEventTypeFoldsToQuestionMark() {
+        IngestStats stats = new IngestStats(() -> 0, () -> 0L, () -> 0L, () -> -1L);
+        stats.onRecord(null);
+        stats.onRecord("");
+        assertThat(stats.capture(0L).counts()).containsEntry("?", 2L);
+    }
+
+    @Test
+    void describeComputesPerSecondRatesBusiestFirst() {
+        IngestStats.Snapshot prev = new IngestStats.Snapshot(
+                0L, 0L, Map.of(), 0, 0L, 0L, 0L);
+        Map<String, Long> counts = new TreeMap<>();
+        counts.put("break", 120L);
+        counts.put("place", 80L);
+        long twoSeconds = 2_000_000_000L;
+        long allocAfter = (long) (2.0 * 28 * 1_048_576); // 28 MB/s over 2s
+        IngestStats.Snapshot now = new IngestStats.Snapshot(
+                twoSeconds, 200L, counts, 5, 150L, 0L, allocAfter);
+
+        List<String> lines = IngestStats.describe(prev, now);
+
+        assertThat(lines.get(0))
+                .contains("ingest 100.0 ev/s")
+                .contains("queue=5")
+                .contains("persisted 75.0/s (total 150)")
+                .contains("dropped 0")
+                .contains("28.0 MB/s");
+        // Busiest type first: break (60/s, 120 in window) before place (40/s, 80).
+        assertThat(lines.get(1)).contains("break").contains("60.0").contains("(120)");
+        assertThat(lines.get(2)).contains("place").contains("40.0").contains("(80)");
+        assertThat(lines).hasSize(3);
+    }
+
+    @Test
+    void describeRendersAllocationNotAvailableWhenNegative() {
+        IngestStats.Snapshot prev = new IngestStats.Snapshot(0L, 0L, Map.of(), 0, 0L, 0L, -1L);
+        IngestStats.Snapshot now = new IngestStats.Snapshot(
+                1_000_000_000L, 10L, Map.of("chat", 10L), 0, 10L, 0L, -1L);
+        List<String> lines = IngestStats.describe(prev, now);
+        assertThat(lines.get(0)).contains("alloc n/a");
+    }
+
+    @Test
+    void describeReportsAnEmptyWindowExplicitly() {
+        IngestStats.Snapshot a = new IngestStats.Snapshot(0L, 0L, Map.of(), 0, 0L, 0L, 0L);
+        IngestStats.Snapshot b = new IngestStats.Snapshot(1_000_000_000L, 0L, Map.of(), 0, 0L, 0L, 0L);
+        List<String> lines = IngestStats.describe(a, b);
+        assertThat(lines).hasSize(2);
+        assertThat(lines.get(1)).contains("no events");
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/ThreadAllocationTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/ThreadAllocationTest.java
@@ -1,0 +1,40 @@
+package net.medievalrp.spyglass.plugin.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * #168: the allocation sampler attributes Spyglass-owned background threads by a
+ * case-insensitive {@code spyglass-} name prefix, so both the lowercase ingest
+ * threads ({@code spyglass-drain}, {@code spyglass-deferred-serializer-*}) and
+ * the capital-S rollback executors ({@code Spyglass-WorldWriter-*},
+ * {@code Spyglass-RollbackRead}) are counted. Foreign threads are not.
+ */
+class ThreadAllocationTest {
+
+    @Test
+    void matchesSpyglassOwnedThreadsCaseInsensitively() {
+        assertThat(ThreadAllocation.isSpyglassThread("spyglass-drain")).isTrue();
+        assertThat(ThreadAllocation.isSpyglassThread("spyglass-deferred-serializer-3")).isTrue();
+        assertThat(ThreadAllocation.isSpyglassThread("Spyglass-WorldWriter-1")).isTrue();
+        assertThat(ThreadAllocation.isSpyglassThread("Spyglass-RollbackRead")).isTrue();
+    }
+
+    @Test
+    void doesNotMatchForeignThreads() {
+        assertThat(ThreadAllocation.isSpyglassThread("Server thread")).isFalse();
+        assertThat(ThreadAllocation.isSpyglassThread("ForkJoinPool-1-worker-1")).isFalse();
+        assertThat(ThreadAllocation.isSpyglassThread("Netty Server IO #2")).isFalse();
+        assertThat(ThreadAllocation.isSpyglassThread(null)).isFalse();
+        assertThat(ThreadAllocation.isSpyglassThread("")).isFalse();
+    }
+
+    @Test
+    void spyglassAllocatedBytesReturnsMinusOneOrNonNegative() {
+        // Either the JVM doesn't support per-thread allocation (-1) or it returns
+        // a non-negative sum. Never throws, never a stray negative.
+        long bytes = ThreadAllocation.spyglassAllocatedBytes();
+        assertThat(bytes).isGreaterThanOrEqualTo(-1L);
+    }
+}


### PR DESCRIPTION
Closes #168.

## What

An **opt-in** ingest analytics mode. Off by default (zero hot-path overhead); enable with `analytics.enabled = true`.

When on, Spyglass:
- counts the events it records **per second, by type**;
- tracks recorder **queue depth**, **persist rate** (records/s reaching the store), and **drops**;
- reports the allocation rate of its own background threads (best-effort);
- logs a periodic console report every `analytics.interval` (default 60s, floored 5s);
- answers **`/spyglass stats`** on demand.

Example report line:
```
[Spyglass] Spyglass analytics: ingest 0.8 ev/s over 5s | queue=0 | persisted 0.8/s (total 25) | dropped 0 | spyglass-threads alloc 0.0 MB/s
```

## How

- `IngestStats` - per-type counters + a snapshot/rate model (pure, unit-tested).
- `AsyncRecorder` - an optional counting hook at the single `record()` / `recordAll()` chokepoint (a `volatile` read + null check when off, mirroring the existing `committedHook`), plus `queueDepth()` / `drainedCount()` / `droppedCount()` gauges.
- `ThreadAllocation` - best-effort per-thread allocation sum over Spyglass-owned threads (case-insensitive `spyglass-` prefix). Excludes the storage driver's internal threads (ClickHouse/Mongo client pools), so cross-check spark for those; renders `n/a` when the JVM can't report allocation.
- `IngestStatsReporter` - async periodic report.
- `StatsService` + the `/spyglass stats` command.
- `config.conf`: `analytics { enabled = false, interval = "60s" }`.

## Compatibility

- Opt-in: a new top-level config section. Existing configs without it default to **off** (absent-key default), so upgrades are no-ops until an operator turns it on.
- No change to the default (analytics-off) ingest path.

## Testing

- Unit tests: counters, rate math + rendering edges (sub-1/s precision, empty window, allocation n/a), the case-insensitive thread matcher, config parsing (default / explicit / 5s floor / malformed-interval fallback), and the recorder counting hook.
- `./gradlew check` passes (jacoco floors hold).
- Verified live in-game on an isolated SQLite server: real break/place events surface in both `/spyglass stats` and the periodic console report.
- Adversarial diff review (4 lenses) run pre-merge; findings addressed.