### PR TITLE
perf(listener): skip getState() for plain blocks on break/place (#172)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListener.java
@@ -57,9 +57,10 @@ public final class BlockBreakListener implements RecordingListener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        // captureRaw carries the immutable BlockData; getAsString() is deferred
-        // to finishCapture on the serializer thread (#154).
-        BlockSnapshots.RawCapture rawOriginal = BlockSnapshots.captureRaw(event.getBlock().getState());
+        // captureRawCached grabs only the immutable BlockData and skips the
+        // CraftBlockState build for materials proven to carry no tile-entity data
+        // (#168 stage 2); getAsString() stays deferred to finishCapture (#154).
+        BlockSnapshots.RawCapture rawOriginal = BlockSnapshots.captureRawCached(event.getBlock());
         BlockSnapshot after = BlockSnapshots.air();
         BlockLocation location = BlockLocations.fromBlock(event.getBlock());
         // Build context (stamps occurred + time-ordered id) on the main thread

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListener.java
@@ -68,9 +68,12 @@ public final class BlockPlaceListener implements RecordingListener {
                 ? null
                 : BlockSnapshots.captureRaw(event.getBlockReplacedState());
 
-        // captureRaw carries the immutable BlockData; getAsString() is deferred
-        // to finishCapture on the serializer thread (#154).
-        BlockSnapshots.RawCapture rawAfter = BlockSnapshots.captureRaw(event.getBlock().getState());
+        // captureRawCached grabs only the immutable BlockData and skips the
+        // CraftBlockState build for materials proven to carry no tile-entity data
+        // (#168 stage 2); getAsString() stays deferred to finishCapture (#154).
+        // (The before-state above uses the snapshot Bukkit already built for the
+        // event, so there is no getState() of ours to skip there.)
+        BlockSnapshots.RawCapture rawAfter = BlockSnapshots.captureRawCached(event.getBlock());
 
         // Allocation trim (#116): fromBlock avoids a throwaway Location allocation.
         BlockLocation location = BlockLocations.fromBlock(event.getBlock());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockSnapshots.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockSnapshots.java
@@ -9,6 +9,7 @@ import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.block.Banner;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.DecoratedPot;
@@ -146,6 +147,104 @@ public final class BlockSnapshots {
                 bannerPatterns,
                 jukeboxRecord,
                 potSherds);
+    }
+
+    // ---- stage 2: skip getState() for blocks that carry no tile-entity data ----
+    //
+    // For the overwhelming majority of break/place volume - plain terrain and
+    // building blocks - building a full CraftBlockState (an allocation plus a
+    // tile-entity chunk lookup) is wasted: captureRaw reads only the material
+    // and the immutable BlockData from it. captureRawCached grabs just that
+    // BlockData (the irreducible main-thread cost) and skips getState() for any
+    // material PROVEN to produce a non-data-bearing state.
+
+    private static final byte UNKNOWN = 0;
+    private static final byte PLAIN = 1;
+    private static final byte DATA_BEARING = 2;
+
+    /**
+     * Per-{@link Material} plainness verdict, indexed by {@link Material#ordinal()}:
+     * {@code UNKNOWN}, {@code PLAIN} (no tile-entity data {@link #captureRaw}
+     * would extract) or {@code DATA_BEARING} (a Container / Sign / Banner /
+     * Jukebox / DecoratedPot).
+     *
+     * <p>The verdict is learned lazily from the authoritative {@link BlockState}
+     * itself: the first event for a material always runs the full
+     * {@link #captureRaw} path and only then records what that state turned out
+     * to be. A material therefore can never be misclassified into the fast path -
+     * the fast path is only taken after the plugin has seen, on this exact
+     * server, that the material's state is not data-bearing. This is strictly
+     * safer than a hand-maintained allowlist (which a new game version could make
+     * wrong) while needing zero per-version maintenance.
+     *
+     * <p>Bukkit block events fire on the main thread and {@link #captureRaw} is
+     * already documented as main-thread-only, so this array is main-thread
+     * confined and needs no synchronization. (A {@code byte} write is atomic
+     * regardless; the worst a hypothetical race could do is re-learn the same
+     * verdict - never a wrong one, since every learn reads a real state.)
+     */
+    private static final byte[] PLAINNESS = new byte[Material.values().length];
+
+    /**
+     * {@link #captureRaw} for callers holding a live {@link Block} (the break and
+     * place-after hot paths). For a material proven {@link #PLAIN} this skips the
+     * {@link Block#getState()} CraftBlockState construction and its tile-entity
+     * lookup, grabbing only the immutable {@link BlockData} every snapshot needs.
+     * For anything not yet proven plain it falls back to {@code getState()} +
+     * {@link #captureRaw} - byte-for-byte the original behavior - and learns the
+     * verdict for next time.
+     *
+     * <p><b>Correctness:</b> a misclassified container would silently lose its
+     * contents and break rollback for it, so the fast path is gated on the
+     * plugin having itself observed a non-data-bearing state for this material.
+     * {@link #isDataBearing} MUST mirror the tile-entity types special-cased in
+     * {@link #captureRaw}; see its note.
+     */
+    public static RawCapture captureRawCached(Block block) {
+        // The grab: one chunk read + an immutable, world-detached BlockData copy.
+        // This is unavoidable on the main thread and is needed by every snapshot.
+        BlockData data = block.getBlockData();
+        Material type = data.getMaterial();
+        if (PLAINNESS[type.ordinal()] == PLAIN) {
+            return plainCapture(type, data);
+        }
+        // Unknown or known-data-bearing: take the authoritative full path. On the
+        // first sighting of a material, learn its verdict from the real state.
+        BlockState state = block.getState();
+        if (PLAINNESS[type.ordinal()] == UNKNOWN) {
+            PLAINNESS[type.ordinal()] = isDataBearing(state) ? DATA_BEARING : PLAIN;
+        }
+        return captureRaw(state);
+    }
+
+    /**
+     * The {@link RawCapture} for a block with no tile-entity payload - identical
+     * to what {@link #captureRaw} produces for a plain block (empty item / sign /
+     * banner / pot lists, null container contents and jukebox disc), without
+     * building a {@link BlockState}.
+     */
+    private static RawCapture plainCapture(Material type, BlockData data) {
+        return new RawCapture(type, data, null, List.of(), List.of(), List.of(), null, List.of());
+    }
+
+    /**
+     * Whether {@link #captureRaw} would extract tile-entity data from this state.
+     * This is the safety predicate behind {@link #captureRawCached}: it MUST list
+     * exactly the tile-entity types {@link #captureRaw} special-cases. Adding a
+     * new branch to {@code captureRaw} without adding it here would let the
+     * proven-plain fast path silently drop the new data.
+     */
+    static boolean isDataBearing(BlockState state) {
+        return state instanceof Container
+                || state instanceof Sign
+                || state instanceof Banner
+                || state instanceof Jukebox
+                || state instanceof DecoratedPot;
+    }
+
+    /** Visible for tests: clear the learned plainness verdicts. */
+    static void resetPlainnessCache() {
+        java.util.Arrays.fill(PLAINNESS, UNKNOWN);
     }
 
     /**

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockBreakListenerTest.java
@@ -166,11 +166,18 @@ class BlockBreakListenerTest {
         // loop exits immediately (y >= maxHeight).
         when(world.getMaxHeight()).thenReturn(0);
 
+        when(blockData.getMaterial()).thenReturn(Material.STONE);
+
         BlockState state = mock(BlockState.class);
         when(state.getType()).thenReturn(Material.STONE);
         when(state.getBlockData()).thenReturn(blockData);
 
         Block block = mock(Block.class);
+        // captureRawCached (#168 stage 2) grabs getBlockData() first and only
+        // falls back to getState() for materials not yet proven plain; stub both
+        // so the fixture is correct whether the static plainness cache is cold or
+        // already warm from a prior test (STONE is plain -> learns PLAIN once).
+        when(block.getBlockData()).thenReturn(blockData);
         when(block.getState()).thenReturn(state);
         when(block.getWorld()).thenReturn(world);
         when(block.getX()).thenReturn(10);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BlockPlaceListenerTest.java
@@ -205,9 +205,14 @@ class BlockPlaceListenerTest {
         BlockState placedState = mock(BlockState.class);
         when(placedState.getType()).thenReturn(placedMaterial);
         when(placedState.getBlockData()).thenReturn(placedData);
+        when(placedData.getMaterial()).thenReturn(placedMaterial);
 
-        // The block after placing (for fromBlock and getState()).
+        // The block after placing. captureRawCached (#168 stage 2) grabs
+        // getBlockData() first and only falls back to getState() for materials
+        // not yet proven plain; stub both so the fixture works whether the static
+        // plainness cache is cold or already warm (STONE learns PLAIN once).
         Block block = mock(Block.class);
+        when(block.getBlockData()).thenReturn(placedData);
         when(block.getState()).thenReturn(placedState);
         when(block.getWorld()).thenReturn(world);
         when(block.getX()).thenReturn(5);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockSnapshotsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockSnapshotsTest.java
@@ -3,17 +3,24 @@ package net.medievalrp.spyglass.plugin.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
 import net.medievalrp.spyglass.api.event.StoredItem;
 import org.bukkit.Material;
+import org.bukkit.block.Banner;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
+import org.bukkit.block.DecoratedPot;
+import org.bukkit.block.Jukebox;
+import org.bukkit.block.Sign;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,6 +45,121 @@ import org.junit.jupiter.api.Test;
  * would have produced.
  */
 class BlockSnapshotsTest {
+
+    @BeforeEach
+    void clearPlainnessCache() {
+        // The plainness cache (#168 stage 2) is static; reset it so each test
+        // starts from a cold cache regardless of order.
+        BlockSnapshots.resetPlainnessCache();
+    }
+
+    // ---- #168 stage 2: captureRawCached / the learned plainness cache --------
+
+    /**
+     * The first sighting of a material must consult the authoritative
+     * {@link BlockState} (to learn its verdict); once proven plain, subsequent
+     * captures of that material must skip {@code getState()} entirely.
+     */
+    @Test
+    void captureRawCachedLearnsPlainThenSkipsGetState() {
+        PlainFixture f = plainFixture(Material.STONE);
+
+        BlockSnapshots.RawCapture r1 = BlockSnapshots.captureRawCached(f.block);
+        // First time: must read the real state to learn the verdict.
+        verify(f.block, times(1)).getState();
+
+        BlockSnapshots.RawCapture r2 = BlockSnapshots.captureRawCached(f.block);
+        // Proven plain: getState() is NOT called again - the whole point of #168.
+        verify(f.block, times(1)).getState();
+
+        // Both carry the immutable BlockData grab and no tile-entity payload.
+        assertThat(r1.type()).isEqualTo(Material.STONE);
+        assertThat(r2.type()).isEqualTo(Material.STONE);
+        assertThat(r2.blockData()).isSameAs(f.data);
+        assertThat(r2.containerContents()).isNull();
+        assertThat(r2.signFront()).isEmpty();
+        assertThat(r2.signBack()).isEmpty();
+        assertThat(r2.bannerPatterns()).isEmpty();
+        assertThat(r2.potSherds()).isEmpty();
+        assertThat(r2.jukeboxRecord()).isNull();
+    }
+
+    /**
+     * The plain fast path must finish to a snapshot identical to the one the
+     * authoritative {@code captureRaw(getState())} path produces for a plain
+     * block - same material, blockdata string, and (empty) payload.
+     */
+    @Test
+    void plainFastPathFinishesIdenticallyToCaptureRaw() {
+        PlainFixture f = plainFixture(Material.DIRT);
+
+        BlockSnapshot viaState = BlockSnapshots.finishCapture(BlockSnapshots.captureRaw(f.state));
+
+        BlockSnapshots.captureRawCached(f.block);                              // learn DIRT=plain
+        BlockSnapshot viaFast = BlockSnapshots.finishCapture(
+                BlockSnapshots.captureRawCached(f.block));                     // fast path
+
+        assertThat(viaFast.material()).isEqualTo(viaState.material());
+        assertThat(viaFast.blockData()).isEqualTo(viaState.blockData());
+        assertThat(viaFast.containerItems()).isEqualTo(viaState.containerItems());
+        assertThat(viaFast.simple()).isEqualTo(viaState.simple());
+    }
+
+    /**
+     * SAFETY: a container must NEVER take the plain fast path. Every sighting
+     * goes through {@code getState()} so its contents are captured - a misclassed
+     * container would silently lose its contents and break rollback.
+     */
+    @Test
+    void captureRawCachedNeverFastPathsAContainer() {
+        Fixture cf = containerFixture();
+        BlockData data = mock(BlockData.class);
+        when(data.getMaterial()).thenReturn(Material.CHEST);
+        Block block = mock(Block.class);
+        when(block.getBlockData()).thenReturn(data);
+        when(block.getState()).thenReturn(cf.state);
+
+        BlockSnapshots.RawCapture r1 = BlockSnapshots.captureRawCached(block);
+        verify(block, times(1)).getState();
+        assertThat(r1.containerContents())
+                .as("contents captured on the first (learning) sighting")
+                .containsExactly(cf.clone0, null, cf.clone2);
+
+        BlockSnapshots.RawCapture r2 = BlockSnapshots.captureRawCached(block);
+        verify(block, times(2)).getState();
+        assertThat(r2.containerContents())
+                .as("a known-data-bearing material STILL goes through getState - no data loss")
+                .containsExactly(cf.clone0, null, cf.clone2);
+    }
+
+    /**
+     * {@code isDataBearing} is the safety predicate behind the cache: it must be
+     * true for exactly the tile-entity types {@code captureRaw} special-cases,
+     * and false for a plain state.
+     */
+    @Test
+    void isDataBearingMatchesTheTileEntityTypesCaptureRawExtracts() {
+        assertThat(BlockSnapshots.isDataBearing(mock(Container.class))).isTrue();
+        assertThat(BlockSnapshots.isDataBearing(mock(Sign.class))).isTrue();
+        assertThat(BlockSnapshots.isDataBearing(mock(Banner.class))).isTrue();
+        assertThat(BlockSnapshots.isDataBearing(mock(Jukebox.class))).isTrue();
+        assertThat(BlockSnapshots.isDataBearing(mock(DecoratedPot.class))).isTrue();
+        assertThat(BlockSnapshots.isDataBearing(mock(BlockState.class)))
+                .as("a plain block state is not data-bearing")
+                .isFalse();
+    }
+
+    /** Verdicts are independent per material - learning one does not affect another. */
+    @Test
+    void verdictsAreLearnedPerMaterial() {
+        PlainFixture stone = plainFixture(Material.STONE);
+        BlockSnapshots.captureRawCached(stone.block);          // STONE -> plain
+        BlockSnapshots.captureRawCached(stone.block);
+
+        PlainFixture glass = plainFixture(Material.GLASS);
+        BlockSnapshots.captureRawCached(glass.block);          // GLASS unseen -> consults state
+        verify(glass.block, times(1)).getState();
+    }
 
     @Test
     void airReturnsTheSameSharedInstance() {
@@ -179,5 +301,28 @@ class BlockSnapshotsTest {
 
     private record Fixture(BlockState state, ItemStack slot0, ItemStack slot2,
                            ItemStack clone0, ItemStack clone2, BlockData blockData) {
+    }
+
+    /**
+     * A live {@link Block} for a plain (non-tile-entity) material: its
+     * {@code getBlockData()} grab and its {@code getState()} fallback both report
+     * the same material and data, so {@code captureRawCached} works on either path.
+     */
+    private static PlainFixture plainFixture(Material material) {
+        BlockData data = mock(BlockData.class);
+        when(data.getMaterial()).thenReturn(material);
+        when(data.getAsString()).thenReturn("minecraft:" + material.name().toLowerCase());
+
+        BlockState state = mock(BlockState.class);   // plain - not any tile-entity type
+        when(state.getType()).thenReturn(material);
+        when(state.getBlockData()).thenReturn(data);
+
+        Block block = mock(Block.class);
+        when(block.getBlockData()).thenReturn(data);
+        when(block.getState()).thenReturn(state);
+        return new PlainFixture(block, state, data);
+    }
+
+    private record PlainFixture(Block block, BlockState state, BlockData data) {
     }
 }


### PR DESCRIPTION
Closes #172.

## What

`BlockSnapshots.captureRawCached`: on the break and place-after hot paths, grab only the immutable `BlockData` (the irreducible main-thread cost) and skip the full `getState()` (CraftBlockState alloc + tile-entity lookup) for any material proven non-data-bearing.

The verdict is **learned at runtime**: the first event for a material does the real `getState()` and caches whether it's a Container/Sign/Banner/Jukebox/DecoratedPot (the exact set `captureRaw` extracts). Plain materials thereafter skip `getState()`. It's impossible to misclassify (the truth comes from `getState()` itself), needs zero per-version maintenance, and defaults to `getState()` for anything unknown - strictly safer than a hand-maintained allowlist. (place-before reuses the event's prebuilt snapshot, so there's no `getState()` of ours to skip there.)

## Evidence

- JFR @5000 ev/s (same machine, back-to-back): `getState` 3.5% -> 0.9% of active Server-thread samples; net grab (getState+getBlockData) 3.9% -> 2.2%.
- Added-MSPT A/B @5000 (each vs its own vanilla, median of 3): mean ~0.79 -> ~0.68 ms (~-13%), tighter p99.
- Live in-game (isolated SQLite, real player): 13/13 incl. a chest broken then rolled back **with its diamond intact** (the misclassify-a-container money check). Containers/signs/banners/jukeboxes/decorated pots always take the full path.

This is a clean main-thread shave with zero correctness risk. It does NOT change the SG-vs-CoreProtect mean story (that gap is background record-building, not the main thread - SG is already leaner than CP on main-thread CPU).

## Testing

New unit tests pin the safety invariant (a container never takes the fast path; `isDataBearing` matches exactly the tile-entity types `captureRaw` extracts) and the learn-then-skip behavior. `./gradlew check` passes (jacoco floors hold). Live-verified.