### PR TITLE
feat(storage): add a MariaDB / MySQL record-store backend (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Proudly sponsored by and running on:
 
 ## Performance
 
-A 2,000,376-block rollback, measured five ways: Spyglass on each of its three backends and CoreProtect on both of theirs, on one server (Paper 1.21.8, 6 GB heap, stock Aikar flags).
+A 2,000,376-block rollback on Spyglass (ClickHouse) versus CoreProtect (MySQL), on one server (Paper 1.21.8, 6 GB heap, stock Aikar flags).
 
-| 2M-block rollback | Spyglass · ClickHouse | Spyglass · MongoDB | Spyglass · SQLite | CoreProtect · SQLite | CoreProtect · MySQL |
-|---|---|---|---|---|---|
-| Rollback wall-clock | ~5 s | ~7 s | **~3 s** | ~11 s | ~12 s |
-| Undo / restore wall-clock | ~4 s | ~6 s | **~3 s** | ~9 s | ~210 s |
-| TPS during the op (min / avg) | **20.0 / 20.0** | **20.0 / 20.0** | **20.0 / 20.0** | 14 / 19 | 13 / 20 |
-| Worst single tick | ~50 ms | ~100 ms | **~37 ms** | ~670 ms | ~270 ms |
-| On-disk footprint (data + index) | **~11 MiB** | ~145 MiB | ~156 MiB | ~160 MiB | ~180 MiB |
+| 2M-block rollback | Spyglass · ClickHouse | CoreProtect · MySQL |
+|---|---|---|
+| Rollback wall-clock | **~5 s** | ~12 s |
+| Undo / restore wall-clock | **~4 s** | ~10 s |
+| TPS during the op (min / avg) | **20.0 / 20.0** | 13 / 20 |
+| Worst single tick | **~50 ms** | ~270 ms |
+| On-disk footprint (data + index) | **~11 MiB** | ~180 MiB |
 
 A live [spark profile](https://spark.lucko.me/5JzJrfOmaM) of Spyglass running in production on [Crusalis](https://crusalis.net), with 1,000 players online at the time.
 
-> **Why MongoDB?** the60th asks me the same question. I really just like using MongoDB. Although we recommend servers utilize ClickHouse for performance and efficient disk space usage. MySQL will not come to Spyglass. 
+> **Why MongoDB?** the60th asks me the same question. I really just like using MongoDB. Although we recommend servers utilize ClickHouse for performance and efficient disk space usage. MariaDB and MySQL are supported now too, for servers that already run one.
 
 ## Features
 
@@ -65,10 +65,10 @@ A live [spark profile](https://spark.lucko.me/5JzJrfOmaM) of Spyglass running in
 | TPS during a 2M rollback | **20.0, flat** | dips to ~13 |
 | Worst single tick | **~100 ms** | up to ~900 ms |
 | Automatic data pruning | ✓ |  |
-| Storage engines | SQLite, MongoDB, ClickHouse | SQLite, MySQL |
+| Storage engines | SQLite, MongoDB, ClickHouse, MariaDB/MySQL | SQLite, MySQL |
 | Minecraft versions | 1.21.x | 1.7+ |
 
-Spyglass runs on SQLite, MongoDB, or ClickHouse. The embedded SQLite backend needs no external database, so the zero-ops install CoreProtect offers is available on Spyglass too; MongoDB and ClickHouse are there when you outgrow it.
+Spyglass runs on SQLite, MongoDB, ClickHouse, or MariaDB/MySQL. The embedded SQLite backend needs no external database, so the zero-ops install CoreProtect offers is available on Spyglass too; MongoDB, ClickHouse, and MariaDB/MySQL are there when you outgrow it or already run one.
 
 ## Requirements
 
@@ -78,6 +78,7 @@ Spyglass runs on SQLite, MongoDB, or ClickHouse. The embedded SQLite backend nee
   - Embedded SQLite, no external database (the default); writes to a file under the plugin folder
   - MongoDB (set `database.backend = "mongo"`) at `mongodb://localhost:27017`
   - ClickHouse (set `database.backend = "clickhouse"`)
+  - MariaDB or MySQL (set `database.backend = "mariadb"`, or `"mysql"`) at `localhost:3306`
 - Optional: WorldEdit 7.3+ or FastAsyncWorldEdit 2.15+ for WorldEdit-edit capture and `-we` queries. Capture hooks the edit-session pipeline, not command names, so every block-mutating operation is recorded - `//set`, `//replace`, `//walls`, `//overlay`, `//paste`, schematic paste, brushes, generation, `//move`/`//stack`, and `//undo`/`//redo` alike - for player and non-player (console/plugin) edits
 
 ## Commands

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ val velocityApiVersion = "3.4.0-SNAPSHOT"
 val mongoDriverVersion = "5.5.0"
 val clickhouseClientVersion = "0.9.8"
 val sqliteJdbcVersion = "3.50.1.0"
+// MariaDB Connector/J (LGPL-2.1) speaks both the MariaDB and MySQL wire
+// protocols, so one driver serves backend = "mariadb" and "mysql" alike.
+val mariaDbDriverVersion = "3.5.6"
 val configurateVersion = "4.2.0"
 val cloudMinecraftVersion = "2.0.0-beta.16"
 val cloudCoreVersion = "2.0.0"
@@ -149,6 +152,7 @@ extra.apply {
     set("mongoDriverVersion", mongoDriverVersion)
     set("clickhouseClientVersion", clickhouseClientVersion)
     set("sqliteJdbcVersion", sqliteJdbcVersion)
+    set("mariaDbDriverVersion", mariaDbDriverVersion)
     set("configurateVersion", configurateVersion)
     set("cloudMinecraftVersion", cloudMinecraftVersion)
     set("cloudCoreVersion", cloudCoreVersion)

--- a/spyglass-core/build.gradle.kts
+++ b/spyglass-core/build.gradle.kts
@@ -6,6 +6,7 @@ val paperApiVersion: String by rootProject.extra
 val mongoDriverVersion: String by rootProject.extra
 val clickhouseClientVersion: String by rootProject.extra
 val sqliteJdbcVersion: String by rootProject.extra
+val mariaDbDriverVersion: String by rootProject.extra
 val junitVersion: String by rootProject.extra
 val assertjVersion: String by rootProject.extra
 val mockitoVersion: String by rootProject.extra
@@ -58,6 +59,13 @@ dependencies {
     // store directly, mirroring the Mongo / ClickHouse drivers above.
     api("org.xerial:sqlite-jdbc:$sqliteJdbcVersion")
 
+    // MariaDB / MySQL backend (#169): the client-server SQL store for
+    // operators who already run a MariaDB or MySQL server. MariaDB
+    // Connector/J speaks both wire protocols, so one driver serves
+    // backend = "mariadb" and "mysql". Exposed as `api` like the other
+    // drivers so the plugin + proxy construct the store directly.
+    api("org.mariadb.jdbc:mariadb-java-client:$mariaDbDriverVersion")
+
     testImplementation(project(":spyglass-api"))
     testImplementation("io.papermc.paper:paper-api:$paperApiVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
@@ -67,6 +75,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
     testImplementation("org.testcontainers:mongodb:$testcontainersVersion")
     testImplementation("org.testcontainers:clickhouse:$testcontainersVersion")
+    testImplementation("org.testcontainers:mariadb:$testcontainersVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -80,7 +89,7 @@ tasks.test {
     // exercise. Run via `./gradlew :spyglass-core:clickhouseBench` /
     // `:spyglass-core:sqliteBench`.
     useJUnitPlatform {
-        excludeTags("bench", "ch-bench", "sqlite-bench")
+        excludeTags("bench", "ch-bench", "sqlite-bench", "mariadb-bench")
     }
     finalizedBy(tasks.named("jacocoTestReport"))
 }
@@ -103,6 +112,33 @@ tasks.register<Test>("sqliteBench") {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
     maxHeapSize = "4g"
+    for ((key, value) in System.getProperties()) {
+        val name = key.toString()
+        if (name.startsWith("SG_BENCH_")) {
+            systemProperty(name, value.toString())
+        }
+    }
+}
+
+tasks.register<Test>("mariadbBench") {
+    description = "Spyglass·MariaDB disk + rollback-read benchmark (#169; requires Docker)."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("mariadb-bench")
+    }
+    extensions.configure<JacocoTaskExtension> {
+        isEnabled = false
+    }
+    testLogging {
+        events("started", "passed", "failed", "standard_out")
+        showStandardStreams = true
+        showExceptions = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+    maxHeapSize = "4g"
+    systemProperty("org.slf4j.simpleLogger.defaultLogLevel", "warn")
     for ((key, value) in System.getProperties()) {
         val name = key.toString()
         if (name.startsWith("SG_BENCH_")) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbPredicateToSql.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbPredicateToSql.java
@@ -1,0 +1,267 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Translates a list of {@link QueryPredicate} into a self-contained SQL
+ * WHERE fragment for the {@link MariaDbRecordStore} schema.
+ *
+ * <p>Structurally identical to {@link SqlitePredicateToSql} - the MariaDB
+ * store reuses the same palette-interned, hybrid schema, so high-cardinality
+ * strings / UUIDs are resolved to their small integer palette id <em>up
+ * front</em> via {@link Palette} and that integer is inlined. The same three
+ * consequences hold: no SQL string-escaping surface (only resolved ints reach
+ * the SQL text), an un-interned literal compiles to a constant-false {@code 0},
+ * and a regex against an interned column raises {@link
+ * UnsupportedPredicateException} so the store post-filters it in memory.
+ *
+ * <p>The one dialect difference from the SQLite translator is the chunk
+ * bucket. SQLite seeks its location index with an inline expression
+ * ({@code x>>4}); MariaDB / MySQL can't index an inline expression portably,
+ * so {@link MariaDbRecordStore} materializes the bucket as virtual generated
+ * columns {@code cx = FLOOR(x/16)} / {@code cz = FLOOR(z/16)} and indexes
+ * those. So a coordinate range bounds {@code cx} / {@code cz} directly (a
+ * plain column compare the planner seeks), with the bound computed by
+ * {@link Math#floorDiv}, which matches {@code FLOOR(coord/16)} for negatives
+ * too. The exact x/z clauses still filter within the seeked chunks, so results
+ * are identical.
+ */
+@ApiStatus.Internal
+final class MariaDbPredicateToSql {
+
+    /** Read-side palette resolution. {@code null} means "not interned". */
+    interface Palette {
+        Integer dictId(String value);
+
+        Integer uuidId(UUID value);
+    }
+
+    static final class UnsupportedPredicateException extends RuntimeException {
+        UnsupportedPredicateException(String message) {
+            super(message);
+        }
+    }
+
+    /** How a column's literal is resolved before it's inlined. */
+    private enum Kind {
+        /** {@code seq} primary key - value is the {@link EventIds} sequence of a UUID. */
+        SEQ,
+        /** A {@code dict} string reference. */
+        DICT,
+        /** A {@code uuids} reference. */
+        UUID_REF,
+        /** Epoch-seconds timestamp column. */
+        INSTANT_SEC,
+        /** Plain signed integer column (coordinates). */
+        INT
+    }
+
+    private record Col(String name, Kind kind) {
+    }
+
+    // Only the indexed / filterable scalar paths map to a column. Deep paths
+    // into the per-event payload (item.name, message, beforeItem.lore,
+    // source.entityType, ...) have no column and raise Unsupported, so they
+    // fall to the in-memory post-filter against the decoded record.
+    private static final Map<String, Col> COLUMNS = Map.ofEntries(
+            Map.entry("id", new Col("seq", Kind.SEQ)),
+            Map.entry("event", new Col("event", Kind.DICT)),
+            Map.entry("occurred", new Col("occurred", Kind.INSTANT_SEC)),
+            Map.entry("origin.kind", new Col("origin_kind", Kind.DICT)),
+            Map.entry("source.playerId", new Col("player", Kind.UUID_REF)),
+            Map.entry("location.worldId", new Col("world", Kind.UUID_REF)),
+            Map.entry("location.x", new Col("x", Kind.INT)),
+            Map.entry("location.y", new Col("y", Kind.INT)),
+            Map.entry("location.z", new Col("z", Kind.INT)),
+            Map.entry("server", new Col("server", Kind.DICT)),
+            Map.entry("target", new Col("target", Kind.DICT)));
+
+    private final Palette palette;
+
+    MariaDbPredicateToSql(Palette palette) {
+        this.palette = palette;
+    }
+
+    /** Translate a top-level AND list; empty input yields the empty string. */
+    String translate(List<QueryPredicate> predicates) {
+        if (predicates.isEmpty()) {
+            return "";
+        }
+        if (predicates.size() == 1) {
+            return translate(predicates.get(0));
+        }
+        StringBuilder sql = new StringBuilder("(");
+        for (int i = 0; i < predicates.size(); i++) {
+            if (i > 0) {
+                sql.append(" AND ");
+            }
+            sql.append(translate(predicates.get(i)));
+        }
+        return sql.append(")").toString();
+    }
+
+    private String translate(QueryPredicate predicate) {
+        return switch (predicate) {
+            case QueryPredicate.Eq eq -> translateEq(col(eq.field()), eq.field(), eq.value());
+            case QueryPredicate.In in -> translateIn(col(in.field()), in.values());
+            case QueryPredicate.Range range -> translateRange(range);
+            case QueryPredicate.Exists exists -> translateExists(col(exists.field()), exists.expected());
+            case QueryPredicate.Not not -> "(NOT " + translate(not.predicate()) + ")";
+            case QueryPredicate.And and -> translateGroup("AND", and.predicates());
+            case QueryPredicate.Or or -> translateGroup("OR", or.predicates());
+        };
+    }
+
+    private String translateGroup(String op, List<QueryPredicate> children) {
+        if (children.isEmpty()) {
+            return "AND".equals(op) ? "1" : "0";
+        }
+        StringBuilder sb = new StringBuilder("(");
+        for (int i = 0; i < children.size(); i++) {
+            if (i > 0) {
+                sb.append(" ").append(op).append(" ");
+            }
+            sb.append(translate(children.get(i)));
+        }
+        return sb.append(")").toString();
+    }
+
+    private String translateEq(Col col, String field, Object value) {
+        if (value instanceof Pattern) {
+            // A regex can't run against an interned int column; evaluate it
+            // in memory against the decoded record instead.
+            throw new UnsupportedPredicateException(
+                    "MariaDB backend cannot push a regex match on interned column '" + field + "'.");
+        }
+        Long resolved = resolve(col, value);
+        // A literal absent from the palette can't match any row.
+        return resolved == null ? "0" : col.name() + " = " + resolved;
+    }
+
+    private String translateIn(Col col, List<?> values) {
+        List<Long> ids = new ArrayList<>(values.size());
+        for (Object value : values) {
+            if (value instanceof Pattern) {
+                throw new UnsupportedPredicateException(
+                        "MariaDB backend cannot push a regex match in an IN clause on '" + col.name() + "'.");
+            }
+            Long resolved = resolve(col, value);
+            if (resolved != null) {
+                ids.add(resolved);
+            }
+        }
+        if (ids.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder(col.name()).append(" IN (");
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(ids.get(i));
+        }
+        return sb.append(")").toString();
+    }
+
+    private String translateRange(QueryPredicate.Range range) {
+        Col col = col(range.field());
+        if (col.kind() != Kind.INSTANT_SEC && col.kind() != Kind.INT) {
+            // Ranges only make sense on ordered numeric columns; an
+            // interned-string/uuid range is meaningless.
+            throw new UnsupportedPredicateException(
+                    "MariaDB backend cannot range over column '" + col.name() + "'.");
+        }
+        List<String> clauses = new ArrayList<>(4);
+        Long lower = scalar(col, range.lowerInclusive());
+        Long upper = scalar(col, range.upperInclusive());
+        if (lower != null) {
+            clauses.add(col.name() + " >= " + lower);
+        }
+        if (upper != null) {
+            clauses.add(col.name() + " <= " + upper);
+        }
+        // Let a block-coordinate range also seek the chunk-bucketed location
+        // index by bounding its chunk column (cx / cz). Those are virtual
+        // generated columns FLOOR(x/16) / FLOOR(z/16), so floorDiv(coord,16)
+        // is the exact bucket, negatives included.
+        String chunkCol = chunkColumnFor(col.name());
+        if (chunkCol != null) {
+            if (range.lowerInclusive() instanceof Number n) {
+                clauses.add(chunkCol + " >= " + Math.floorDiv(n.longValue(), 16));
+            }
+            if (range.upperInclusive() instanceof Number n) {
+                clauses.add(chunkCol + " <= " + Math.floorDiv(n.longValue(), 16));
+            }
+        }
+        if (clauses.isEmpty()) {
+            return "1";
+        }
+        if (clauses.size() == 1) {
+            return clauses.get(0);
+        }
+        return "(" + String.join(" AND ", clauses) + ")";
+    }
+
+    private String translateExists(Col col, boolean expected) {
+        return expected ? "(" + col.name() + " IS NOT NULL)" : "(" + col.name() + " IS NULL)";
+    }
+
+    private static String chunkColumnFor(String column) {
+        if ("x".equals(column)) {
+            return "cx";
+        }
+        if ("z".equals(column)) {
+            return "cz";
+        }
+        return null;
+    }
+
+    // Resolve an equality/IN literal to the long that the column stores.
+    // Returns null when a palette literal isn't interned (no such row).
+    private Long resolve(Col col, Object value) {
+        return switch (col.kind()) {
+            case SEQ -> value instanceof UUID uuid
+                    ? EventIds.sequenceOf(uuid)
+                    : ((Number) value).longValue();
+            case INT -> ((Number) value).longValue();
+            case INSTANT_SEC -> ((Instant) value).getEpochSecond();
+            case DICT -> {
+                Integer id = palette.dictId(String.valueOf(value));
+                yield id == null ? null : id.longValue();
+            }
+            case UUID_REF -> {
+                Integer id = palette.uuidId((UUID) value);
+                yield id == null ? null : id.longValue();
+            }
+        };
+    }
+
+    // Scalar bound for a range - only INSTANT_SEC / INT reach here.
+    private static Long scalar(Col col, Object bound) {
+        if (bound == null) {
+            return null;
+        }
+        return col.kind() == Kind.INSTANT_SEC
+                ? ((Instant) bound).getEpochSecond()
+                : ((Number) bound).longValue();
+    }
+
+    private static Col col(String fieldPath) {
+        Col col = COLUMNS.get(fieldPath);
+        if (col == null) {
+            throw new UnsupportedPredicateException(
+                    "MariaDB backend cannot filter on field '" + fieldPath
+                            + "': it lives in the per-event payload and isn't a column "
+                            + "(evaluated in memory against the decoded record instead).");
+        }
+        return col;
+    }
+}

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -1,0 +1,1293 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.EventCatalog;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.Rollbackable;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * MariaDB / MySQL {@link RecordStore} - the client-server SQL backend
+ * (#169) for operators who already run a MariaDB or MySQL server.
+ *
+ * <h2>Same density design as SQLite (#106), one server engine apart</h2>
+ *
+ * This store is a deliberate fork of {@link SqliteRecordStore}: the dense
+ * schema is what beats CoreProtect, and there is no reason to invent a
+ * second one. Every lever carries over:
+ *
+ * <ol>
+ *   <li><b>Palette interning.</b> Block-data strings, event / server names
+ *       live once in a {@code dict} table; world and player UUIDs (with
+ *       display names) live once in a {@code uuids} table. Each
+ *       {@code records} row holds small integer references.</li>
+ *   <li><b>Hybrid schema.</b> A clean, player-sourced, no-tile-entity block
+ *       edit lives entirely in columns - no payload. Everything else carries
+ *       one {@code deflate(BSON(record))} blob ({@link BsonBlobs}) in the
+ *       {@code payload} column, decoded only when that row is read. The lean
+ *       rollback never touches it.</li>
+ *   <li><b>seq IS the sort key.</b> The {@link EventIds} sequence is the
+ *       {@code BIGINT} primary key, co-monotonic with {@code occurred}, so
+ *       the store sorts / keysets on {@code seq} alone - no time index.</li>
+ *   <li><b>Derived / folded columns.</b> Material recovered from block-data,
+ *       names from the uuids palette, {@code source.kind} always
+ *       {@code player}, {@code expiresAt = occurred + retention}. The chunk
+ *       bucket is two <em>virtual generated</em> columns ({@code cx =
+ *       FLOOR(x/16)}, {@code cz = FLOOR(z/16)}) - no row storage, only the
+ *       location index materializes them - because MariaDB / MySQL can't
+ *       portably index an inline expression the way SQLite does.</li>
+ * </ol>
+ *
+ * <h2>Engine</h2>
+ *
+ * InnoDB. One batched writer (the recorder, off the main thread) commits a
+ * drain under a single transaction, with {@code rewriteBatchedStatements}
+ * folding the batch into one multi-row INSERT; a small pool of read
+ * connections serves search / rollback. Retention is a periodic
+ * {@code DELETE ... WHERE occurred < now - retention} since neither engine
+ * has a native row TTL.
+ *
+ * <p>One driver - MariaDB Connector/J - speaks both the MariaDB and MySQL
+ * wire protocols, so this single store backs {@code backend = "mariadb"} and
+ * {@code "mysql"} alike.
+ */
+@ApiStatus.Internal
+public final class MariaDbRecordStore implements RecordStore {
+
+    private static final Logger LOGGER = Logger.getLogger(MariaDbRecordStore.class.getName());
+
+    // The MariaDB JDBC driver self-registers with DriverManager only when its
+    // class is loaded. In the lean (library-loaded) jar the driver lives in
+    // Paper's isolated library classloader, which DriverManager's one-time
+    // system-classloader ServiceLoader scan never sees - so a bare
+    // getConnection() would throw "No suitable driver". Force the class load
+    // here, from a classloader this store can reach, so the driver registers.
+    // Harmless in the shaded / test jars (the driver is already on this
+    // classloader); this just makes the load order explicit.
+    static {
+        try {
+            Class.forName("org.mariadb.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(
+                    "MariaDB JDBC driver (org.mariadb.jdbc.Driver) is not on the classpath; "
+                            + "the mariadb-java-client library failed to load");
+        }
+    }
+
+    private static final int DEFAULT_READ_POOL = 4;
+    private static final long DEFAULT_RETENTION_SECONDS = 28L * 24 * 3600; // 4 weeks
+    private static final long RETENTION_SWEEP_MINUTES = 60L;
+    private static final int POST_FILTER_SCAN_CAP = 20_000;
+
+    // 14 columns, in bind order. Notably absent (folded / derived / generated,
+    // see the class doc): expires_at, source_kind, player_name, world_name,
+    // origin_detail, cx / cz, and per-side block materials.
+    private static final String INSERT_SQL = "INSERT IGNORE INTO records ("
+            + "seq, event, occurred, origin_kind, player, world, x, y, z, "
+            + "server, target, orig_block, new_block, payload) "
+            + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+
+    private static final String DECODE_COLUMNS =
+            "seq, event, occurred, origin_kind, player, world, x, y, z, "
+            + "server, target, orig_block, new_block, payload";
+
+    private final String baseUrl;       // jdbc:mariadb://host:port/db?params
+    private final String bootstrapUrl;   // jdbc:mariadb://host:port/?params (no schema)
+    private final String database;
+    private final String user;
+    private final String password;
+    private final boolean readOnly;
+    private final long retentionSeconds;
+
+    private final Connection writeConn;
+    private final Object writeLock = new Object();
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement dictInsert;
+    private final PreparedStatement uuidInsert;
+
+    private final BlockingQueue<Connection> readPool;
+    private final List<Connection> allConnections = new ArrayList<>();
+    // Dedicated connection for palette reverse-lookups on a cache miss -
+    // separate from the query read pool so a miss inside a decode loop that
+    // already holds a pooled connection can't deadlock it.
+    private final Connection lookupConn;
+    private final Object lookupLock = new Object();
+
+    // Palette caches - forward (intern) and reverse (resolve). Loaded whole on
+    // open; the single writer keeps them current.
+    private final ConcurrentHashMap<String, Integer> dictForward = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> dictReverse = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Integer> uuidForward = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, UUID> uuidReverse = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> uuidName = new ConcurrentHashMap<>();
+
+    private final Set<String> rollbackableEvents;
+    private final Set<String> chatEvents;
+
+    private final MariaDbPredicateToSql.Palette palette = new MariaDbPredicateToSql.Palette() {
+        @Override
+        public Integer dictId(String value) {
+            return resolveDictId(value);
+        }
+
+        @Override
+        public Integer uuidId(UUID value) {
+            return resolveUuidId(value);
+        }
+    };
+    private final MariaDbPredicateToSql predicateToSql = new MariaDbPredicateToSql(palette);
+
+    private final ScheduledExecutorService retention;
+
+    public MariaDbRecordStore(String host, int port, String database, String user,
+                              String password, boolean ssl, long retentionSeconds) {
+        this(host, port, database, user, password, ssl, false, DEFAULT_READ_POOL, retentionSeconds);
+    }
+
+    public MariaDbRecordStore(String host, int port, String database, String user,
+                              String password, boolean ssl, boolean readOnly) {
+        this(host, port, database, user, password, ssl, readOnly, DEFAULT_READ_POOL,
+                DEFAULT_RETENTION_SECONDS);
+    }
+
+    public MariaDbRecordStore(String host, int port, String database, String user,
+                              String password, boolean ssl, boolean readOnly,
+                              int readPoolSize, long retentionSeconds) {
+        this.database = validateIdentifier(database);
+        this.user = user;
+        this.password = password;
+        this.readOnly = readOnly;
+        this.retentionSeconds = retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS;
+        // rewriteBatchedStatements folds the drain's addBatch into one
+        // multi-row INSERT (the throughput lever); sslMode=trust encrypts an
+        // ssl=true connection without demanding a verified CA (operators on a
+        // private network), sslMode=disable is plain.
+        String params = "?rewriteBatchedStatements=true&connectTimeout=10000&socketTimeout=0&sslMode="
+                + (ssl ? "trust" : "disable");
+        this.bootstrapUrl = "jdbc:mariadb://" + host + ":" + port + "/" + params;
+        this.baseUrl = "jdbc:mariadb://" + host + ":" + port + "/" + this.database + params;
+        this.rollbackableEvents = rollbackableEventNames();
+        this.chatEvents = EventCatalog.eventsStoredAs(ChatRecord.class);
+        try {
+            if (!readOnly) {
+                createDatabaseIfMissing();
+            }
+            this.writeConn = open(false);
+            if (readOnly) {
+                this.insertStatement = null;
+                this.dictInsert = null;
+                this.uuidInsert = null;
+            } else {
+                ensureSchema(writeConn);
+                this.insertStatement = writeConn.prepareStatement(INSERT_SQL);
+                // Idempotent insert-or-get: a value already in the palette
+                // table (e.g. re-interned on the recorder's retry-after-failure
+                // path, or by a value present from a prior run) resolves to its
+                // existing id via LAST_INSERT_ID instead of throwing a
+                // duplicate-key. Without this, a transient save failure + retry
+                // would re-insert an already-committed palette value and fail
+                // on UNIQUE(val) / UNIQUE(hi,lo). getGeneratedKeys returns the
+                // id whether the row was inserted or matched.
+                this.dictInsert = writeConn.prepareStatement(
+                        "INSERT INTO dict(val) VALUES (?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)",
+                        Statement.RETURN_GENERATED_KEYS);
+                this.uuidInsert = writeConn.prepareStatement(
+                        "INSERT INTO uuids(hi, lo, name) VALUES (?, ?, ?) "
+                                + "ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)",
+                        Statement.RETURN_GENERATED_KEYS);
+            }
+
+            int poolSize = Math.max(1, readPoolSize);
+            this.readPool = new ArrayBlockingQueue<>(poolSize);
+            for (int i = 0; i < poolSize; i++) {
+                Connection read = open(true);
+                allConnections.add(read);
+                readPool.add(read);
+            }
+            this.lookupConn = open(true);
+            allConnections.add(lookupConn);
+            loadPalette();
+        } catch (SQLException ex) {
+            throw new RuntimeException("Failed to open MariaDB store at " + baseUrl
+                    + ": " + ex.getMessage(), ex);
+        }
+
+        if (readOnly) {
+            this.retention = null;
+        } else {
+            this.retention = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "spyglass-mariadb-retention");
+                t.setDaemon(true);
+                return t;
+            });
+            this.retention.scheduleWithFixedDelay(this::pruneExpiredQuietly,
+                    RETENTION_SWEEP_MINUTES, RETENTION_SWEEP_MINUTES, TimeUnit.MINUTES);
+            pruneExpiredQuietly();
+        }
+    }
+
+    // ===== Connection / schema =================================
+
+    private Connection open(boolean asReadOnly) throws SQLException {
+        Properties props = new Properties();
+        if (user != null) {
+            props.setProperty("user", user);
+        }
+        if (password != null) {
+            props.setProperty("password", password);
+        }
+        Connection conn = DriverManager.getConnection(baseUrl, props);
+        if (asReadOnly) {
+            conn.setReadOnly(true);
+        }
+        return conn;
+    }
+
+    /**
+     * Best-effort create of the target schema. A privileged user (the common
+     * case) gets it auto-created on first start; a least-privilege user
+     * without CREATE rights pre-creates it and lands here with an
+     * access-denied that we log and move past - the real gate is {@link
+     * #open}, which fails loudly with "Unknown database" if it truly doesn't
+     * exist. Either way we never mask a genuine missing-database error.
+     */
+    private void createDatabaseIfMissing() {
+        Properties props = new Properties();
+        if (user != null) {
+            props.setProperty("user", user);
+        }
+        if (password != null) {
+            props.setProperty("password", password);
+        }
+        try (Connection conn = DriverManager.getConnection(bootstrapUrl, props);
+             Statement st = conn.createStatement()) {
+            st.execute("CREATE DATABASE IF NOT EXISTS `" + database
+                    + "` DEFAULT CHARACTER SET utf8mb4");
+        } catch (SQLException ex) {
+            LOGGER.log(Level.FINE, () -> "Could not auto-create MariaDB database '" + database
+                    + "' (continuing; pre-create it if it does not exist): " + ex.getMessage());
+        }
+    }
+
+    private static void ensureSchema(Connection conn) throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute("CREATE TABLE IF NOT EXISTS dict ("
+                    + "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, "
+                    + "val VARCHAR(512) NOT NULL, "
+                    + "UNIQUE KEY uq_dict_val (val)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            // name rides on the uuid palette so a simple block needn't carry
+            // player_name / world_name columns - they fold to the ref.
+            st.execute("CREATE TABLE IF NOT EXISTS uuids ("
+                    + "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, "
+                    + "hi BIGINT NOT NULL, lo BIGINT NOT NULL, name VARCHAR(255), "
+                    + "UNIQUE KEY uq_uuids_hilo (hi, lo)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            // The chunk bucket is two VIRTUAL generated columns - no row
+            // storage, the location index materializes them. FLOOR(coord/16)
+            // is exact-decimal floor division, matching Math.floorDiv the
+            // predicate translator emits for the bounds (negatives included),
+            // and the >>4 the other backends bucket on.
+            String recordsBody = "CREATE TABLE IF NOT EXISTS records ("
+                    + "seq BIGINT NOT NULL PRIMARY KEY, "   // EventIds sequence == sort key
+                    + "event INT NOT NULL, "                // dict ref
+                    + "occurred BIGINT NOT NULL, "          // epoch SECONDS
+                    + "origin_kind INT NULL, "              // dict ref
+                    + "player INT NULL, "                   // uuids ref (source.playerId)
+                    + "world INT NULL, "                    // uuids ref (location.worldId)
+                    + "x INT NULL, y INT NULL, z INT NULL, "
+                    + "server INT NULL, target INT NULL, "          // dict refs
+                    + "orig_block INT NULL, new_block INT NULL, "    // dict refs (simple-block data)
+                    + "payload MEDIUMBLOB NULL, "           // deflate(BSON(record)); NULL for simple blocks
+                    + "cx INT AS (FLOOR(x / 16)) VIRTUAL, "
+                    + "cz INT AS (FLOOR(z / 16)) VIRTUAL, "
+                    + "KEY idx_player (player), "
+                    + "KEY idx_loc (world, cx, cz)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+            // Compressed row format roughly halves the footprint (measured
+            // 259 -> 124 MiB at 2M block edits, under CoreProtect·MySQL's
+            // ~180) for a ~5% rollback-read cost, all off the main thread. It
+            // needs innodb_file_per_table=ON (the default); a host without it
+            // rejects the clause, so fall back to the default row format
+            // rather than refusing to start.
+            try {
+                st.execute(recordsBody + " ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8");
+            } catch (SQLException compressedUnsupported) {
+                LOGGER.log(Level.INFO, () -> "MariaDB compressed row format unavailable "
+                        + "(innodb_file_per_table off?); using the default row format. "
+                        + "On-disk footprint will be larger. Cause: "
+                        + compressedUnsupported.getMessage());
+                st.execute(recordsBody);
+            }
+        }
+    }
+
+    private void loadPalette() throws SQLException {
+        try (Statement st = writeConn.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SELECT id, val FROM dict")) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    String val = rs.getString(2);
+                    dictForward.put(val, id);
+                    dictReverse.put(id, val);
+                }
+            }
+            try (ResultSet rs = st.executeQuery("SELECT id, hi, lo, name FROM uuids")) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    UUID uuid = new UUID(rs.getLong(2), rs.getLong(3));
+                    uuidForward.put(uuid, id);
+                    uuidReverse.put(id, uuid);
+                    String name = rs.getString(4);
+                    if (name != null) {
+                        uuidName.put(id, name);
+                    }
+                }
+            }
+        }
+    }
+
+    private static Set<String> rollbackableEventNames() {
+        Set<String> names = new HashSet<>();
+        for (String name : EventCatalog.eventNames()) {
+            Class<? extends EventRecord> clazz = EventCatalog.recordClassOf(name);
+            if (clazz != null && Rollbackable.class.isAssignableFrom(clazz)) {
+                names.add(name);
+            }
+        }
+        return names;
+    }
+
+    /** Reject a non-identifier schema name so it can't escape the backticks. */
+    private static String validateIdentifier(String name) {
+        if (name == null || !name.matches("[A-Za-z0-9_]+")) {
+            throw new IllegalArgumentException(
+                    "Illegal MariaDB database name '" + name + "' (allowed: letters, digits, underscore)");
+        }
+        return name;
+    }
+
+    // ===== Save ================================================
+
+    @Override
+    public void save(List<EventRecord> records) {
+        if (records.isEmpty() || readOnly) {
+            return;
+        }
+        synchronized (writeLock) {
+            Map<String, Integer> pendingDict = new HashMap<>();
+            Map<UUID, Integer> pendingUuid = new HashMap<>();
+            Map<Integer, String> pendingNames = new HashMap<>();
+            try {
+                writeConn.setAutoCommit(false);
+                for (EventRecord record : records) {
+                    bindRecord(record, pendingDict, pendingUuid, pendingNames);
+                    insertStatement.addBatch();
+                }
+                insertStatement.executeBatch();
+                writeConn.commit();
+                // Promote interns to the shared cache only after a durable
+                // commit, so a rolled-back batch never leaves phantom ids.
+                pendingDict.forEach((val, id) -> {
+                    dictForward.put(val, id);
+                    dictReverse.put(id, val);
+                });
+                pendingUuid.forEach((uuid, id) -> {
+                    uuidForward.put(uuid, id);
+                    uuidReverse.put(id, uuid);
+                });
+                uuidName.putAll(pendingNames);
+            } catch (SQLException ex) {
+                rollbackQuietly();
+                throw new RuntimeException("MariaDB save failed: " + ex.getMessage(), ex);
+            } finally {
+                restoreAutoCommit();
+            }
+        }
+    }
+
+    private void bindRecord(EventRecord record, Map<String, Integer> pendingDict,
+                            Map<UUID, Integer> pendingUuid, Map<Integer, String> pendingNames)
+            throws SQLException {
+        PreparedStatement ps = insertStatement;
+        ps.setLong(1, EventIds.sequenceOf(record.id()));
+        ps.setInt(2, internDict(record.event(), pendingDict));
+        ps.setLong(3, record.occurred().getEpochSecond());
+
+        Origin origin = record.origin();
+        bindDictRef(ps, 4, origin == null ? null : origin.kind(), pendingDict);
+
+        Source source = record.source();
+        bindUuidRef(ps, 5, source == null ? null : source.playerId(),
+                source == null ? null : source.playerName(), pendingUuid, pendingNames);
+
+        BlockLocation location = record.location();
+        UUID worldId = location == null ? null : location.worldId();
+        bindUuidRef(ps, 6, worldId, location == null ? null : location.worldName(),
+                pendingUuid, pendingNames);
+        if (location == null) {
+            ps.setNull(7, Types.INTEGER);
+            ps.setNull(8, Types.INTEGER);
+            ps.setNull(9, Types.INTEGER);
+        } else {
+            ps.setInt(7, location.x());
+            ps.setInt(8, location.y());
+            ps.setInt(9, location.z());
+        }
+
+        bindDictRef(ps, 10, record.server(), pendingDict);
+        bindDictRef(ps, 11, record.target(), pendingDict);
+
+        if (columnStorable(record)) {
+            BlockSnapshot before = beforeBlock(record);
+            BlockSnapshot after = afterBlock(record);
+            ps.setInt(12, internDict(before.blockData(), pendingDict));
+            ps.setInt(13, internDict(after.blockData(), pendingDict));
+            ps.setNull(14, Types.BLOB);
+        } else {
+            ps.setNull(12, Types.INTEGER);
+            ps.setNull(13, Types.INTEGER);
+            ps.setBytes(14, deflate(BsonBlobs.encodeRecordBytes(record)));
+        }
+    }
+
+    /**
+     * {@code true} when a record reduces, losslessly, to columns alone - no
+     * payload. That's a block break / place whose two snapshots are simple
+     * and whose material is recoverable from the block-data string, with a
+     * plain player source and a default origin. Anything the lean columns
+     * can't carry forces a payload blob.
+     */
+    private static boolean columnStorable(EventRecord record) {
+        BlockSnapshot before = beforeBlock(record);
+        BlockSnapshot after = afterBlock(record);
+        if (before == null || after == null || !before.simple() || !after.simple()) {
+            return false;
+        }
+        if (!record.extensions().isEmpty()) {
+            return false;
+        }
+        // material must round-trip from the block-data string alone.
+        if (!materialMatches(before) || !materialMatches(after)) {
+            return false;
+        }
+        Origin origin = record.origin();
+        if (origin != null && origin.detail() != null) {
+            return false;
+        }
+        Source source = record.source();
+        // Columns carry only a plain player source (kind is reconstructed as
+        // "player"); the UUID / name fold to the palette.
+        return source != null
+                && "player".equals(source.kind())
+                && source.entityId() == null && source.entityType() == null
+                && source.pluginName() == null && source.commandBlockLocation() == null
+                && source.description() == null;
+    }
+
+    private static boolean materialMatches(BlockSnapshot snapshot) {
+        Material derived = materialFromBlockData(snapshot.blockData());
+        return derived != null && derived == snapshot.material();
+    }
+
+    private static Material materialFromBlockData(String blockData) {
+        if (blockData == null || !blockData.startsWith("minecraft:")) {
+            return null;
+        }
+        String key = blockData.substring("minecraft:".length());
+        int bracket = key.indexOf('[');
+        if (bracket >= 0) {
+            key = key.substring(0, bracket);
+        }
+        try {
+            return Material.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private static BlockSnapshot beforeBlock(EventRecord record) {
+        if (record instanceof BlockBreakRecord b) {
+            return b.originalBlock();
+        }
+        if (record instanceof BlockPlaceRecord p) {
+            return p.originalBlock();
+        }
+        return null;
+    }
+
+    private static BlockSnapshot afterBlock(EventRecord record) {
+        if (record instanceof BlockBreakRecord b) {
+            return b.newBlock();
+        }
+        if (record instanceof BlockPlaceRecord p) {
+            return p.newBlock();
+        }
+        return null;
+    }
+
+    // ===== Query ===============================================
+
+    @Override
+    public QueryResult query(QueryRequest request) {
+        return runQuery(request, true);
+    }
+
+    @Override
+    public QueryResult querySummary(QueryRequest request) {
+        return runQuery(request, false);
+    }
+
+    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
+        List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
+        String where;
+        List<QueryPredicate> residual = List.of();
+        try {
+            where = predicateToSql.translate(predicates);
+        } catch (MariaDbPredicateToSql.UnsupportedPredicateException unsupported) {
+            List<QueryPredicate> pushable = new ArrayList<>();
+            List<QueryPredicate> inMemory = new ArrayList<>();
+            for (QueryPredicate predicate : predicates) {
+                try {
+                    predicateToSql.translate(List.of(predicate));
+                    pushable.add(predicate);
+                } catch (MariaDbPredicateToSql.UnsupportedPredicateException ex) {
+                    inMemory.add(predicate);
+                }
+            }
+            residual = inMemory;
+            where = predicateToSql.translate(pushable);
+        }
+        boolean postFilter = !residual.isEmpty();
+        boolean hydrate = includeHeavy || postFilter;
+        where = appendNoChat(where, request);
+
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + (postFilter ? POST_FILTER_SCAN_CAP : request.limit());
+
+        List<EventRecord> records = new ArrayList<>(postFilter ? 64 : Math.min(request.limit(), 4096));
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                EventRecord record = decodeRow(rs, hydrate);
+                if (record == null) {
+                    continue;
+                }
+                if (postFilter && !PredicateEvaluator.matchesAll(residual, record)) {
+                    continue;
+                }
+                records.add(record);
+                if (postFilter && records.size() >= request.limit()) {
+                    break;
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB query failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+
+        List<QueryResult.RecordAggregation> aggregations =
+                request.grouping() && !request.flags().contains(Flag.NO_GROUP)
+                        ? aggregate(records)
+                        : List.of();
+        return new QueryResult(records, aggregations);
+    }
+
+    @Override
+    public QueryPage queryPage(QueryRequest request, QueryPage.Cursor cursor, int pageSize) {
+        // Generic keyset page over seq - all event types, full decode. The
+        // lean, rollbackable-filtered path is streamRollbackEffects below.
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String where = appendNoChat(predicateToSql.translate(new ArrayList<>(request.predicates())), request);
+        where = appendKeyset(where, cursor, newestFirst);
+
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + pageSize;
+
+        List<EventRecord> records = new ArrayList<>(Math.min(pageSize, 4096));
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                EventRecord record = decodeRow(rs, true);
+                if (record != null) {
+                    records.add(record);
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB paged query failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        QueryPage.Cursor next = null;
+        if (records.size() == pageSize) {
+            EventRecord last = records.get(records.size() - 1);
+            if (last.occurred() != null && last.id() != null) {
+                next = new QueryPage.Cursor(last.occurred(), last.id());
+            }
+        }
+        return new QueryPage(records, next);
+    }
+
+    @Override
+    public QueryPage.Cursor streamRollbackEffects(QueryRequest request, QueryPage.Cursor cursor,
+                                                  int windowLimit, boolean rollback,
+                                                  RollbackEffectSink sink) {
+        // Allocation-lean rollback read (mirrors the SQLite #67/#83 path): a
+        // direction-specific, rollbackable-only keyset scan that resolves the
+        // one block-data side the apply engine writes straight from the
+        // in-memory palette - the cached String is the SAME reference for
+        // every stone / air row, so the simple-block hot path allocates
+        // nothing per row. Only a payload row (container / entity / complex
+        // block) decodes.
+        String blockColumn = rollback ? "orig_block" : "new_block";
+        boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
+        String where = predicateToSql.translate(new ArrayList<>(request.predicates()));
+        where = appendAnd(where, rollbackableFilter());
+        where = appendKeyset(where, cursor, newestFirst);
+
+        String sql = "SELECT seq, occurred, world, x, y, z, "
+                + blockColumn + " AS blk, payload, event FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + windowLimit;
+
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int count = 0;
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                count++;
+                long seq = rs.getLong("seq");
+                UUID id = EventIds.uuidOf(seq);
+                Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+                lastOccurred = occurred;
+                lastId = id;
+                emitEffect(rs, rollback, occurred, id, sink);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB rollback stream failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        return (count == windowLimit && lastOccurred != null && lastId != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
+    private void emitEffect(ResultSet rs, boolean rollback, Instant occurred, UUID id,
+                            RollbackEffectSink sink) throws SQLException {
+        byte[] blob = rs.getBytes("payload");
+        if (blob == null) {
+            // Simple-block fast path: resolve the one side's block-data from
+            // the palette and hand primitives straight to the sink - no
+            // record, snapshot, or effect object. expectedCurrent is unused
+            // under force-overwrite (#69), so pass null.
+            int blockRef = rs.getInt("blk");
+            if (rs.wasNull()) {
+                sink.skip(occurred, id);
+                return;
+            }
+            UUID world = uuidValue(rs.getInt("world"));
+            sink.block(world, rs.getInt("x"), rs.getInt("y"), rs.getInt("z"),
+                    dictValue(blockRef), null, occurred, id);
+            return;
+        }
+        EventRecord record = decodeBlob(blob);
+        if (!(record instanceof Rollbackable rollbackable)) {
+            sink.skip(occurred, id);
+            return;
+        }
+        RollbackEffect effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+        if (effect instanceof RollbackEffect.BlockReplace br
+                && br.replacement() != null && br.replacement().simple()) {
+            BlockLocation loc = br.location();
+            sink.block(loc.worldId(), loc.x(), loc.y(), loc.z(),
+                    br.replacement().blockData(), null, occurred, id);
+        } else {
+            sink.complex(effect, occurred, id);
+        }
+    }
+
+    // ===== Row decode ==========================================
+
+    private EventRecord decodeRow(ResultSet rs, boolean includeHeavy) throws SQLException {
+        byte[] blob = rs.getBytes("payload");
+        if (blob != null) {
+            return decodeBlob(blob); // authoritative; columns were only for pushdown
+        }
+        // Column-stored: a clean player-sourced simple block.
+        String event = dictValue(rs.getInt("event"));
+        Class<? extends EventRecord> clazz = EventCatalog.recordClassOf(event);
+        if (clazz == null) {
+            return null;
+        }
+        UUID id = EventIds.uuidOf(rs.getLong("seq"));
+        Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+        Instant expiresAt = occurred.plusSeconds(retentionSeconds);
+        Origin origin = new Origin(dictValueOrNull(rs, "origin_kind"), null);
+        int playerRef = rs.getInt("player");
+        boolean hasPlayer = !rs.wasNull();
+        Source source = new Source("player",
+                hasPlayer ? uuidValue(playerRef) : null,
+                hasPlayer ? uuidName.get(playerRef) : null,
+                null, null, null, null, null);
+        int worldRef = rs.getInt("world");
+        boolean hasWorld = !rs.wasNull();
+        BlockLocation location = new BlockLocation(
+                hasWorld ? uuidValue(worldRef) : null,
+                hasWorld ? uuidName.get(worldRef) : null,
+                rs.getInt("x"), rs.getInt("y"), rs.getInt("z"));
+        String server = dictValueOrNull(rs, "server");
+        String target = dictValueOrNull(rs, "target");
+        BlockSnapshot before = includeHeavy ? snapshot(rs, "orig_block") : null;
+        BlockSnapshot after = includeHeavy ? snapshot(rs, "new_block") : null;
+
+        if (clazz == BlockBreakRecord.class) {
+            return new BlockBreakRecord(id, event, occurred, expiresAt,
+                    origin, source, location, server, target, before, after);
+        }
+        if (clazz == BlockPlaceRecord.class) {
+            return new BlockPlaceRecord(id, event, occurred, expiresAt,
+                    origin, source, location, server, target, before, after);
+        }
+        return null; // only block break / place are ever column-stored
+    }
+
+    private BlockSnapshot snapshot(ResultSet rs, String blockColumn) throws SQLException {
+        String blockData = dictValueOrNull(rs, blockColumn);
+        if (blockData == null) {
+            return null;
+        }
+        Material material = materialFromBlockData(blockData);
+        if (material == null) {
+            return null; // column storage guaranteed derivability, but stay defensive
+        }
+        return new BlockSnapshot(material, blockData,
+                List.of(), List.of(), List.of(), List.of(), null, List.of());
+    }
+
+    private EventRecord decodeBlob(byte[] blob) {
+        return BsonBlobs.decodeRecordBytes(inflate(blob));
+    }
+
+    // ===== Predicate / SQL helpers =============================
+
+    private String appendNoChat(String where, QueryRequest request) {
+        if (!request.flags().contains(Flag.NO_CHAT)) {
+            return where;
+        }
+        List<Integer> ids = new ArrayList<>(chatEvents.size());
+        for (String name : chatEvents) {
+            Integer id = dictForward.get(name);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        if (ids.isEmpty()) {
+            return where;
+        }
+        return appendAnd(where, "event NOT IN (" + joinInts(ids) + ")");
+    }
+
+    private static String appendAnd(String where, String clause) {
+        if (clause == null || clause.isEmpty()) {
+            return where;
+        }
+        return where.isEmpty() ? clause : where + " AND " + clause;
+    }
+
+    private static String appendKeyset(String where, QueryPage.Cursor cursor, boolean newestFirst) {
+        if (cursor == null) {
+            return where;
+        }
+        // Sort / keyset is on seq alone (co-monotonic with occurred), so the
+        // cursor is a single-column compare on the primary key.
+        String op = newestFirst ? "<" : ">";
+        return appendAnd(where, "seq " + op + " " + EventIds.sequenceOf(cursor.id()));
+    }
+
+    private String rollbackableFilter() {
+        List<Integer> ids = new ArrayList<>(rollbackableEvents.size());
+        for (String name : rollbackableEvents) {
+            Integer id = dictForward.get(name);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids.isEmpty() ? "0" : "event IN (" + joinInts(ids) + ")";
+    }
+
+    private static String joinInts(List<Integer> ids) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ids.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(ids.get(i));
+        }
+        return sb.toString();
+    }
+
+    // ===== Palette resolution ==================================
+
+    private int internDict(String value, Map<String, Integer> pending) throws SQLException {
+        Integer id = dictForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        id = pending.get(value);
+        if (id != null) {
+            return id;
+        }
+        dictInsert.setString(1, value);
+        dictInsert.executeUpdate();
+        int newId = generatedKey(dictInsert);
+        pending.put(value, newId);
+        return newId;
+    }
+
+    private int internUuid(UUID value, String name, Map<UUID, Integer> pending,
+                           Map<Integer, String> pendingNames) throws SQLException {
+        Integer id = uuidForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        id = pending.get(value);
+        if (id != null) {
+            return id;
+        }
+        uuidInsert.setLong(1, value.getMostSignificantBits());
+        uuidInsert.setLong(2, value.getLeastSignificantBits());
+        if (name == null) {
+            uuidInsert.setNull(3, Types.VARCHAR);
+        } else {
+            uuidInsert.setString(3, name);
+        }
+        uuidInsert.executeUpdate();
+        int newId = generatedKey(uuidInsert);
+        pending.put(value, newId);
+        if (name != null) {
+            pendingNames.put(newId, name);
+        }
+        return newId;
+    }
+
+    private void bindDictRef(PreparedStatement ps, int index, String value,
+                             Map<String, Integer> pending) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+        } else {
+            ps.setInt(index, internDict(value, pending));
+        }
+    }
+
+    private void bindUuidRef(PreparedStatement ps, int index, UUID value, String name,
+                             Map<UUID, Integer> pending, Map<Integer, String> pendingNames)
+            throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+        } else {
+            ps.setInt(index, internUuid(value, name, pending, pendingNames));
+        }
+    }
+
+    private static int generatedKey(PreparedStatement ps) throws SQLException {
+        try (ResultSet keys = ps.getGeneratedKeys()) {
+            if (keys.next()) {
+                return keys.getInt(1);
+            }
+        }
+        throw new SQLException("INSERT returned no generated key");
+    }
+
+    private String dictValue(int id) {
+        String val = dictReverse.get(id);
+        if (val != null) {
+            return val;
+        }
+        val = lookupDict(id);
+        if (val != null) {
+            dictReverse.put(id, val);
+            dictForward.putIfAbsent(val, id);
+        }
+        return val;
+    }
+
+    private UUID uuidValue(int id) {
+        UUID val = uuidReverse.get(id);
+        if (val != null) {
+            return val;
+        }
+        val = lookupUuid(id);
+        if (val != null) {
+            uuidReverse.put(id, val);
+            uuidForward.putIfAbsent(val, id);
+        }
+        return val;
+    }
+
+    private String dictValueOrNull(ResultSet rs, String column) throws SQLException {
+        int id = rs.getInt(column);
+        return rs.wasNull() ? null : dictValue(id);
+    }
+
+    private Integer resolveDictId(String value) {
+        Integer id = dictForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement("SELECT id FROM dict WHERE val = ?")) {
+                ps.setString(1, value);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        int found = rs.getInt(1);
+                        dictForward.putIfAbsent(value, found);
+                        dictReverse.putIfAbsent(found, value);
+                        return found;
+                    }
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB dict lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+        return null;
+    }
+
+    private Integer resolveUuidId(UUID value) {
+        Integer id = uuidForward.get(value);
+        if (id != null) {
+            return id;
+        }
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement(
+                    "SELECT id FROM uuids WHERE hi = ? AND lo = ?")) {
+                ps.setLong(1, value.getMostSignificantBits());
+                ps.setLong(2, value.getLeastSignificantBits());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        int found = rs.getInt(1);
+                        uuidForward.putIfAbsent(value, found);
+                        uuidReverse.putIfAbsent(found, value);
+                        return found;
+                    }
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB uuid lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+        return null;
+    }
+
+    private String lookupDict(int id) {
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement("SELECT val FROM dict WHERE id = ?")) {
+                ps.setInt(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? rs.getString(1) : null;
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB dict reverse lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private UUID lookupUuid(int id) {
+        synchronized (lookupLock) {
+            try (PreparedStatement ps = lookupConn.prepareStatement(
+                    "SELECT hi, lo, name FROM uuids WHERE id = ?")) {
+                ps.setInt(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    UUID uuid = new UUID(rs.getLong(1), rs.getLong(2));
+                    String name = rs.getString(3);
+                    if (name != null) {
+                        uuidName.putIfAbsent(id, name);
+                    }
+                    return uuid;
+                }
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB uuid reverse lookup failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    // ===== Read pool ===========================================
+
+    private Connection borrow() {
+        try {
+            Connection conn = readPool.take();
+            // Server-side idle timeout (wait_timeout) can kill a long-idle
+            // read connection. Validate on borrow and transparently reopen so
+            // a search after a quiet night doesn't surface a stale-socket
+            // error. The writer stays hot (Spyglass logs continuously) so it
+            // doesn't need the same dance.
+            if (!isValidQuietly(conn)) {
+                replaceReadConnection(conn);
+                return borrow();
+            }
+            return conn;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted borrowing a MariaDB read connection", ex);
+        }
+    }
+
+    private void giveBack(Connection conn) {
+        readPool.offer(conn);
+    }
+
+    private static boolean isValidQuietly(Connection conn) {
+        try {
+            return conn.isValid(2);
+        } catch (SQLException ex) {
+            return false;
+        }
+    }
+
+    private void replaceReadConnection(Connection dead) {
+        synchronized (allConnections) {
+            allConnections.remove(dead);
+        }
+        closeQuietly(dead);
+        try {
+            Connection fresh = open(true);
+            synchronized (allConnections) {
+                allConnections.add(fresh);
+            }
+            readPool.offer(fresh);
+        } catch (SQLException ex) {
+            // Couldn't reopen now (server down?); surface on the next borrow
+            // rather than spin. Re-offer nothing so the pool shrinks by one.
+            LOGGER.log(Level.WARNING, "MariaDB read connection could not be reopened", ex);
+        }
+    }
+
+    /** Work that runs against a borrowed connection and may throw {@link SQLException}. */
+    @FunctionalInterface
+    public interface ConnectionWork<T> {
+        T apply(Connection connection) throws SQLException;
+    }
+
+    /**
+     * Run {@code work} on a pooled read connection. The auxiliary MariaDB
+     * stores (undo / tool-state / salvage) share this store's read pool
+     * rather than opening their own, so connection count stays bounded.
+     */
+    public <T> T withReadConnection(ConnectionWork<T> work) {
+        Connection conn = borrow();
+        try {
+            return work.apply(conn);
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB read failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+    }
+
+    /**
+     * Run {@code work} on the single write connection under the write lock,
+     * so every writer (records + aux) serialises on one connection.
+     */
+    public <T> T withWriteConnection(ConnectionWork<T> work) {
+        synchronized (writeLock) {
+            try {
+                return work.apply(writeConn);
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB write failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    // ===== Retention / maintenance =============================
+
+    private void pruneExpiredQuietly() {
+        try {
+            pruneExpired();
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.WARNING, "MariaDB retention sweep failed", ex);
+        }
+    }
+
+    /** Drop records past the retention horizon; the TTL analogue. */
+    public long pruneExpired() {
+        if (readOnly) {
+            return 0L;
+        }
+        long thresholdSec = (System.currentTimeMillis() / 1000L) - retentionSeconds;
+        synchronized (writeLock) {
+            try (PreparedStatement ps = writeConn.prepareStatement(
+                    "DELETE FROM records WHERE occurred < ?")) {
+                ps.setLong(1, thresholdSec);
+                return ps.executeUpdate();
+            } catch (SQLException ex) {
+                throw new RuntimeException("MariaDB retention prune failed: " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    /** Total record rows - test / benchmark helper. */
+    public long count() {
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT count(*) FROM records")) {
+            return rs.next() ? rs.getLong(1) : 0L;
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB count failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+    }
+
+    public String databaseName() {
+        return database;
+    }
+
+    // ===== Aggregate (mirrors Mongo / ClickHouse / SQLite) =====
+
+    private List<QueryResult.RecordAggregation> aggregate(List<EventRecord> records) {
+        Map<String, Long> counts = new HashMap<>();
+        Map<String, EventRecord> sample = new HashMap<>();
+        for (EventRecord record : records) {
+            String key = record.event() + "|" + record.sourceName() + "|" + record.target() + "|"
+                    + record.occurred().atZone(java.time.ZoneOffset.UTC).toLocalDate();
+            counts.merge(key, 1L, Long::sum);
+            sample.putIfAbsent(key, record);
+        }
+        return counts.entrySet().stream()
+                .map(entry -> new QueryResult.RecordAggregation(sample.get(entry.getKey()), entry.getValue()))
+                .sorted(Comparator.comparing((QueryResult.RecordAggregation aggregation)
+                        -> aggregation.sample().occurred()).reversed())
+                .toList();
+    }
+
+    // ===== Compression (per-event payload) =====================
+
+    private static byte[] deflate(byte[] input) {
+        Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION);
+        deflater.setInput(input);
+        deflater.finish();
+        ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(32, input.length / 2));
+        byte[] buffer = new byte[8192];
+        while (!deflater.finished()) {
+            out.write(buffer, 0, deflater.deflate(buffer));
+        }
+        deflater.end();
+        return out.toByteArray();
+    }
+
+    private static byte[] inflate(byte[] input) {
+        Inflater inflater = new Inflater();
+        inflater.setInput(input);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(32, input.length * 2));
+        byte[] buffer = new byte[8192];
+        try {
+            while (!inflater.finished()) {
+                int n = inflater.inflate(buffer);
+                if (n == 0 && inflater.needsInput()) {
+                    break;
+                }
+                out.write(buffer, 0, n);
+            }
+        } catch (java.util.zip.DataFormatException ex) {
+            throw new RuntimeException("MariaDB payload inflate failed: " + ex.getMessage(), ex);
+        } finally {
+            inflater.end();
+        }
+        return out.toByteArray();
+    }
+
+    // ===== Lifecycle ===========================================
+
+    private void rollbackQuietly() {
+        try {
+            writeConn.rollback();
+        } catch (SQLException ignored) {
+            // best-effort; the original failure is what we surface
+        }
+    }
+
+    private void restoreAutoCommit() {
+        try {
+            writeConn.setAutoCommit(true);
+        } catch (SQLException ignored) {
+            // best-effort
+        }
+    }
+
+    @Override
+    public void close() {
+        if (retention != null) {
+            retention.shutdownNow();
+        }
+        closeQuietly(insertStatement);
+        closeQuietly(dictInsert);
+        closeQuietly(uuidInsert);
+        closeQuietly(writeConn);
+        synchronized (allConnections) {
+            for (Connection conn : allConnections) {
+                closeQuietly(conn);
+            }
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception ignored) {
+            // shutdown best-effort
+        }
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbBench.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbBench.java
@@ -1,0 +1,246 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * On-disk footprint + rollback-read throughput for {@link MariaDbRecordStore}
+ * (#169), measured against a real InnoDB server.
+ *
+ * <p>Seeds the same realistic 2M block-edit cube the SQLite bench and
+ * {@code compare.js} use (a {@code /fill stone} then {@code //replace stone
+ * air}, so the disk numbers are apples-to-apples with the ~180 MiB
+ * CoreProtect·MySQL footprint the issue targets), then reports:
+ *
+ * <ul>
+ * <li>total on-disk bytes (data + index) for the schema, with a per-table
+ * breakdown from {@code information_schema.TABLES} after {@code ANALYZE};</li>
+ * <li>a full keyset rollback read over every row, in effects/sec - the lean
+ * {@code streamRollbackEffects} path the engine drives;</li>
+ * <li>a by-player scoped rollback read (the common operator action).</li>
+ * </ul>
+ *
+ * <p>By default starts a throwaway Testcontainers MariaDB (Docker). Point it
+ * at an external server with {@code -DSG_BENCH_MARIADB_HOST=...} (plus
+ * {@code _PORT} / {@code _DB} / {@code _USER} / {@code _PASS}) to keep the
+ * data around for inspection. Default 2,000,000 records; override with
+ * {@code -DSG_BENCH_RECORDS=N}. Run with {@code ./gradlew :spyglass-core:mariadbBench}.
+ */
+@Tag("mariadb-bench")
+class MariaDbBench {
+
+    private static final int RECORDS = Integer.getInteger("SG_BENCH_RECORDS", 2_000_000);
+    private static final int BATCH = 10_000;
+    private static final int ROLLBACK_WINDOW = 4_000;
+    private static final long CP_MYSQL_MIB = 180; // the figure to beat (README)
+
+    private static final UUID WORLD = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+    private static final UUID PLAYER = UUID.fromString("99999999-0000-0000-0000-000000001000");
+    private static final int X0 = 10_000;
+    private static final int Y0 = -32;
+    private static final int Z0 = 10_000;
+    private static final int SIDE = (int) Math.round(Math.cbrt(RECORDS));
+
+    @Test
+    void footprintAndRollbackAt2M() throws Exception {
+        String extHost = System.getProperty("SG_BENCH_MARIADB_HOST");
+        MariaDBContainer<?> container = null;
+        String host;
+        int port;
+        String db;
+        String user;
+        String pw;
+        if (extHost != null) {
+            host = extHost;
+            port = Integer.parseInt(System.getProperty("SG_BENCH_MARIADB_PORT", "3306"));
+            db = System.getProperty("SG_BENCH_MARIADB_DB", "spyglass_bench");
+            user = System.getProperty("SG_BENCH_MARIADB_USER", "root");
+            pw = System.getProperty("SG_BENCH_MARIADB_PASS", "");
+        } else {
+            assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                    .as("docker not available")
+                    .isTrue();
+            container = new MariaDBContainer<>(DockerImageName.parse("mariadb:11"));
+            container.start();
+            host = container.getHost();
+            port = container.getFirstMappedPort();
+            db = container.getDatabaseName();
+            user = container.getUsername();
+            pw = container.getPassword();
+        }
+
+        MariaDbRecordStore store = new MariaDbRecordStore(host, port, db, user, pw, false, false);
+        try {
+            long t0 = System.nanoTime();
+            seed(store);
+            double seedSec = (System.nanoTime() - t0) / 1e9;
+
+            System.out.printf(Locale.ROOT,
+                    "%n=== MariaDB footprint @ %,d block records ===%n", RECORDS);
+            System.out.printf(Locale.ROOT, "seed: %.1fs (%,.0f rec/s)%n", seedSec, RECORDS / seedSec);
+            System.out.printf(Locale.ROOT, "rows in records table: %,d%n", store.count());
+
+            double mib = reportDisk(host, port, db, user, pw);
+            System.out.printf(Locale.ROOT,
+                    "CoreProtect·MySQL target: ~%d MiB -> Spyglass·MariaDB is %s%n",
+                    CP_MYSQL_MIB, mib < CP_MYSQL_MIB ? String.format(Locale.ROOT,
+                            "SMALLER by %.0f%%", 100 * (CP_MYSQL_MIB - mib) / CP_MYSQL_MIB)
+                            : "LARGER (over target!)");
+
+            // Full rollback read over every row, lean path, in windows.
+            AtomicLong effects = new AtomicLong();
+            RecordStore.RollbackEffectSink sink = countingSink(effects);
+            QueryRequest all = new QueryRequest(List.of(), Sort.NEWEST_FIRST, RECORDS,
+                    java.util.EnumSet.noneOf(Flag.class), false);
+            long r0 = System.nanoTime();
+            QueryPage.Cursor cursor = null;
+            do {
+                cursor = store.streamRollbackEffects(all, cursor, ROLLBACK_WINDOW, true, sink);
+            } while (cursor != null);
+            double rbSec = (System.nanoTime() - r0) / 1e9;
+            System.out.printf(Locale.ROOT,
+                    "%nrollback read: %,d effects in %.2fs (%,.0f effects/s)%n",
+                    effects.get(), rbSec, effects.get() / rbSec);
+
+            // Scoped (single-player) rollback - the by-player index seek.
+            AtomicLong scoped = new AtomicLong();
+            RecordStore.RollbackEffectSink countSink = countingSink(scoped);
+            long s0 = System.nanoTime();
+            cursor = null;
+            do {
+                cursor = store.streamRollbackEffects(
+                        new QueryRequest(List.of(new QueryPredicate.Eq("source.playerId", PLAYER)),
+                                Sort.NEWEST_FIRST, RECORDS, java.util.EnumSet.noneOf(Flag.class), false),
+                        cursor, ROLLBACK_WINDOW, true, countSink);
+            } while (cursor != null);
+            double scopedSec = (System.nanoTime() - s0) / 1e9;
+            System.out.printf(Locale.ROOT,
+                    "by-player rollback: %,d effects in %.3fs (%,.0f effects/s)%n",
+                    scoped.get(), scopedSec, scoped.get() / scopedSec);
+        } finally {
+            store.close();
+            if (container != null) {
+                container.stop();
+            }
+        }
+    }
+
+    private double reportDisk(String host, int port, String db, String user, String pw) throws Exception {
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:mariadb://" + host + ":" + port + "/" + db, user, pw);
+             Statement st = conn.createStatement()) {
+            st.execute("ANALYZE TABLE records");
+            st.execute("ANALYZE TABLE dict");
+            st.execute("ANALYZE TABLE uuids");
+            long total = 0;
+            System.out.println("per-table bytes (information_schema, data+index):");
+            try (ResultSet rs = st.executeQuery(
+                    "SELECT table_name, data_length, index_length FROM information_schema.TABLES "
+                            + "WHERE table_schema = '" + db + "' ORDER BY (data_length+index_length) DESC")) {
+                while (rs.next()) {
+                    long bytes = rs.getLong(2) + rs.getLong(3);
+                    total += bytes;
+                    System.out.printf(Locale.ROOT, " %-16s %8.1f MiB (data %.1f / index %.1f)%n",
+                            rs.getString(1), bytes / (1024.0 * 1024.0),
+                            rs.getLong(2) / (1024.0 * 1024.0), rs.getLong(3) / (1024.0 * 1024.0));
+                }
+            }
+            double mib = total / (1024.0 * 1024.0);
+            System.out.printf(Locale.ROOT, "TOTAL on disk (data + index): %.1f MiB (%.1f MiB / million)%n",
+                    mib, mib / (RECORDS / 1_000_000.0));
+            return mib;
+        }
+    }
+
+    private void seed(MariaDbRecordStore store) {
+        Instant base = Instant.now().minus(7, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+        List<EventRecord> batch = new ArrayList<>(BATCH);
+        for (int i = 0; i < RECORDS; i++) {
+            batch.add(record(i, base.plusMillis(i)));
+            if (batch.size() == BATCH) {
+                store.save(batch);
+                batch.clear();
+            }
+        }
+        if (!batch.isEmpty()) {
+            store.save(batch);
+        }
+    }
+
+    private EventRecord record(int i, Instant occurred) {
+        int dx = i % SIDE;
+        int dz = (i / SIDE) % SIDE;
+        int dy = i / (SIDE * SIDE);
+        BlockLocation loc = new BlockLocation(WORLD, "world", X0 + dx, Y0 + dy, Z0 + dz);
+        return new BlockBreakRecord(EventIds.newId(), "break", occurred,
+                occurred.plus(28, ChronoUnit.DAYS), Origin.player(),
+                Source.player(PLAYER, "Builder"), loc, "world", "STONE",
+                snap("minecraft:stone"), snap("minecraft:air"));
+    }
+
+    private static RecordStore.RollbackEffectSink countingSink(AtomicLong counter) {
+        return new RecordStore.RollbackEffectSink() {
+            @Override
+            public void block(UUID world, int x, int y, int z, String data, String expected,
+                              Instant occurred, UUID id) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void complex(net.medievalrp.spyglass.api.rollback.RollbackEffect effect,
+                                Instant occurred, UUID id) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public void skip(Instant occurred, UUID id) {
+            }
+        };
+    }
+
+    private static BlockSnapshot snap(String blockData) {
+        return new BlockSnapshot(material(blockData), blockData,
+                List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    private static Material material(String blockData) {
+        String key = blockData.substring("minecraft:".length());
+        int bracket = key.indexOf('[');
+        if (bracket >= 0) {
+            key = key.substring(0, bracket);
+        }
+        try {
+            return Material.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return Material.STONE;
+        }
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbPredicateToSqlTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbPredicateToSqlTest.java
@@ -1,0 +1,144 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the palette-resolving MariaDB predicate translator.
+ * Same contract as the SQLite translator (resolve user strings/UUIDs to
+ * integer palette ids up front, so there's no string-escaping surface and an
+ * unknown value compiles to a constant-false clause); the one difference is
+ * the chunk bound, which references the {@code cx} / {@code cz} virtual
+ * generated columns instead of an inline {@code >>} expression. No Docker.
+ */
+class MariaDbPredicateToSqlTest {
+
+    private static final UUID PLAYER = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    // Fake palette: "break"->7, "Alice"->9; PLAYER->3. Everything else absent.
+    private final MariaDbPredicateToSql translator = new MariaDbPredicateToSql(
+            new MariaDbPredicateToSql.Palette() {
+                @Override
+                public Integer dictId(String value) {
+                    return switch (value) {
+                        case "break" -> 7;
+                        case "Alice" -> 9;
+                        default -> null;
+                    };
+                }
+
+                @Override
+                public Integer uuidId(UUID value) {
+                    return PLAYER.equals(value) ? 3 : null;
+                }
+            });
+
+    private String translate(QueryPredicate predicate) {
+        return translator.translate(List.of(predicate));
+    }
+
+    @Test
+    void resolvesStringEqualityToPaletteId() {
+        assertThat(translate(new QueryPredicate.Eq("event", "break"))).isEqualTo("event = 7");
+    }
+
+    @Test
+    void resolvesUuidEqualityToPaletteId() {
+        assertThat(translate(new QueryPredicate.Eq("source.playerId", PLAYER))).isEqualTo("player = 3");
+    }
+
+    @Test
+    void unknownValueCompilesToConstantFalse() {
+        assertThat(translate(new QueryPredicate.Eq("event", "never-seen"))).isEqualTo("0");
+    }
+
+    @Test
+    void inDropsAbsentValuesAndKeepsPresentOnes() {
+        assertThat(translate(new QueryPredicate.In("event", List.of("break", "ghost"))))
+                .isEqualTo("event IN (7)");
+        assertThat(translate(new QueryPredicate.In("event", List.of("ghost"))))
+                .isEqualTo("0");
+    }
+
+    @Test
+    void timeRangeInlinesEpochSeconds() {
+        Instant lo = Instant.ofEpochSecond(1000);
+        Instant hi = Instant.ofEpochSecond(2000);
+        assertThat(translate(new QueryPredicate.Range("occurred", lo, hi)))
+                .isEqualTo("(occurred >= 1000 AND occurred <= 2000)");
+    }
+
+    @Test
+    void coordinateRangeAlsoBoundsChunkColumnForTheIndex() {
+        // x in [10, 40] => cx in [floorDiv(10,16), floorDiv(40,16)] = [0, 2].
+        // cx / cz are virtual generated columns FLOOR(x/16) / FLOOR(z/16).
+        assertThat(translate(new QueryPredicate.Range("location.x", 10, 40)))
+                .isEqualTo("(x >= 10 AND x <= 40 AND cx >= 0 AND cx <= 2)");
+        // Negative coordinates floor toward -inf, matching FLOOR(coord/16).
+        assertThat(translate(new QueryPredicate.Range("location.z", -20, -1)))
+                .isEqualTo("(z >= -20 AND z <= -1 AND cz >= -2 AND cz <= -1)");
+    }
+
+    @Test
+    void idEqualityMapsUuidThroughEventIdsSequence() {
+        UUID id = EventIds.newId();
+        assertThat(translate(new QueryPredicate.Eq("id", id)))
+                .isEqualTo("seq = " + EventIds.sequenceOf(id));
+    }
+
+    @Test
+    void regexOnInternedColumnIsUnsupported() {
+        // server is an interned dict column; a regex can't run against the int.
+        assertThatThrownBy(() -> translate(new QueryPredicate.Eq(
+                "server", Pattern.compile("survi.*"))))
+                .isInstanceOf(MariaDbPredicateToSql.UnsupportedPredicateException.class);
+    }
+
+    @Test
+    void payloadOnlyFieldIsUnsupported() {
+        assertThatThrownBy(() -> translate(new QueryPredicate.Eq("message", "hi")))
+                .isInstanceOf(MariaDbPredicateToSql.UnsupportedPredicateException.class);
+    }
+
+    @Test
+    void hostileStringNeverReachesSqlOnlyItsResolvedId() {
+        // A SQL-injection attempt as an interned value resolves to "no such id"
+        // (the fake palette doesn't know it) and compiles to a constant - the
+        // raw string is never inlined into the SQL text.
+        String sql = translate(new QueryPredicate.Eq("server", "'; DROP TABLE records;--"));
+        assertThat(sql).isEqualTo("0");
+        assertThat(sql).doesNotContain("DROP");
+    }
+
+    @Test
+    void andOrNotCompose() {
+        QueryPredicate and = new QueryPredicate.And(List.of(
+                new QueryPredicate.Eq("event", "break"),
+                new QueryPredicate.Eq("source.playerId", PLAYER)));
+        assertThat(translate(and)).isEqualTo("(event = 7 AND player = 3)");
+
+        QueryPredicate not = new QueryPredicate.Not(new QueryPredicate.Eq("event", "break"));
+        assertThat(translate(not)).isEqualTo("(NOT event = 7)");
+
+        // Existence on an interned column.
+        assertThat(translate(new QueryPredicate.Exists("target", true)))
+                .isEqualTo("(target IS NOT NULL)");
+    }
+
+    @Test
+    void multipleTopLevelPredicatesJoinWithAnd() {
+        String sql = translator.translate(List.of(
+                new QueryPredicate.Eq("event", "break"),
+                new QueryPredicate.Eq("origin.kind", "Alice")));
+        assertThat(sql).isEqualTo("(event = 7 AND origin_kind = 9)");
+        assertThat(translator.translate(List.of())).isEmpty();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStoreIT.java
@@ -1,0 +1,408 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ChatRecord;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.EntityDeathRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.event.TeleportRecord;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * MariaDB store coverage (#169) via Testcontainers. The same suite the
+ * SQLite store runs (hybrid schema simple-block -> columns / everything ->
+ * payload, keyset page, lean rollback stream both directions, predicate
+ * pushdown + post-filter, palette interning, retention), proving parity
+ * against the client-server InnoDB engine. Requires Docker.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MariaDbRecordStoreIT {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+    // occurred is stored at second precision, so truncate fixtures to match.
+    private static final Instant BASE = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    // Column-stored rows reconstruct expiresAt as occurred + retention.
+    private static final long RETENTION = 3600L;
+
+    private MariaDBContainer<?> container;
+    private String host;
+    private int port;
+    private String db;
+    private String user;
+    private String pw;
+    private MariaDbRecordStore store;
+
+    @BeforeAll
+    void setup() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        container = new MariaDBContainer<>(DockerImageName.parse("mariadb:11"));
+        container.start();
+        host = container.getHost();
+        port = container.getFirstMappedPort();
+        db = container.getDatabaseName();
+        user = container.getUsername();
+        pw = container.getPassword();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @BeforeEach
+    void fresh() throws SQLException {
+        // The server persists between tests; drop the data tables so each
+        // test starts empty (and the reopened store's palette caches start
+        // clean - truncating the palette under a live store would desync it).
+        try (Connection conn = direct(); Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS records");
+            st.execute("DROP TABLE IF EXISTS dict");
+            st.execute("DROP TABLE IF EXISTS uuids");
+        }
+        store = new MariaDbRecordStore(host, port, db, user, pw, false, RETENTION);
+    }
+
+    @AfterEach
+    void close() {
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    private Connection direct() throws SQLException {
+        return DriverManager.getConnection("jdbc:mariadb://" + host + ":" + port + "/" + db, user, pw);
+    }
+
+    // ===== Builders (shared with the SQLite suite) =============
+
+    private static BlockSnapshot simple(Material material, String data) {
+        return new BlockSnapshot(material, data, List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    private static BlockSnapshot sign() {
+        return new BlockSnapshot(Material.OAK_SIGN, "minecraft:oak_sign",
+                List.of(), List.of("line"), List.of(), List.of(), null);
+    }
+
+    private BlockBreakRecord breakAt(UUID player, String name, int x, long secondsAgo,
+                                     BlockSnapshot before, BlockSnapshot after) {
+        Instant occurred = BASE.minusSeconds(secondsAgo);
+        return new BlockBreakRecord(EventIds.newId(), "break", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(player, name),
+                new BlockLocation(WORLD, "world", x, 64, x), "srv", "STONE", before, after);
+    }
+
+    private BlockBreakRecord simpleBreak(int x) {
+        return breakAt(UUID.randomUUID(), "Alice", x, x,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+    }
+
+    private ContainerDepositRecord deposit(int slot) {
+        Instant occurred = BASE.minusSeconds(slot);
+        return new ContainerDepositRecord(EventIds.newId(), "deposit", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Bob"),
+                new BlockLocation(WORLD, "world", slot, 70, slot), "srv", "CHEST",
+                "CHEST", slot, 1,
+                new StoredItem(slot, "DIAMOND", "minecraft:diamond"), null);
+    }
+
+    private EntityDeathRecord death(String type) {
+        return new EntityDeathRecord(EventIds.newId(), "death", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Cara"),
+                new BlockLocation(WORLD, "world", 5, 64, 5), "srv", type,
+                type, UUID.randomUUID(), "PLAYER", "ENTITY_ATTACK", null);
+    }
+
+    private ChatRecord chat(String message) {
+        return new ChatRecord(EventIds.newId(), "say", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Dan"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv", null,
+                message, List.of(), Map.of());
+    }
+
+    private static QueryRequest request(List<QueryPredicate> predicates) {
+        return new QueryRequest(predicates, Sort.NEWEST_FIRST, 1000,
+                EnumSet.noneOf(Flag.class), false);
+    }
+
+    private byte[] rawPayload(long seq) throws SQLException {
+        try (Connection conn = direct();
+             var ps = conn.prepareStatement("SELECT payload FROM records WHERE seq = ?")) {
+            ps.setLong(1, seq);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getBytes(1) : new byte[0];
+            }
+        }
+    }
+
+    private long rawCount(String table) throws SQLException {
+        try (Connection conn = direct();
+             Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT count(*) FROM " + table)) {
+            return rs.next() ? rs.getLong(1) : 0L;
+        }
+    }
+
+    // ===== Tests ===============================================
+
+    @Test
+    void registersMariaDbDriverOnClassLoad() {
+        boolean registered = DriverManager.drivers()
+                .anyMatch(d -> d.getClass().getName().equals("org.mariadb.jdbc.Driver"));
+        assertThat(registered)
+                .as("MariaDbRecordStore must self-register the org.mariadb.jdbc.Driver")
+                .isTrue();
+    }
+
+    @Test
+    void simpleBlockRoundTripsThroughColumnsWithNoPayload() throws SQLException {
+        BlockBreakRecord record = simpleBreak(10);
+        store.save(List.of(record));
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactly(record);
+        assertThat(rawPayload(EventIds.sequenceOf(record.id()))).isNull();
+    }
+
+    @Test
+    void tileEntityBlockRoundTripsThroughPayload() throws SQLException {
+        BlockBreakRecord record = breakAt(UUID.randomUUID(), "Alice", 1, 1,
+                sign(), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(record));
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactly(record);
+        assertThat(rawPayload(EventIds.sequenceOf(record.id()))).isNotEmpty();
+    }
+
+    @Test
+    void nonBlockEventsRoundTripThroughPayload() {
+        BlockPlaceRecord place = new BlockPlaceRecord(EventIds.newId(), "place", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Eve"),
+                new BlockLocation(WORLD, "world", 2, 65, 2), "srv", "DIRT",
+                simple(Material.AIR, "minecraft:air"), simple(Material.DIRT, "minecraft:dirt"));
+        TeleportRecord teleport = new TeleportRecord(EventIds.newId(), "teleport", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Finn"),
+                new BlockLocation(WORLD, "world", 3, 64, 3), "srv", null,
+                new BlockLocation(WORLD, "world", 3, 64, 3),
+                new BlockLocation(WORLD, "world", 99, 64, 99), "COMMAND");
+        List<EventRecord> records = List.of(place, deposit(4), death("ZOMBIE"), chat("hi"), teleport);
+        store.save(records);
+
+        QueryResult result = store.query(request(List.of()));
+        assertThat(result.records()).containsExactlyInAnyOrderElementsOf(records);
+    }
+
+    @Test
+    void streamRollbackEffectsEmitsSimpleBlockAsPrimitives() {
+        BlockBreakRecord record = breakAt(UUID.randomUUID(), "Alice", 7, 1,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(record));
+
+        CapturingSink rollback = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, true, rollback);
+        assertThat(rollback.complex).isEmpty();
+        assertThat(rollback.blocks).singleElement().satisfies(b -> {
+            assertThat(b.data()).isEqualTo("minecraft:stone"); // rollback writes the before-state
+            assertThat(b.x()).isEqualTo(7);
+            assertThat(b.world()).isEqualTo(WORLD);
+        });
+
+        CapturingSink restore = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, false, restore);
+        assertThat(restore.blocks).singleElement().satisfies(
+                b -> assertThat(b.data()).isEqualTo("minecraft:air")); // restore writes the after-state
+    }
+
+    @Test
+    void streamRollbackEffectsEmitsContainerAndEntityAsComplexAndSkipsChat() {
+        store.save(List.of(deposit(1), death("ZOMBIE"), chat("noise")));
+
+        CapturingSink sink = new CapturingSink();
+        store.streamRollbackEffects(request(List.of()), null, 1000, true, sink);
+
+        // chat is filtered out at the SQL level (not rollbackable).
+        assertThat(sink.skips).isZero();
+        assertThat(sink.blocks).isEmpty();
+        assertThat(sink.complex).hasSize(2);
+        assertThat(sink.complex).anySatisfy(e ->
+                assertThat(e).isInstanceOf(RollbackEffect.ContainerSlotWrite.class));
+        assertThat(sink.complex).anySatisfy(e ->
+                assertThat(e).isInstanceOf(RollbackEffect.EntitySpawn.class));
+    }
+
+    @Test
+    void keysetPageReturnsEveryRowOnceInOrder() {
+        List<EventRecord> saved = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            saved.add(simpleBreak(i));
+        }
+        store.save(saved);
+
+        List<UUID> seen = new ArrayList<>();
+        QueryPage.Cursor cursor = null;
+        do {
+            QueryPage page = store.queryPage(request(List.of()), cursor, 7);
+            page.records().forEach(r -> seen.add(r.id()));
+            cursor = page.next();
+        } while (cursor != null);
+
+        List<UUID> newestFirst = new ArrayList<>(saved.stream().map(EventRecord::id).toList());
+        java.util.Collections.reverse(newestFirst);
+        assertThat(seen).containsExactlyElementsOf(newestFirst);
+    }
+
+    @Test
+    void predicatePushdownFiltersByPlayerEventAndTime() {
+        UUID alice = UUID.randomUUID();
+        BlockBreakRecord aliceBreak = breakAt(alice, "Alice", 1, 10,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        BlockBreakRecord bobBreak = breakAt(UUID.randomUUID(), "Bob", 2, 10,
+                simple(Material.DIRT, "minecraft:dirt"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(aliceBreak, bobBreak, chat("hi")));
+
+        QueryResult byPlayer = store.query(request(List.of(
+                new QueryPredicate.Eq("source.playerId", alice))));
+        assertThat(byPlayer.records()).containsExactly(aliceBreak);
+
+        QueryResult byEvent = store.query(request(List.of(
+                new QueryPredicate.Eq("event", "break"))));
+        assertThat(byEvent.records()).containsExactlyInAnyOrder(aliceBreak, bobBreak);
+
+        QueryResult byTime = store.query(request(List.of(
+                new QueryPredicate.Range("occurred", BASE.minusSeconds(20), BASE.minusSeconds(5)))));
+        assertThat(byTime.records()).containsExactlyInAnyOrder(aliceBreak, bobBreak);
+    }
+
+    @Test
+    void absentPaletteValueMatchesNothing() {
+        store.save(List.of(simpleBreak(1)));
+        QueryResult result = store.query(request(List.of(
+                new QueryPredicate.Eq("source.playerId", UUID.randomUUID())))); // never recorded
+        assertThat(result.records()).isEmpty();
+    }
+
+    @Test
+    void coordinateRangeReturnsBlocksInBox() {
+        store.save(List.of(simpleBreak(5), simpleBreak(50), simpleBreak(500)));
+        QueryResult inBox = store.query(request(List.of(
+                new QueryPredicate.Range("location.x", 0, 100),
+                new QueryPredicate.Range("location.z", 0, 100))));
+        // x and z are equal in simpleBreak(n); only n in [0,100] qualifies.
+        assertThat(inBox.records()).hasSize(2);
+    }
+
+    @Test
+    void regexPredicateFallsToPostFilter() {
+        store.save(List.of(
+                breakAt(UUID.randomUUID(), "Alice", 1, 1,
+                        simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air")),
+                breakAt(UUID.randomUUID(), "Bartholomew", 2, 1,
+                        simple(Material.DIRT, "minecraft:dirt"), simple(Material.AIR, "minecraft:air"))));
+
+        QueryResult result = store.query(request(List.of(new QueryPredicate.Eq(
+                "source.playerName", Pattern.compile("Alic.*")))));
+        assertThat(result.records()).singleElement().satisfies(
+                r -> assertThat(r.sourceName()).isEqualTo("Alice"));
+    }
+
+    @Test
+    void paletteInternsRepeatedValuesOnce() throws SQLException {
+        UUID player = UUID.randomUUID();
+        store.save(List.of(
+                breakAt(player, "Zed", 1, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air")),
+                breakAt(player, "Zed", 2, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air")),
+                breakAt(player, "Zed", 3, 1, simple(Material.STONE, "minecraft:stone"),
+                        simple(Material.AIR, "minecraft:air"))));
+        // Exactly two UUIDs (world + player) despite three rows.
+        assertThat(rawCount("uuids")).isEqualTo(2L);
+        // A small fixed set of strings, NOT three-per-row.
+        assertThat(rawCount("dict")).isLessThan(12L);
+    }
+
+    @Test
+    void retentionPrunesExpiredRows() throws SQLException {
+        BlockBreakRecord fresh = simpleBreak(1);
+        Instant old = BASE.minusSeconds(2 * RETENTION);
+        BlockBreakRecord stale = new BlockBreakRecord(EventIds.newId(), "break",
+                old, old.plusSeconds(RETENTION),
+                Origin.player(), Source.player(UUID.randomUUID(), "Old"),
+                new BlockLocation(WORLD, "world", 9, 64, 9), "srv", "STONE",
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(fresh, stale));
+        assertThat(rawCount("records")).isEqualTo(2L);
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned).isEqualTo(1L);
+        assertThat(store.query(request(List.of())).records()).containsExactly(fresh);
+    }
+
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        record Block(UUID world, int x, int y, int z, String data) {
+        }
+
+        final List<Block> blocks = new ArrayList<>();
+        final List<RollbackEffect> complex = new ArrayList<>();
+        int skips;
+
+        @Override
+        public void block(UUID world, int x, int y, int z, String data, String expected,
+                          Instant occurred, UUID id) {
+            blocks.add(new Block(world, x, y, z, data));
+        }
+
+        @Override
+        public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+            complex.add(effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skips++;
+        }
+    }
+}

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
 import net.medievalrp.spyglass.plugin.storage.IndexManager;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
 import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
 import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
@@ -117,6 +118,14 @@ public final class SpyglassProxy {
                         ? configured
                         : dataDirectory.resolve(configured);
                 yield new SqliteRecordStore(dbPath, true);
+            }
+            case MARIADB -> {
+                // Read-only companion: same network-served database the Paper
+                // server writes to, opened read-only (no schema create / TTL).
+                SpyglassProxyConfig.MariaDb maria = db.mariadb();
+                yield new MariaDbRecordStore(
+                        maria.host(), maria.port(), maria.database(),
+                        maria.user(), maria.password(), maria.ssl(), true);
             }
         };
     }

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
@@ -37,8 +37,9 @@ public record SpyglassProxyConfig(
             case "clickhouse" -> Backend.CLICKHOUSE;
             case "sqlite" -> Backend.SQLITE;
             case "mongo", "mongodb" -> Backend.MONGO;
+            case "mariadb", "mysql", "maria" -> Backend.MARIADB;
             default -> throw new IOException("Unknown database.backend: " + backendName
-                    + " (expected 'mongo', 'clickhouse', or 'sqlite')");
+                    + " (expected 'sqlite', 'mongo', 'clickhouse', or 'mariadb')");
         };
 
         return new SpyglassProxyConfig(
@@ -56,7 +57,14 @@ public record SpyglassProxyConfig(
                                 root.node("database", "clickhouse", "password").getString(""),
                                 root.node("database", "clickhouse", "ssl").getBoolean(false)),
                         new Sqlite(
-                                root.node("database", "sqlite", "path").getString("spyglass.db"))),
+                                root.node("database", "sqlite", "path").getString("spyglass.db")),
+                        new MariaDb(
+                                root.node("database", "mariadb", "host").getString("localhost"),
+                                root.node("database", "mariadb", "port").getInt(3306),
+                                root.node("database", "mariadb", "database").getString("spyglass"),
+                                root.node("database", "mariadb", "user").getString("root"),
+                                root.node("database", "mariadb", "password").getString(""),
+                                root.node("database", "mariadb", "ssl").getBoolean(false))),
                 new Defaults(
                         Duration.parse(root.node("defaults", "time").getString("4h"))),
                 new Limits(
@@ -67,7 +75,8 @@ public record SpyglassProxyConfig(
     public enum Backend {
         MONGO,
         CLICKHOUSE,
-        SQLITE
+        SQLITE,
+        MARIADB
     }
 
     public record Database(
@@ -76,7 +85,23 @@ public record SpyglassProxyConfig(
             String name,
             String collection,
             ClickHouse clickhouse,
-            Sqlite sqlite) {
+            Sqlite sqlite,
+            MariaDb mariadb) {
+    }
+
+    /**
+     * MariaDB / MySQL connection settings (used when
+     * {@code backend = "mariadb"} / {@code "mysql"}). Served over the
+     * network, so unlike the embedded SQLite file the proxy reaches it the
+     * same way the Paper server does - it just opens it read-only.
+     */
+    public record MariaDb(
+            String host,
+            int port,
+            String database,
+            String user,
+            String password,
+            boolean ssl) {
     }
 
     /**
@@ -124,8 +149,8 @@ public record SpyglassProxyConfig(
                 # Spyglass plugin. Copy the database block from your Paper
                 # config.conf so this proxy reads the same backend.
                 database {
-                  # "mongo", "clickhouse", or "sqlite" - must match the
-                  # Paper-side backend.
+                  # "sqlite", "mongo", "clickhouse", or "mariadb" - must
+                  # match the Paper-side backend.
                   backend = "mongo"
 
                   # Mongo (used when backend = "mongo")
@@ -151,6 +176,18 @@ public record SpyglassProxyConfig(
                   # network the way Mongo / ClickHouse are.
                   sqlite {
                     path = "spyglass.db"
+                  }
+
+                  # MariaDB / MySQL (used when backend = "mariadb"). Served
+                  # over the network, so the proxy reaches it the same way
+                  # the Paper server does (read-only).
+                  mariadb {
+                    host = "localhost"
+                    port = 3306
+                    database = "spyglass"
+                    user = "root"
+                    password = ""
+                    ssl = false
                   }
                 }
 

--- a/spyglass/build.gradle.kts
+++ b/spyglass/build.gradle.kts
@@ -13,6 +13,7 @@ val paperApiVersion: String by rootProject.extra
 val mongoDriverVersion: String by rootProject.extra
 val clickhouseClientVersion: String by rootProject.extra
 val sqliteJdbcVersion: String by rootProject.extra
+val mariaDbDriverVersion: String by rootProject.extra
 val configurateVersion: String by rootProject.extra
 val cloudMinecraftVersion: String by rootProject.extra
 val cloudCoreVersion: String by rootProject.extra
@@ -96,6 +97,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
     testImplementation("org.testcontainers:mongodb:$testcontainersVersion")
     testImplementation("org.testcontainers:clickhouse:$testcontainersVersion")
+    testImplementation("org.testcontainers:mariadb:$testcontainersVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -109,6 +111,7 @@ tasks.processResources {
             "mongoDriverVersion" to mongoDriverVersion,
             "clickhouseClientVersion" to clickhouseClientVersion,
             "sqliteJdbcVersion" to sqliteJdbcVersion,
+            "mariaDbDriverVersion" to mariaDbDriverVersion,
             "configurateVersion" to configurateVersion,
             "cloudMinecraftVersion" to cloudMinecraftVersion,
             "cloudCoreVersion" to cloudCoreVersion,

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -100,6 +100,7 @@ import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
 import net.medievalrp.spyglass.plugin.pipeline.DeferredSerializer;
 import net.medievalrp.spyglass.plugin.pipeline.RecordCommittedPublisher;
 import net.medievalrp.spyglass.plugin.rollback.ClickHouseUndoStack;
+import net.medievalrp.spyglass.plugin.rollback.MariaDbUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.MongoUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
 import net.medievalrp.spyglass.plugin.rollback.RollbackPhysicsBlocker;
@@ -107,11 +108,13 @@ import net.medievalrp.spyglass.plugin.rollback.SqliteUndoStack;
 import net.medievalrp.spyglass.plugin.rollback.UndoStack;
 import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
 import net.medievalrp.spyglass.plugin.storage.IndexManager;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
 import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
 import net.medievalrp.spyglass.plugin.storage.RecordStore;
 import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
 import net.medievalrp.spyglass.plugin.storage.SynthesizingRecordStore;
 import net.medievalrp.spyglass.plugin.salvage.ClickHouseSalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.MariaDbSalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.MongoSalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.SqliteSalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.SalvageCapturer;
@@ -120,6 +123,7 @@ import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
 import net.medievalrp.spyglass.plugin.salvage.SalvageWithdrawLogger;
 import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.tool.ClickHouseToolStateStore;
+import net.medievalrp.spyglass.plugin.command.service.tool.MariaDbToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.MongoToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.SqliteToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.ToolStateStore;
@@ -237,6 +241,21 @@ public final class SpyglassPlugin extends JavaPlugin {
                     undoStack = new SqliteUndoStack(sqliteStore);
                     toolStateStore = new SqliteToolStateStore(sqliteStore);
                     salvageStore = new SqliteSalvageStore(sqliteStore, 30L);
+                }
+                case MARIADB -> {
+                    // Client-server SQL backend: records, undo ledger, wand
+                    // state, and salvage all live in the one MariaDB / MySQL
+                    // database. Retention drives the periodic TTL sweep and the
+                    // reconstructed expiry on column-stored rows.
+                    SpyglassConfig.MariaDb maria = config.database().mariadb();
+                    MariaDbRecordStore mariaStore = new MariaDbRecordStore(
+                            maria.host(), maria.port(), maria.database(),
+                            maria.user(), maria.password(), maria.ssl(),
+                            config.storage().retention().seconds());
+                    recordStore = mariaStore;
+                    undoStack = new MariaDbUndoStack(mariaStore);
+                    toolStateStore = new MariaDbToolStateStore(mariaStore);
+                    salvageStore = new MariaDbSalvageStore(mariaStore, 30L);
                 }
             }
             if (config.storage().rolledAuditSynthesized()) {
@@ -624,7 +643,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         // clash with another plugin's bundled bStats. Opt-out is either
         // metrics.enabled = false here or the server-wide bStats config the
         // library writes. One custom chart reports the storage backend in use
-        // (sqlite / mongo / clickhouse); the rest is bStats' default,
+        // (sqlite / mongo / clickhouse / mariadb); the rest is bStats' default,
         // non-identifying platform data (server software, player count, Java).
         if (config.metrics().enabled()) {
             this.metrics = new Metrics(this, BSTATS_PLUGIN_ID);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/MariaDbToolStateStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/MariaDbToolStateStore.java
@@ -1,0 +1,70 @@
+package net.medievalrp.spyglass.plugin.command.service.tool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * MariaDB / MySQL-backed {@link ToolStateStore} - a small {@code (player_id,
+ * enabled_at)} table in the shared Spyglass database. Point operations on a
+ * {@code VARCHAR(36)} primary key, so {@link #enable} / {@link #disable} are
+ * O(log N) with no scan. Models {@code SqliteToolStateStore}.
+ */
+@ApiStatus.Internal
+public final class MariaDbToolStateStore implements ToolStateStore {
+
+    private final MariaDbRecordStore store;
+
+    public MariaDbToolStateStore(MariaDbRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS tool_states ("
+                        + "player_id VARCHAR(36) NOT NULL PRIMARY KEY, enabled_at BIGINT) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Collection<UUID> loadActive() {
+        return store.withReadConnection(conn -> {
+            List<UUID> out = new ArrayList<>();
+            try (var st = conn.createStatement();
+                 var rs = st.executeQuery("SELECT player_id FROM tool_states")) {
+                while (rs.next()) {
+                    out.add(UUID.fromString(rs.getString("player_id")));
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public void enable(UUID playerId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement(
+                    "REPLACE INTO tool_states (player_id, enabled_at) VALUES (?, ?)")) {
+                ps.setString(1, playerId.toString());
+                ps.setLong(2, System.currentTimeMillis());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void disable(UUID playerId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM tool_states WHERE player_id = ?")) {
+                ps.setString(1, playerId.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -69,8 +69,9 @@ public record SpyglassConfig(
             case "clickhouse" -> Backend.CLICKHOUSE;
             case "sqlite" -> Backend.SQLITE;
             case "mongo", "mongodb" -> Backend.MONGO;
+            case "mariadb", "mysql", "maria" -> Backend.MARIADB;
             default -> throw new IOException("Unknown database.backend: " + backendName
-                    + " (expected 'mongo', 'clickhouse', or 'sqlite')");
+                    + " (expected 'sqlite', 'mongo', 'clickhouse', or 'mariadb')");
         };
         return new SpyglassConfig(
                 new Database(
@@ -87,7 +88,14 @@ public record SpyglassConfig(
                                 root.node("database", "clickhouse", "password").getString(""),
                                 root.node("database", "clickhouse", "ssl").getBoolean(false)),
                         new Sqlite(
-                                root.node("database", "sqlite", "path").getString("spyglass.db"))),
+                                root.node("database", "sqlite", "path").getString("spyglass.db")),
+                        new MariaDb(
+                                root.node("database", "mariadb", "host").getString("localhost"),
+                                root.node("database", "mariadb", "port").getInt(3306),
+                                root.node("database", "mariadb", "database").getString("spyglass"),
+                                root.node("database", "mariadb", "user").getString("root"),
+                                root.node("database", "mariadb", "password").getString(""),
+                                root.node("database", "mariadb", "ssl").getBoolean(false))),
                 new Storage(
                         Duration.parse(root.node("storage", "retention").getString("4w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
@@ -200,11 +208,19 @@ public record SpyglassConfig(
      * embedded SQLite file ({@code database.sqlite.path}), so a small or
      * medium server runs Spyglass with no external database process at
      * all.
+     *
+     * <p>{@link #MARIADB} is the client-server SQL option for operators
+     * who already run a MariaDB or MySQL server (the common shared-host /
+     * panel setup). Like ClickHouse and SQLite it is fully self-contained -
+     * the records, undo ledger, wand state, and salvage all live in that
+     * one database. The config name {@code "mariadb"}, {@code "mysql"}, and
+     * {@code "maria"} all select it; one driver speaks both protocols.
      */
     public enum Backend {
         MONGO,
         CLICKHOUSE,
-        SQLITE
+        SQLITE,
+        MARIADB
     }
 
     public record Database(
@@ -213,7 +229,23 @@ public record SpyglassConfig(
             String name,
             String collection,
             ClickHouse clickhouse,
-            Sqlite sqlite) {
+            Sqlite sqlite,
+            MariaDb mariadb) {
+    }
+
+    /**
+     * MariaDB / MySQL connection settings (used when
+     * {@code backend = "mariadb"} / {@code "mysql"}). The database is
+     * created on first start if the configured user has rights to;
+     * otherwise pre-create it and point a least-privilege user here.
+     */
+    public record MariaDb(
+            String host,
+            int port,
+            String database,
+            String user,
+            String password,
+            boolean ssl) {
     }
 
     /**

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/MariaDbUndoStack.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/MariaDbUndoStack.java
@@ -1,0 +1,149 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * MariaDB / MySQL-backed {@link UndoStack}. One small row per undo
+ * operation, stored <b>by reference</b> (the resolved query that replays
+ * the original op in the opposite direction - see {@code UndoReferenceBson}),
+ * mirroring the reference-only contract the other backends settled on (#17).
+ *
+ * <p>A 24h horizon is enforced with an opportunistic delete on each push
+ * (neither engine has a native TTL), matching the 1-day window the other
+ * backends TTL. Models {@code SqliteUndoStack}; self-creates its table in
+ * the shared Spyglass database.
+ */
+@ApiStatus.Internal
+public final class MariaDbUndoStack implements UndoStack {
+
+    private static final long TTL_MS = java.util.concurrent.TimeUnit.DAYS.toMillis(1);
+
+    private final MariaDbRecordStore store;
+
+    public MariaDbUndoStack(MariaDbRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS undo_history ("
+                        + "operation_id VARCHAR(36) NOT NULL PRIMARY KEY, "
+                        + "player_id VARCHAR(36) NOT NULL, "
+                        + "created_at BIGINT NOT NULL, "
+                        + "operation_type VARCHAR(64) NOT NULL, "
+                        + "reference MEDIUMTEXT NOT NULL, "
+                        + "KEY idx_undo_player (player_id, created_at)) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void pushReference(UUID playerId, String operationType, String referenceBase64) {
+        UUID operationId = UUID.randomUUID();
+        long now = System.currentTimeMillis();
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("INSERT INTO undo_history "
+                    + "(operation_id, player_id, created_at, operation_type, reference) "
+                    + "VALUES (?, ?, ?, ?, ?)")) {
+                ps.setString(1, operationId.toString());
+                ps.setString(2, playerId.toString());
+                ps.setLong(3, now);
+                ps.setString(4, operationType + REF_MARKER);
+                ps.setString(5, referenceBase64);
+                ps.executeUpdate();
+            }
+            // Opportunistic TTL: drop anything past the 24h window.
+            try (var ps = conn.prepareStatement("DELETE FROM undo_history WHERE created_at < ?")) {
+                ps.setLong(1, now - TTL_MS);
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Optional<Popped> openLatest(UUID playerId) {
+        return store.withReadConnection(conn -> {
+            try (var ps = conn.prepareStatement("SELECT operation_id, created_at, "
+                    + "operation_type, reference FROM undo_history "
+                    + "WHERE player_id = ? AND created_at >= ? "
+                    + "ORDER BY created_at DESC LIMIT 1")) {
+                ps.setString(1, playerId.toString());
+                ps.setLong(2, System.currentTimeMillis() - TTL_MS);
+                try (var rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return Optional.empty();
+                    }
+                    UUID operationId = UUID.fromString(rs.getString("operation_id"));
+                    Instant createdAt = Instant.ofEpochMilli(rs.getLong("created_at"));
+                    String storedType = rs.getString("operation_type");
+                    String reference = rs.getString("reference");
+                    String type = storedType.endsWith(REF_MARKER)
+                            ? storedType.substring(0, storedType.length() - REF_MARKER.length())
+                            : storedType;
+                    return Optional.of(new Reference(operationId, createdAt, type, reference));
+                }
+            }
+        });
+    }
+
+    private void tombstone(UUID operationId) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM undo_history WHERE operation_id = ?")) {
+                ps.setString(1, operationId.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    private final class Reference implements ReplayReference {
+
+        private final UUID operationId;
+        private final Instant createdAt;
+        private final String operationType;
+        private String reference;
+
+        private Reference(UUID operationId, Instant createdAt,
+                          String operationType, String reference) {
+            this.operationId = operationId;
+            this.createdAt = createdAt;
+            this.operationType = operationType;
+            this.reference = reference;
+        }
+
+        @Override
+        public UUID operationId() {
+            return operationId;
+        }
+
+        @Override
+        public Instant createdAt() {
+            return createdAt;
+        }
+
+        @Override
+        public String operationType() {
+            return operationType;
+        }
+
+        @Override
+        public String referenceBase64() {
+            return reference;
+        }
+
+        @Override
+        public void tombstone() {
+            MariaDbUndoStack.this.tombstone(operationId);
+        }
+
+        @Override
+        public void close() {
+            reference = null;
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/MariaDbSalvageStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/MariaDbSalvageStore.java
@@ -1,0 +1,220 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.BsonBlobs;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * MariaDB / MySQL-backed {@link SalvageStore}. A row per captured container
+ * inventory in the shared Spyglass database, keyed on {@code id} so an
+ * extraction's {@link #replaceItems} overwrites in place and {@link #delete}
+ * removes the emptied snapshot. Items are a {@code |}-joined list of
+ * {@link BsonBlobs#encodeStoredItem} blobs - the base64 alphabet never
+ * contains {@code |}, so the split is unambiguous. Models
+ * {@code SqliteSalvageStore}; self-creates its table.
+ */
+@ApiStatus.Internal
+public final class MariaDbSalvageStore implements SalvageStore {
+
+    private final MariaDbRecordStore store;
+    private final long ttlMs;
+
+    public MariaDbSalvageStore(MariaDbRecordStore store, long ttlDays) {
+        this.store = store;
+        this.ttlMs = ttlDays > 0 ? java.util.concurrent.TimeUnit.DAYS.toMillis(ttlDays) : 0L;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS salvage ("
+                        + "id VARCHAR(36) NOT NULL PRIMARY KEY, "
+                        + "rollback_op_id VARCHAR(36), "
+                        + "world_id VARCHAR(36), world_name VARCHAR(255), "
+                        + "x INT, y INT, z INT, "
+                        + "container_type VARCHAR(255), operator_name VARCHAR(255), "
+                        + "captured_at BIGINT, items MEDIUMTEXT, "
+                        + "KEY idx_salvage_captured (captured_at), "
+                        + "KEY idx_salvage_rollback (rollback_op_id)) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void save(SalvageSnapshot snapshot) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("REPLACE INTO salvage "
+                    + "(id, rollback_op_id, world_id, world_name, x, y, z, "
+                    + "container_type, operator_name, captured_at, items) "
+                    + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                ps.setString(1, snapshot.id().toString());
+                ps.setString(2, snapshot.rollbackOpId() == null ? null : snapshot.rollbackOpId().toString());
+                ps.setString(3, snapshot.worldId() == null ? null : snapshot.worldId().toString());
+                ps.setString(4, snapshot.worldName());
+                ps.setInt(5, snapshot.x());
+                ps.setInt(6, snapshot.y());
+                ps.setInt(7, snapshot.z());
+                ps.setString(8, snapshot.containerType());
+                ps.setString(9, snapshot.operatorName());
+                ps.setLong(10, snapshot.capturedAt().toEpochMilli());
+                ps.setString(11, encodeItems(snapshot.items()));
+                ps.executeUpdate();
+            }
+            pruneExpired(conn);
+            return null;
+        });
+    }
+
+    @Override
+    public List<SalvageSnapshot> list(int limit) {
+        return store.withReadConnection(conn -> {
+            List<SalvageSnapshot> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement(selectColumns()
+                    + " FROM salvage ORDER BY captured_at DESC LIMIT ?")) {
+                ps.setInt(1, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        out.add(fromRow(rs));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public List<RollbackGroup> listRollbacks(int limit) {
+        return store.withReadConnection(conn -> {
+            List<RollbackGroup> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement("SELECT rollback_op_id, count(*) AS c, "
+                    + "max(operator_name) AS op, max(captured_at) AS latest FROM salvage "
+                    + "WHERE rollback_op_id IS NOT NULL "
+                    + "GROUP BY rollback_op_id ORDER BY latest DESC LIMIT ?")) {
+                ps.setInt(1, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        String rollbackId = rs.getString("rollback_op_id");
+                        out.add(new RollbackGroup(UUID.fromString(rollbackId), rs.getInt("c"),
+                                rs.getString("op"), Instant.ofEpochMilli(rs.getLong("latest"))));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public List<SalvageSnapshot> listByRollback(UUID rollbackId, int limit) {
+        return store.withReadConnection(conn -> {
+            List<SalvageSnapshot> out = new ArrayList<>();
+            try (var ps = conn.prepareStatement(selectColumns()
+                    + " FROM salvage WHERE rollback_op_id = ? ORDER BY captured_at DESC LIMIT ?")) {
+                ps.setString(1, rollbackId.toString());
+                ps.setInt(2, Math.max(1, limit));
+                try (var rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        out.add(fromRow(rs));
+                    }
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public Optional<SalvageSnapshot> get(UUID id) {
+        return store.withReadConnection(conn -> {
+            try (var ps = conn.prepareStatement(selectColumns() + " FROM salvage WHERE id = ? LIMIT 1")) {
+                ps.setString(1, id.toString());
+                try (var rs = ps.executeQuery()) {
+                    return rs.next() ? Optional.of(fromRow(rs)) : Optional.<SalvageSnapshot>empty();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void replaceItems(UUID id, List<StoredItem> remaining) {
+        get(id).ifPresent(current -> save(current.withItems(remaining)));
+    }
+
+    @Override
+    public void delete(UUID id) {
+        store.withWriteConnection(conn -> {
+            try (var ps = conn.prepareStatement("DELETE FROM salvage WHERE id = ?")) {
+                ps.setString(1, id.toString());
+                ps.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    private void pruneExpired(java.sql.Connection conn) throws SQLException {
+        if (ttlMs <= 0) {
+            return;
+        }
+        try (var ps = conn.prepareStatement("DELETE FROM salvage WHERE captured_at < ?")) {
+            ps.setLong(1, System.currentTimeMillis() - ttlMs);
+            ps.executeUpdate();
+        }
+    }
+
+    private static String selectColumns() {
+        return "SELECT id, rollback_op_id, world_id, world_name, x, y, z, "
+                + "container_type, operator_name, captured_at, items";
+    }
+
+    private static SalvageSnapshot fromRow(ResultSet rs) throws SQLException {
+        String rollbackId = rs.getString("rollback_op_id");
+        String worldId = rs.getString("world_id");
+        return new SalvageSnapshot(
+                UUID.fromString(rs.getString("id")),
+                rollbackId == null ? null : UUID.fromString(rollbackId),
+                worldId == null ? null : UUID.fromString(worldId),
+                rs.getString("world_name"),
+                rs.getInt("x"), rs.getInt("y"), rs.getInt("z"),
+                rs.getString("container_type"),
+                rs.getString("operator_name"),
+                Instant.ofEpochMilli(rs.getLong("captured_at")),
+                decodeItems(rs.getString("items")));
+    }
+
+    // Items as a '|'-joined list of base64 blobs; the base64 alphabet never
+    // contains '|', so the split is unambiguous.
+    static String encodeItems(List<StoredItem> items) {
+        StringBuilder sb = new StringBuilder();
+        for (StoredItem item : items) {
+            String enc = BsonBlobs.encodeStoredItem(item);
+            if (enc != null) {
+                if (sb.length() > 0) {
+                    sb.append('|');
+                }
+                sb.append(enc);
+            }
+        }
+        return sb.toString();
+    }
+
+    static List<StoredItem> decodeItems(String blob) {
+        List<StoredItem> items = new ArrayList<>();
+        if (blob == null || blob.isEmpty()) {
+            return items;
+        }
+        for (String part : blob.split("\\|")) {
+            if (!part.isEmpty()) {
+                StoredItem item = BsonBlobs.decodeStoredItem(part);
+                if (item != null) {
+                    items.add(item);
+                }
+            }
+        }
+        return items;
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -1,8 +1,8 @@
 database {
   # Which backend stores Spyglass data. Pick one — operators run
-  # exactly one of MongoDB, ClickHouse, or SQLite, never several. The
-  # chosen backend stores the primary EventRecord stream AND the
-  # auxiliary UndoHistory / Tools / Salvage collections; the unused
+  # exactly one of SQLite, MongoDB, ClickHouse, or MariaDB/MySQL, never
+  # several. The chosen backend stores the primary EventRecord stream AND
+  # the auxiliary UndoHistory / Tools / Salvage collections; the unused
   # backend blocks are ignored.
   #
   # "sqlite"     — embedded SQLite file; the default. Zero external
@@ -18,6 +18,11 @@ database {
   #                on per-player /spyglass search lookups (architectural
   #                trade-off — sparse primary index vs. B-tree). For the
   #                largest servers.
+  # "mariadb"    — MariaDB / MySQL ("mysql" selects the same backend). The
+  #                client-server SQL option for operators who already run a
+  #                MariaDB or MySQL server (the common shared-host / panel
+  #                setup). Same dense palette-interned schema as the SQLite
+  #                backend, against the database you already operate.
   backend = "sqlite"
 
   # The defaults below assume the database lives on THIS host. Before
@@ -49,6 +54,17 @@ database {
     # next to it. Put it on a local disk (not a network mount) for the
     # WAL locking to behave.
     path = "spyglass.db"
+  }
+
+  # MariaDB / MySQL connection (used when backend = "mariadb" or "mysql").
+  # One driver speaks both protocols, so either name selects this block.
+  mariadb {
+    host = "localhost"       # MariaDB / MySQL server host
+    port = 3306              # the default MySQL/MariaDB port
+    database = "spyglass"    # schema name; created on first start if the user can
+    user = "root"            # database user
+    password = ""            # password for that user ("" = none)
+    ssl = false              # true to connect over TLS (encrypt, no cert verify)
   }
 }
 

--- a/spyglass/src/main/resources/plugin.yml
+++ b/spyglass/src/main/resources/plugin.yml
@@ -40,6 +40,7 @@ libraries:
   - com.clickhouse:clickhouse-http-client:${clickhouseClientVersion}
   - com.clickhouse:clickhouse-data:${clickhouseClientVersion}
   - org.xerial:sqlite-jdbc:${sqliteJdbcVersion}
+  - org.mariadb.jdbc:mariadb-java-client:${mariaDbDriverVersion}
   - org.spongepowered:configurate-hocon:${configurateVersion}
   - org.incendo:cloud-paper:${cloudMinecraftVersion}
   - org.incendo:cloud-annotations:${cloudCoreVersion}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/mariadb/MariaDbAuxStoresIT.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/mariadb/MariaDbAuxStoresIT.java
@@ -1,0 +1,168 @@
+package net.medievalrp.spyglass.plugin.mariadb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.command.service.tool.MariaDbToolStateStore;
+import net.medievalrp.spyglass.plugin.rollback.MariaDbUndoStack;
+import net.medievalrp.spyglass.plugin.rollback.UndoStack;
+import net.medievalrp.spyglass.plugin.salvage.MariaDbSalvageStore;
+import net.medievalrp.spyglass.plugin.salvage.SalvageSnapshot;
+import net.medievalrp.spyglass.plugin.salvage.SalvageStore;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Covers the three MariaDB auxiliary stores (#169) - undo ledger, wand
+ * state, salvage - sharing the record store's connection, against a real
+ * InnoDB engine. Mirrors {@code SqliteAuxStoresTest}. Requires Docker.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MariaDbAuxStoresIT {
+
+    private MariaDBContainer<?> container;
+    private String host;
+    private int port;
+    private String db;
+    private String user;
+    private String pw;
+    private MariaDbRecordStore store;
+
+    @BeforeAll
+    void setup() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        container = new MariaDBContainer<>(DockerImageName.parse("mariadb:11"));
+        container.start();
+        host = container.getHost();
+        port = container.getFirstMappedPort();
+        db = container.getDatabaseName();
+        user = container.getUsername();
+        pw = container.getPassword();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @BeforeEach
+    void fresh() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:mariadb://" + host + ":" + port + "/" + db, user, pw);
+             Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS undo_history");
+            st.execute("DROP TABLE IF EXISTS tool_states");
+            st.execute("DROP TABLE IF EXISTS salvage");
+            st.execute("DROP TABLE IF EXISTS records");
+            st.execute("DROP TABLE IF EXISTS dict");
+            st.execute("DROP TABLE IF EXISTS uuids");
+        }
+        store = new MariaDbRecordStore(host, port, db, user, pw, false, 3600L);
+    }
+
+    @AfterEach
+    void close() {
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    @Test
+    void undoPushOpenAndTombstone() {
+        MariaDbUndoStack undo = new MariaDbUndoStack(store);
+        UUID player = UUID.randomUUID();
+        assertThat(undo.openLatest(player)).isEmpty();
+
+        undo.pushReference(player, "ROLLBACK", "ref-blob-base64");
+        Optional<UndoStack.Popped> popped = undo.openLatest(player);
+        assertThat(popped).isPresent();
+        UndoStack.Popped op = popped.get();
+        assertThat(op).isInstanceOf(UndoStack.ReplayReference.class);
+        assertThat(op.operationType()).isEqualTo("ROLLBACK"); // marker stripped
+        assertThat(((UndoStack.ReplayReference) op).referenceBase64()).isEqualTo("ref-blob-base64");
+
+        op.tombstone();
+        assertThat(undo.openLatest(player)).isEmpty();
+    }
+
+    @Test
+    void undoReturnsNewestPerPlayer() {
+        MariaDbUndoStack undo = new MariaDbUndoStack(store);
+        UUID player = UUID.randomUUID();
+        undo.pushReference(player, "ROLLBACK", "older");
+        undo.pushReference(player, "RESTORE", "newer");
+        UndoStack.Popped op = undo.openLatest(player).orElseThrow();
+        assertThat(op.operationType()).isEqualTo("RESTORE");
+        assertThat(((UndoStack.ReplayReference) op).referenceBase64()).isEqualTo("newer");
+    }
+
+    @Test
+    void toolStateEnableDisableLoad() {
+        MariaDbToolStateStore tools = new MariaDbToolStateStore(store);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        assertThat(tools.loadActive()).isEmpty();
+
+        tools.enable(a);
+        tools.enable(b);
+        tools.enable(a); // idempotent upsert
+        assertThat(tools.loadActive()).containsExactlyInAnyOrder(a, b);
+
+        tools.disable(a);
+        assertThat(tools.loadActive()).containsExactly(b);
+    }
+
+    @Test
+    void salvageSaveGetReplaceDelete() {
+        MariaDbSalvageStore salvage = new MariaDbSalvageStore(store, 30L);
+        UUID id = UUID.randomUUID();
+        UUID rollbackOp = UUID.randomUUID();
+        SalvageSnapshot snapshot = new SalvageSnapshot(id, rollbackOp,
+                UUID.randomUUID(), "world", 1, 64, 2, "CHEST", "Operator",
+                java.time.Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS),
+                List.of(new StoredItem(0, "DIAMOND", "minecraft:diamond"),
+                        new StoredItem(1, "GOLD_INGOT", "minecraft:gold_ingot")));
+
+        salvage.save(snapshot);
+        Optional<SalvageSnapshot> fetched = salvage.get(id);
+        assertThat(fetched).isPresent();
+        assertThat(fetched.get().items()).hasSize(2);
+        assertThat(fetched.get().containerType()).isEqualTo("CHEST");
+        assertThat(fetched.get().operatorName()).isEqualTo("Operator");
+
+        assertThat(salvage.list(10)).hasSize(1);
+        List<SalvageStore.RollbackGroup> groups = salvage.listRollbacks(10);
+        assertThat(groups).singleElement().satisfies(g -> {
+            assertThat(g.rollbackId()).isEqualTo(rollbackOp);
+            assertThat(g.containerCount()).isEqualTo(1);
+        });
+        assertThat(salvage.listByRollback(rollbackOp, 10)).hasSize(1);
+
+        salvage.replaceItems(id, List.of(new StoredItem(0, "DIAMOND", "minecraft:diamond")));
+        assertThat(salvage.get(id).orElseThrow().items()).hasSize(1);
+
+        salvage.delete(id);
+        assertThat(salvage.get(id)).isEmpty();
+        assertThat(salvage.list(10)).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #169.

Fourth backend alongside SQLite, MongoDB, and ClickHouse, for operators who already run a MariaDB or MySQL server. One driver (MariaDB Connector/J, LGPL-2.1) speaks both wire protocols, so `backend = "mariadb"` and `"mysql"` are aliases for the same store.

## Design

Forks the SQLite store's dense design (#106) onto InnoDB rather than inventing a second schema. Every density lever carries over: palette interning (`dict` / `uuids` tables of small int refs), the hybrid column/blob schema (a clean player-sourced simple block lives in columns; everything else carries one `deflate(BSON)` payload), `seq` as the sole sort key, and the allocation-lean `streamRollbackEffects` rollback read. Dialect adaptations:

- `BIGINT seq` PK (we supply the `EventIds` sequence), `INT AUTO_INCREMENT` palette ids.
- Idempotent **insert-or-get** interning (`INSERT ... ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`) so the recorder's retry-after-failure path can't trip the `UNIQUE` constraint.
- `MEDIUMBLOB` payload; chunk bucket as **virtual generated columns** `cx = FLOOR(x/16)` / `cz` indexed by `idx_loc` (MariaDB/MySQL can't portably index an inline expression the way SQLite does).
- `ROW_FORMAT=COMPRESSED` with a graceful fallback to the default row format when a host lacks `innodb_file_per_table`.
- A small DriverManager connection pool (validate-and-reopen reads against idle timeouts), retention via a scheduled `DELETE`, schema auto-create best-effort (least-privilege users pre-create the DB).

## Parity surface

`MariaDbRecordStore` + the three aux stores (`MariaDbUndoStack`, `MariaDbSalvageStore`, `MariaDbToolStateStore`) + `MariaDbPredicateToSql`; config (`Backend.MARIADB` + `MariaDb` record + parse) and switch wiring on the plugin and the read-only Velocity proxy; driver dependency + `plugin.yml` library + Gradle/processResources wiring; `config.conf`, README, bStats comment.

## Verification

- **Live in-game test** (Paper 1.21.8, lean jar so the driver loads via Paper's library loader): boots `backend = MARIADB`, auto-creates the schema, records block edits, and `/sg rollback` + `/sg undo` round-trip with the world state ground-truth-verified by vanilla `execute if block` (air -> stone -> rollback -> stone -> undo). Rolled-audit stays synthesized (a 2M rollback adds ~1 row, not 2M).
- The live test caught a real bug a clean build didn't: non-idempotent palette interning hit `Duplicate entry ... for key 'uq_dict_val'` on the recorder's retry path. Fixed (insert-or-get) and re-verified live.

## Tests

`MariaDbRecordStoreIT` (Testcontainers, 13 cases - the SQLite suite ported), `MariaDbAuxStoresIT` (4), `MariaDbPredicateToSqlTest` (12, no Docker), `MariaDbBench` (`mariadb-bench` tag, `./gradlew :spyglass-core:mariadbBench`, for local measurement only). `./gradlew check` green; jacoco floors hold.

Based on `dev`. Not for merge until reviewed.