### PR TITLE
fix(command): stop blocking the main thread on Mojang lookups during player-name resolution

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
@@ -131,13 +131,28 @@ public final class PlayerParam implements QueryParamHandler {
         return new QueryPredicate.In("source.playerName", names);
     }
 
-    @SuppressWarnings("deprecation")
     private static UUID resolveViaBukkit(String name) {
-        var offline = Bukkit.getOfflinePlayer(name);
-        if (offline == null || !offline.hasPlayedBefore() && Bukkit.getPlayerExact(name) == null) {
-            var online = Bukkit.getPlayerExact(name);
-            return online == null ? null : online.getUniqueId();
+        // Prefer an exact online match (the common case: staff investigating
+        // someone currently connected), then the local user cache.
+        //
+        // NEVER call Bukkit.getOfflinePlayer(String) here. That overload does
+        // a BLOCKING HTTP lookup to Mojang's profile API when the name isn't
+        // already cached, and commands run on the main server thread (the
+        // simple execution coordinator dispatches handlers inline), so a cache
+        // miss stalls the whole server for the round-trip - seconds, on a
+        // Mojang slowdown. Spark caught exactly this (PlayerParam.parse ->
+        // getOfflinePlayer -> HttpURLConnection on "Server thread").
+        //
+        // The Mojang round-trip also buys nothing for the query: source.playerId
+        // only ever holds UUIDs of players who acted on THIS server, so a name
+        // resolved for someone who never joined can't match a record. On a cache
+        // miss we return null and the caller falls back to a verbatim
+        // source.playerName match, which is exactly what we want.
+        var online = Bukkit.getPlayerExact(name);
+        if (online != null) {
+            return online.getUniqueId();
         }
-        return offline.getUniqueId();
+        var cached = Bukkit.getOfflinePlayerIfCached(name);
+        return cached == null ? null : cached.getUniqueId();
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/RecipientParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/RecipientParam.java
@@ -61,16 +61,22 @@ public final class RecipientParam implements QueryParamHandler {
                 .toList();
     }
 
-    @SuppressWarnings("deprecation")
     private static UUID resolve(String name) {
+        // Online exact match first, then the local user cache. Same hard rule
+        // as PlayerParam: never call Bukkit.getOfflinePlayer(String) - it does
+        // a BLOCKING Mojang HTTP lookup on a cache miss and this resolve() runs
+        // on the main thread during command parse. getOfflinePlayerIfCached is
+        // cache-only and returns null on a miss, which we surface as an
+        // "Unknown player" error (recipients are stored as bare UUIDs, so there
+        // is no name to fall back to). Anyone who has been on the server
+        // recently is in the cache; the discarded Mojang path would only have
+        // resolved players who never joined, who can't appear in a recipients
+        // list anyway.
         var online = Bukkit.getPlayerExact(name);
         if (online != null) {
             return online.getUniqueId();
         }
-        var offline = Bukkit.getOfflinePlayer(name);
-        if (offline != null && offline.hasPlayedBefore()) {
-            return offline.getUniqueId();
-        }
-        return null;
+        var cached = Bukkit.getOfflinePlayerIfCached(name);
+        return cached == null ? null : cached.getUniqueId();
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamResolveTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamResolveTest.java
@@ -1,0 +1,99 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Locks the default (live-Bukkit) name resolver to a NON-BLOCKING,
+ * cache-only path. Spark caught {@code PlayerParam.parse} stalling the
+ * main server thread inside {@code Bukkit.getOfflinePlayer(String)} ->
+ * {@code HttpURLConnection} (a Mojang profile lookup on a cache miss).
+ *
+ * <p>Unlike {@link PlayerParamTest}, which injects a deterministic resolver
+ * to exercise the predicate-building fallbacks, these tests drive the real
+ * {@code resolveViaBukkit} through a {@code mockStatic(Bukkit)} scope so we
+ * can assert which Bukkit calls it makes - and, crucially, which it never
+ * makes.
+ */
+class PlayerParamResolveTest {
+
+    private static final UUID ALICE = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Test
+    void resolverNeverCallsBlockingMojangOverload() throws Exception {
+        // The regression: a cache miss must NOT fall through to the blocking
+        // String overload. getPlayerExact + getOfflinePlayerIfCached both miss,
+        // so the name resolves to nothing and parse() falls back to a verbatim
+        // source.playerName match - all without a network round-trip.
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
+
+            QueryPredicate predicate = new PlayerParam().parse("p", "NeverJoined", ctx());
+
+            assertThat(predicate).isInstanceOf(QueryPredicate.Eq.class);
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("source.playerName");
+            assertThat(eq.value()).isEqualTo("NeverJoined");
+
+            // The whole point of the fix: the deprecated, blocking
+            // String overload is never touched.
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void onlinePlayerResolvesToPlayerIdWithoutHittingCache() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            Player online = mock(Player.class);
+            when(online.getUniqueId()).thenReturn(ALICE);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(online);
+
+            QueryPredicate predicate = new PlayerParam().parse("p", "Alice", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("source.playerId");
+            assertThat(eq.value()).isEqualTo(ALICE);
+
+            // Online match short-circuits: neither offline-cache nor the
+            // blocking overload is consulted.
+            bukkit.verify(() -> Bukkit.getOfflinePlayerIfCached(anyString()), never());
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void cachedOfflinePlayerResolvesToPlayerId() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            OfflinePlayer cached = mock(OfflinePlayer.class);
+            when(cached.getUniqueId()).thenReturn(ALICE);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached("Alice")).thenReturn(cached);
+
+            QueryPredicate predicate = new PlayerParam().parse("p", "Alice", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("source.playerId");
+            assertThat(eq.value()).isEqualTo(ALICE);
+
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    private static ParamContext ctx() {
+        return new ParamContext(null, null, 100);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/RecipientParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/RecipientParamTest.java
@@ -1,0 +1,114 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * {@code rcp:} name resolution must be cache-only and non-blocking, the same
+ * hard rule PlayerParam follows: never call {@code Bukkit.getOfflinePlayer(String)},
+ * which does a blocking Mojang HTTP lookup on the main command thread.
+ *
+ * <p>Recipients are stored as bare UUIDs with no name column, so a cache miss
+ * surfaces as an "Unknown player" error rather than a name fallback.
+ */
+class RecipientParamTest {
+
+    private static final UUID ALICE = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID BOB = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @Test
+    void onlineRecipientResolvesToEqWithoutBlockingLookup() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            Player online = mock(Player.class);
+            when(online.getUniqueId()).thenReturn(ALICE);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(online);
+
+            QueryPredicate predicate = new RecipientParam().parse("rcp", "Alice", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("recipients");
+            assertThat(eq.value()).isEqualTo(ALICE);
+
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void cachedRecipientResolvesToEq() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            OfflinePlayer cached = mock(OfflinePlayer.class);
+            when(cached.getUniqueId()).thenReturn(ALICE);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached("Alice")).thenReturn(cached);
+
+            QueryPredicate predicate = new RecipientParam().parse("rcp", "Alice", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("recipients");
+            assertThat(eq.value()).isEqualTo(ALICE);
+
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void multipleRecipientsResolveToIn() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            Player alice = mock(Player.class);
+            Player bob = mock(Player.class);
+            when(alice.getUniqueId()).thenReturn(ALICE);
+            when(bob.getUniqueId()).thenReturn(BOB);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(alice);
+            bukkit.when(() -> Bukkit.getPlayerExact("Bob")).thenReturn(bob);
+
+            QueryPredicate predicate = new RecipientParam().parse("rcp", "Alice,Bob", ctx());
+
+            QueryPredicate.In in = (QueryPredicate.In) predicate;
+            assertThat(in.field()).isEqualTo("recipients");
+            assertThat(in.values()).hasSize(2);
+            assertThat(in.values().get(0)).isEqualTo(ALICE);
+            assertThat(in.values().get(1)).isEqualTo(BOB);
+        }
+    }
+
+    @Test
+    void cacheMissThrowsUnknownPlayerNeverBlocks() {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
+
+            RecipientParam param = new RecipientParam();
+            assertThatThrownBy(() -> param.parse("rcp", "NeverJoined", ctx()))
+                    .isInstanceOf(ParamParseException.class)
+                    .hasMessageContaining("Unknown player");
+
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void blankValueRejected() {
+        RecipientParam param = new RecipientParam();
+        assertThatThrownBy(() -> param.parse("rcp", "", ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    private static ParamContext ctx() {
+        return new ParamContext(null, null, 100);
+    }
+}


### PR DESCRIPTION
Lands the player-name resolution fix (1 commit, clean merge into dev). Closes out the branch.