### PR TITLE
feat(voicechat): on-the-fly event registration + voice logging (The60th's voicechat-dev, rebased)

### DIFF
--- a/docs/superpowers/specs/2026-06-20-custom-event-registration-design.md
+++ b/docs/superpowers/specs/2026-06-20-custom-event-registration-design.md
@@ -1,0 +1,157 @@
+# Custom event registration API (`registerEvent` + `CustomRecord`)
+
+**Date:** 2026-06-20
+**Status:** Approved — ready for implementation
+
+## Problem
+
+Third-party plugins (e.g. the voicechat integration) want to log their own event
+types and search them by name (`a:voice`). Today `EventCatalog` is a closed,
+hardcoded map: a record with an unregistered `event` name is written but silently
+dropped on read (`recordClassOf(name)` → null → row skipped), and `a:<name>` is
+rejected by `EventParam` because the name isn't in `enabledEvents`. There is no
+public registration hook (Omniscience, which Spyglass's API was modelled on, had
+`OmniApi.registerEvent(name, verb)`).
+
+## Goal
+
+A public API so an integrating plugin can register a custom event name and log
+freeform key/value data against it, fully searchable and displayable — mirroring
+Omni's ergonomics, adapted to Spyglass's typed, sealed record model.
+
+## Key decisions (resolved in brainstorming)
+
+1. **Generic record, not an alias.** Add a new `CustomRecord` type to the sealed
+   `EventRecord` hierarchy rather than aliasing an existing one.
+2. **Strings-only bag, reusing `extensions`.** The key/value bag is
+   `Map<String,String>` carried in the existing `extensions` component. Integrators
+   stringify (as the voice example already does). This means **no new storage
+   columns** in any backend — `extensions` already round-trips through Mongo,
+   ClickHouse, and SQLite and is queryable as `extensions.<key>`.
+3. **Reuse `target` + `message`.** `CustomRecord` exposes `target` (summary string)
+   and `message` (primary freeform text, e.g. a transcript) — both already existing
+   columns — so `t:` and `m:` searches work with no new plumbing.
+4. **Recipients live in the bag**, not a first-class field (keeps the type generic).
+5. **Plain `of(...)` factory**, consistent with every other record (no fluent
+   `OEntry`-style builder).
+6. **Enabled by default, no config required** (Omni-style); an `events.<name>`
+   config entry, if present, overrides (lets operators disable / rename the verb).
+
+## Data model — `CustomRecord` (spyglass-api)
+
+```java
+public record CustomRecord(
+        UUID id, String event, Instant occurred, Instant expiresAt,
+        Origin origin, Source source, BlockLocation location, String server,
+        String target, String message,
+        Map<String, String> extensions) implements EventRecord {
+
+    public static CustomRecord of(RecordContext ctx, String eventName,
+                                  String target, String message, Map<String,String> data);
+}
+```
+
+Added to the `EventRecord permits` list. `of(...)` merges `data` into the context's
+extensions bag. Not `Rollbackable` (custom events have no inverse effect).
+
+## Runtime event registry (spyglass-api)
+
+`EventCatalog` gains a thread-safe runtime layer (a `ConcurrentHashMap` alongside the
+static map):
+
+- `recordClassOf(name)` → static mapping, else a registered custom name →
+  `CustomRecord.class`, else null.
+- `eventNames()` → static names ∪ registered names.
+- New: `register(String name, String pastTense)`, `isRegistered(String name)`,
+  `pastTenseOf(String name)` (registry verb, for the renderer fallback).
+
+Registration is idempotent and case-insensitive (matching `recordClassOf`).
+
+## Public API (spyglass-api `SpyglassApi`)
+
+```java
+void registerEvent(String name, String pastTense);  // name -> CustomRecord, enabled
+boolean isEventRegistered(String name);
+```
+
+`SpyglassApiImpl.registerEvent` registers in `EventCatalog`, marks the name enabled
+in a **live** enabled-events set (see below), and stores the verb for rendering.
+
+## Wiring (spyglass-plugin)
+
+- **enabledEvents becomes live.** Today it's an immutable snapshot built at startup
+  and passed to `EventParam` + `SpyglassApiImpl`. Change to a shared mutable
+  (concurrent) set so `registerEvent` adds names at runtime and `EventParam` /
+  `enabledEvents()` see them. `EventParam.parse` accepts a name that is in the live
+  set (built-ins from config + registered customs).
+- **Verb fallback.** `config.pastTense(name)` falls back to
+  `EventCatalog.pastTenseOf(name)` when the name has no `events.<name>` config entry.
+- **Rendering.** `ResultRenderer` handles `CustomRecord` in the exhaustive switches
+  (`targetOf` → `target`, `quantityOf` → 0); the message renders inline and the
+  bag shows in the hover (the hover already renders `extensions`). Verb comes from
+  `config.pastTense` (→ registry fallback).
+
+## Storage parity (spyglass-core) — no new columns
+
+Each backend maps the new `CustomRecord` *class* onto existing columns
+(`target`, `message`, `extensions`):
+
+- **Mongo** `EventRecordCodec`: encode/decode `CustomRecord` (fields:
+  target, message, extensions). Registered names decode via
+  `recordClassOf` → `CustomRecord`.
+- **ClickHouse** `ClickHouseRecordStore`: `writeRow` writes message + extensions
+  (target is already common); `decodeRow` adds a `CustomRecord` branch.
+- **SQLite** `SqliteRecordStore`: same — write message + extensions, decode branch.
+- **`PredicateEvaluator`**: `CustomRecord` resolves `extensions.<key>` (already the
+  generic path) and the common fields; no item/snapshot paths.
+
+## Sealed-switch fan-out
+
+Adding a sealed type makes the compiler flag every exhaustive `switch (EventRecord)`.
+Expected touch points: `ResultRenderer.targetOf` / `quantityOf`, the Velocity
+`ProxyResultRenderer`, `EventRecordCodec`, ClickHouse + SQLite `writeRow`/`decodeRow`,
+and any `PredicateEvaluator` switch. Mechanical, but must all be handled for the
+build to compile.
+
+## Velocity
+
+`ProxyResultRenderer` (read-only proxy) gets a `CustomRecord` rendering branch so
+cross-server `/sgv` search displays custom events too.
+
+## Integration shape (what voicechat ends up writing)
+
+```java
+if (!api.isEventRegistered("voice")) api.registerEvent("voice", "spoke");
+RecordContext ctx = RecordContext.fresh(occurred, expiresAt, origin, source, loc, server);
+api.record(CustomRecord.of(ctx, "voice", summary, transcript, voiceDataMap));
+```
+
+## Migration of the `voice` quick-fix
+
+The interim `voice → ChatRecord` entry in `EventCatalog` and the `events.voice`
+default in `config.conf` are removed once this lands: `voice` becomes a registered
+`CustomRecord` event instead. Already-written `voice` rows were stored as the
+`ChatRecord` shape (message + recipients + extensions); since `CustomRecord` reads
+the same `message`/`extensions` columns, they still decode and remain searchable
+(the `recipients` column is simply not surfaced on a `CustomRecord` — acceptable;
+it was a stop-gap). This is called out so the cutover is deliberate, not silent.
+
+## Testing
+
+- **api:** `CustomRecord.of` merges data into extensions; `EventCatalog.register` /
+  `isRegistered` / `recordClassOf` / `pastTenseOf` (incl. case-insensitivity and
+  idempotency).
+- **core (Docker-gated ITs):** round-trip a `CustomRecord` through Mongo,
+  ClickHouse, and SQLite — `a:<name>`, `m:` on message, and `extensions.<key>`
+  all match; `querySummary` returns it with the bag intact.
+- **plugin:** `EventParam` accepts a registered custom name and rejects an
+  unregistered one; `SpyglassApiImpl.registerEvent` makes `a:<name>` parse and
+  `isEventRegistered` flip; `ResultRenderer` renders a `CustomRecord` (verb +
+  target + message, bag in hover).
+- `./gradlew check` stays green incl. jacoco floors.
+
+## Non-goals
+
+- Typed (number/boolean/list) bag values — strings only (deferred).
+- Rollback support for custom events.
+- A fluent builder API.

--- a/docs/superpowers/specs/2026-06-21-victim-killer-death-model-design.md
+++ b/docs/superpowers/specs/2026-06-21-victim-killer-death-model-design.md
@@ -1,0 +1,184 @@
+# Victim/Killer-Aware Death Model
+
+**Date:** 2026-06-21
+**Status:** Approved design — pending implementation plan
+**Backend in use:** ClickHouse (design is backend-agnostic; no schema change required)
+
+## Problem
+
+Spyglass records a single `death` event whose `source` is the **killer**, with
+the victim captured only as an entity-type string (`target`/`entityType`) plus a
+raw, non-searchable UUID (`entityId`). The player query param `p:` matches
+**only** `source.playerId` / `source.playerName`.
+
+Consequences:
+
+- `p:the60th a:death` returns deaths the60th **caused**, not deaths he
+  **suffered** — because when he dies, `source` is whoever/whatever killed him,
+  and as a victim he is not in any `p:`-searchable field.
+- There is no way to search a player's kills: `kill` is not an event; kills are
+  folded into `death` with `source = killer`.
+
+Desired:
+
+- `spyglass search p:the60th a:death` → every time the60th died.
+- `spyglass search p:the60th a:kill` → every kill the60th made.
+- Mob kills captured separately so they filter distinctly: `a:mob-kill`.
+
+## Design Overview
+
+Model each lethal event from **two perspectives** so the relevant actor is the
+`source` (and therefore `p:`-searchable) in each:
+
+| Event       | `source` (the `p:`-searchable subject) | `target`                              | Record type         | Rollbackable |
+|-------------|----------------------------------------|---------------------------------------|---------------------|--------------|
+| `death`     | the **victim** who died                | killer name / mob type / damage cause | `EntityDeathRecord` | yes (unchanged) |
+| `kill`      | the **player** killer                  | victim (player name or mob type)      | `EntityHitRecord`   | no           |
+| `mob-kill`  | the **mob** killer                     | victim (player name or mob type)      | `EntityHitRecord`   | no           |
+
+`kill` and `mob-kill` reuse the existing `EntityHitRecord`, whose shape
+(`source` + `victimType` + `victimId` + `damage`/`projectile`/`projectileType`)
+is already exactly "killer → victim". Both Mongo and ClickHouse already persist
+`EntityHitRecord` (used by the `hit` and `shot` events), so **no new record type,
+no Mongo codec change, no ClickHouse schema/column/mapper change** is needed.
+
+This is the minimal change that satisfies the queries, because `p:` resolves to
+`source` only: the victim must be the `source` of `death`, and the killer must be
+the `source` of `kill`/`mob-kill`.
+
+### Why `death` is *flipped* rather than a new `died` event
+
+The user types `a:death` to mean "times X died" — i.e. they expect `death` to be
+victim-centric. Flipping the existing event matches that mental model and avoids
+a redundant fourth event. The `hit`/`shot` events keep `source = attacker`
+(they read naturally as "X hit Y" actions); only `death` is special-cased to be
+victim-centric, with the killer perspective expressed by `kill`/`mob-kill`.
+
+## Field Semantics After the Change
+
+### `death` (`EntityDeathRecord`)
+- `source` = the victim:
+  - victim is a Player → `support.playerSource(victimPlayer)`
+  - victim is a mob → `support.entitySource(victim.getUniqueId(), entityType)`
+- `target` = the killer/cause, for self-describing display and at-a-glance
+  forensics:
+  - player killer → killer's name
+  - mob killer → mob entity type
+  - environment/unknown → the damage cause (e.g. `FALL`, `LAVA`)
+- `entityType` = victim entity type (unchanged — used by rollback respawn)
+- `entityId` = victim UUID (unchanged — used by `restoreEffect`)
+- `killerType` = `"player"`, the mob type, or the damage cause
+- `damageCause` = `lastDamageCause` cause name, or `"UNKNOWN"`
+- `entityNbt` = victim NBT (unchanged)
+- `origin`:
+  - player killer → `Origin.player()`
+  - mob killer → `Origin.environment("death:" + cause)`
+  - environment → `Origin.environment("death:" + cause)` / `"death"`
+
+Rollback is unaffected: `rollbackEffect()` still spawns `entityType` at
+`location` from `entityNbt`; `restoreEffect()` still removes by `entityId`.
+
+### `kill` and `mob-kill` (`EntityHitRecord`)
+- `event` = `"kill"` or `"mob-kill"`
+- `source` = the killer:
+  - `kill` → `support.playerSource(killerPlayer)`
+  - `mob-kill` → `support.entitySource(killerMob.getUniqueId(), killerType)`
+- `target` = the victim identity: victim player name, else victim mob type
+- `victimType` = victim entity type
+- `victimId` = victim UUID
+- `damage` = killing-blow damage from `lastDamageCause.getDamage()` when
+  available, else `0.0`
+- `projectile` = true when the damage cause is `PROJECTILE`
+- `projectileType` = projectile entity type when resolvable, else `null`
+
+## Listener Logic (`EntityDeathListener.onEntityDeath`)
+
+On each `EntityDeathEvent` (priority `MONITOR`, `ignoreCancelled = true`):
+
+1. Build victim identity (`entityType`, `entityId`, `location`, NBT as today).
+2. Resolve the killer:
+   - **Player killer** — `victim.getKiller()` is a `Player`:
+     emit `death` (source = victim, target = killer name) **and**
+     `kill` (source = killer, target = victim).
+   - **Mob killer** — `getKiller()` is null but `getLastDamageCause()` is an
+     `EntityDamageByEntityEvent`: take `getDamager()`; if it is a `Projectile`,
+     resolve its `getShooter()`; if the resulting entity is a non-player
+     `LivingEntity`, emit `death` (source = victim, target = mob type) **and**
+     `mob-kill` (source = mob, target = victim). If the damager resolves to a
+     player (edge cases `getKiller()` missed), treat as the player-killer branch.
+   - **Environment / unknown** — neither of the above: emit `death` only
+     (source = victim, target = damage cause).
+3. The per-mob loot `drop` records (non-player victims) are unchanged.
+
+The `kill`/`mob-kill` records are gated by their config toggles (below); when an
+event is disabled, only the `death` record (if `death` is enabled) is emitted.
+
+`events()` returns `{"death", "drop", "kill", "mob-kill"}` so registration and
+the enabled-event gate cover the new names.
+
+## Catalog, Config, Display
+
+- **`EventCatalog`**: add `m.put("kill", EntityHitRecord.class)` and
+  `m.put("mob-kill", EntityHitRecord.class)`.
+- **`config.conf`**: under the events section add `kill = true` and
+  `mob-kill = true`; add display verbs so `death → "died"` and
+  `kill` / `mob-kill → "killed"`. (Verb lookup follows the existing
+  per-event past-tense config mechanism.)
+- **`ResultRenderer`** and **`ProxyResultRenderer`**:
+  - `death` inline → `"<victim> died <target>"` where `<target>` is the
+    killer/cause (the hover already shows `Cause`).
+  - `kill` / `mob-kill` inline → render via the existing `EntityHitRecord`
+    path with verb "killed": `"<killer> killed <victim>"`. The existing hover
+    detail (Damage, Weapon for projectiles) applies unchanged.
+
+## Historical Data
+
+Existing `death` rows were written with the **old** semantics (`source` =
+killer). After the flip, `p:X a:death` is correct only for rows written **after**
+deployment; pre-existing rows still have killer-as-source and will not match a
+victim search (and will match the killer's `p:` search instead).
+
+**Recommendation: accept going-forward correctness and do not migrate.**
+Re-keying historical `death` rows on ClickHouse is a heavy MergeTree mutation
+(rewrites parts) for a forensic log that is already append-only and ages out via
+retention. If a backfill is ever wanted, it is a separate one-off task. No new
+`kill`/`mob-kill` rows are synthesized for past deaths.
+
+## Testing
+
+- **Listener logic** (the core change): three branches —
+  1. player kill → emits a `death` (source = victim) and a `kill`
+     (source = killer);
+  2. mob kill → emits a `death` (source = victim) and a `mob-kill`
+     (source = mob);
+  3. environment death → emits `death` only, with `source` = victim.
+  Assert source/target/event on each emitted record. Projectile-shooter
+  resolution covered by a mob-projectile case.
+- **Config gating**: `kill` disabled → player kill emits `death` only.
+- **Storage round-trip**: a `kill` and a `mob-kill` record persist and decode
+  back as `EntityHitRecord` with the right `event`, on the in-use backend
+  (ClickHouse IT; SQLite unit test mirrors it).
+- **Rendering**: `ResultRenderer`/`ProxyResultRenderer` produce the new
+  "died" / "killed" inline forms for the three events.
+- **Catalog/params**: `EventParamTest` and suggestion tests pick up `kill` /
+  `mob-kill` automatically from `EventCatalog`; add assertions that the names
+  are known and stored as `EntityHitRecord`.
+
+## Out of Scope
+
+- Migrating/backfilling historical `death` rows.
+- Changing `hit` / `shot` semantics (they remain attacker-as-source).
+- Capturing the killer's weapon item on `kill` (possible future enhancement via
+  `target`/extensions; not required for the requested queries).
+
+## Event-Type Parity Checklist (per CLAUDE.md)
+
+- [x] Sealed `EventRecord` — no new type (reuses `EntityDeathRecord` +
+      `EntityHitRecord`); no change.
+- [x] `EventCatalog` — add `kill`, `mob-kill` → `EntityHitRecord`.
+- [x] Emitting listener — `EntityDeathListener` flips `death`, emits
+      `kill`/`mob-kill`, updates `events()`.
+- [x] Mongo codec — `EntityHitRecord` already registered; no change.
+- [x] ClickHouse schema/mapper — `EntityHitRecord` columns already exist; no
+      change.
+- [x] Config default — add `kill = true`, `mob-kill = true` + verbs.

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/SpyglassApi.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/SpyglassApi.java
@@ -61,6 +61,26 @@ public interface SpyglassApi {
     void record(EventRecord record);
 
     /**
+     * Register a custom event name so an integrating plugin can log and
+     * search its own event types. Records the name as a {@link
+     * net.medievalrp.spyglass.api.event.CustomRecord} event with the given
+     * display verb ({@code pastTense}, e.g. {@code "spoke"} for
+     * {@code "Alice spoke ..."}), makes it enabled and searchable via
+     * {@code a:<name>}, and is idempotent and case-insensitive.
+     *
+     * <p>Build records with {@link
+     * net.medievalrp.spyglass.api.event.CustomRecord#of} and hand them to
+     * {@link #record}. A name that collides with a built-in event is ignored
+     * (built-ins can't be redefined). Call from {@code onEnable()} on the main
+     * thread, typically guarded by {@link #isEventRegistered}.
+     */
+    void registerEvent(String name, String pastTense);
+
+    /** True when {@code name} is a known event — a built-in or a custom name
+     *  already registered via {@link #registerEvent}. Case-insensitive. */
+    boolean isEventRegistered(String name);
+
+    /**
      * Run a query against the event log. The returned stage completes
      * on a worker thread; chain with {@code thenAcceptAsync} (or use
      * Bukkit's main-thread executor) before touching world state.

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/CustomRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/CustomRecord.java
@@ -1,0 +1,64 @@
+package net.medievalrp.spyglass.api.event;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+
+/**
+ * A generic, integrator-defined event. Third-party plugins register a custom
+ * event name via {@link net.medievalrp.spyglass.api.SpyglassApi#registerEvent}
+ * and log one of these per occurrence.
+ *
+ * <p>Deliberately built from components that already exist on every storage
+ * backend so a custom event needs no schema change: {@code target} (a summary
+ * string), {@code message} (the primary freeform text — e.g. a voice
+ * transcript), and the {@code extensions} bag (arbitrary string key/value
+ * data, searchable as {@code extensions.<key>}). Not {@link
+ * net.medievalrp.spyglass.api.rollback.Rollbackable} — a custom event has no
+ * inverse effect.
+ */
+public record CustomRecord(
+        UUID id,
+        String event,
+        Instant occurred,
+        Instant expiresAt,
+        Origin origin,
+        Source source,
+        BlockLocation location,
+        String server,
+        String target,
+        String message,
+        Map<String, String> extensions) implements EventRecord {
+
+    public CustomRecord {
+        extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+    }
+
+    /**
+     * Build a custom-event record. {@code data} is merged into the context's
+     * extensions bag, so both context-supplied metadata and the per-call data
+     * ride into storage together.
+     *
+     * @param eventName the registered custom event name (see
+     *                  {@link net.medievalrp.spyglass.api.SpyglassApi#registerEvent})
+     * @param target    short summary shown inline after the verb (may be null)
+     * @param message   primary freeform text, searchable via {@code m:} (may be null)
+     * @param data      arbitrary string key/value bag (may be null/empty)
+     */
+    public static CustomRecord of(RecordContext ctx, String eventName, String target,
+                                  String message, Map<String, String> data) {
+        Map<String, String> merged;
+        if (data == null || data.isEmpty()) {
+            merged = ctx.extensions();
+        } else {
+            merged = new HashMap<>(ctx.extensions());
+            merged.putAll(data);
+        }
+        return new CustomRecord(
+                ctx.id(), eventName, ctx.occurred(), ctx.expiresAt(),
+                ctx.origin(), ctx.source(), ctx.location(), ctx.server(),
+                target, message, merged);
+    }
+}

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -28,6 +28,13 @@ public final class EventCatalog {
         m.put("break", BlockBreakRecord.class);
         m.put("place", BlockPlaceRecord.class);
         m.put("say", ChatRecord.class);
+        // Spoken voice-chat transcripts pushed in by an external integration
+        // (e.g. voicechat) via SpyglassApi#record. Reuses the ChatRecord
+        // shape — message is the transcript, recipients are the listeners —
+        // so both storage backends persist and decode it with no extra
+        // wiring. Until a general custom-event registration API lands, new
+        // third-party event names are added here.
+        m.put("voice", ChatRecord.class);
         m.put("command", CommandRecord.class);
         m.put("join", JoinRecord.class);
         m.put("quit", QuitRecord.class);

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -21,6 +21,15 @@ import java.util.Set;
  */
 public final class EventCatalog {
 
+    /**
+     * Runtime-registered custom event names → display verb (past tense). All
+     * custom events map to {@link CustomRecord}. Populated by {@link
+     * net.medievalrp.spyglass.api.SpyglassApi#registerEvent} at integrator
+     * startup; consulted by the storage layer's {@link #recordClassOf} on
+     * every read, so it must be thread-safe.
+     */
+    private static final Map<String, String> CUSTOM = new java.util.concurrent.ConcurrentHashMap<>();
+
     private static final Map<String, Class<? extends EventRecord>> TYPES;
 
     static {
@@ -28,13 +37,6 @@ public final class EventCatalog {
         m.put("break", BlockBreakRecord.class);
         m.put("place", BlockPlaceRecord.class);
         m.put("say", ChatRecord.class);
-        // Spoken voice-chat transcripts pushed in by an external integration
-        // (e.g. voicechat) via SpyglassApi#record. Reuses the ChatRecord
-        // shape — message is the transcript, recipients are the listeners —
-        // so both storage backends persist and decode it with no extra
-        // wiring. Until a general custom-event registration API lands, new
-        // third-party event names are added here.
-        m.put("voice", ChatRecord.class);
         m.put("command", CommandRecord.class);
         m.put("join", JoinRecord.class);
         m.put("quit", QuitRecord.class);
@@ -101,14 +103,58 @@ public final class EventCatalog {
         return TYPES;
     }
 
-    /** Every registered event name, in the declared order. */
+    /** Every known event name — built-ins plus runtime-registered customs. */
     public static Set<String> eventNames() {
-        return TYPES.keySet();
+        if (CUSTOM.isEmpty()) {
+            return TYPES.keySet();
+        }
+        Set<String> names = new java.util.LinkedHashSet<>(TYPES.keySet());
+        names.addAll(CUSTOM.keySet());
+        return Set.copyOf(names);
     }
 
-    /** The record class that encodes the given event name, or null when unknown. */
+    /**
+     * The record class that encodes the given event name, or null when
+     * unknown. Built-ins resolve from the static map; a runtime-registered
+     * custom name resolves to {@link CustomRecord}.
+     */
     public static Class<? extends EventRecord> recordClassOf(String eventName) {
-        return eventName == null ? null : TYPES.get(eventName.toLowerCase(java.util.Locale.ROOT));
+        if (eventName == null) {
+            return null;
+        }
+        String key = eventName.toLowerCase(java.util.Locale.ROOT);
+        Class<? extends EventRecord> builtin = TYPES.get(key);
+        if (builtin != null) {
+            return builtin;
+        }
+        return CUSTOM.containsKey(key) ? CustomRecord.class : null;
+    }
+
+    /**
+     * Register a custom event name (idempotent, case-insensitive). All custom
+     * events are stored as {@link CustomRecord}. A name that collides with a
+     * built-in is ignored — built-ins can't be redefined.
+     */
+    public static void register(String eventName, String pastTense) {
+        if (eventName == null || eventName.isBlank()) {
+            return;
+        }
+        String key = eventName.toLowerCase(java.util.Locale.ROOT);
+        if (TYPES.containsKey(key)) {
+            return;
+        }
+        CUSTOM.put(key, pastTense == null || pastTense.isBlank() ? key : pastTense);
+    }
+
+    /** True when {@code eventName} is a known event — built-in or registered custom. */
+    public static boolean isRegistered(String eventName) {
+        return recordClassOf(eventName) != null;
+    }
+
+    /** The display verb for a registered custom event, or null for built-ins
+     *  / unknown names (built-in verbs come from config). */
+    public static String pastTenseOf(String eventName) {
+        return eventName == null ? null : CUSTOM.get(eventName.toLowerCase(java.util.Locale.ROOT));
     }
 
     /** Every event name that's stored as the given record class. */
@@ -122,8 +168,14 @@ public final class EventCatalog {
         return Set.copyOf(out);
     }
 
-    /** Distinct record classes, preserving declaration order. */
+    /** Distinct record classes, preserving declaration order. Always includes
+     *  {@link CustomRecord} — the backing type for any runtime-registered
+     *  custom event — so storage codecs are built for it even before the first
+     *  custom event is registered. */
     public static Collection<Class<? extends EventRecord>> recordClasses() {
-        return new java.util.LinkedHashSet<>(TYPES.values());
+        java.util.LinkedHashSet<Class<? extends EventRecord>> classes =
+                new java.util.LinkedHashSet<>(TYPES.values());
+        classes.add(CustomRecord.class);
+        return classes;
     }
 }

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventRecord.java
@@ -23,7 +23,8 @@ public sealed interface EventRecord permits
         EntityHitRecord,
         EntityMountRecord,
         EntityNameRecord,
-        RollbackOpRecord {
+        RollbackOpRecord,
+        CustomRecord {
 
     UUID id();
 

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/CustomRecordTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/CustomRecordTest.java
@@ -1,0 +1,55 @@
+package net.medievalrp.spyglass.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+class CustomRecordTest {
+
+    private static final UUID PLAYER = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    private static RecordContext context(Map<String, String> extensions) {
+        Instant now = Instant.parse("2026-06-20T12:00:00Z");
+        return new RecordContext(
+                UUID.randomUUID(), now, now.plusSeconds(60),
+                Origin.player(), Source.player(PLAYER, "Alice"),
+                new BlockLocation(WORLD, "world", 1, 64, 2), "srv", extensions);
+    }
+
+    @Test
+    void ofMergesDataIntoExtensionsBag() {
+        CustomRecord record = CustomRecord.of(
+                context(Map.of("ctx_key", "ctx_val")),
+                "voice", "voice to 2 players", "hello there",
+                Map.of("voice_session_id", "42"));
+
+        assertThat(record.event()).isEqualTo("voice");
+        assertThat(record.target()).isEqualTo("voice to 2 players");
+        assertThat(record.message()).isEqualTo("hello there");
+        assertThat(record.extensions())
+                .containsEntry("voice_session_id", "42")
+                .containsEntry("ctx_key", "ctx_val");
+    }
+
+    @Test
+    void ofWithoutDataKeepsContextExtensions() {
+        CustomRecord record = CustomRecord.of(
+                context(Map.of("ctx_key", "ctx_val")),
+                "voice", "t", "m", null);
+
+        assertThat(record.extensions()).containsExactlyEntriesOf(Map.of("ctx_key", "ctx_val"));
+    }
+
+    @Test
+    void extensionsAreImmutable() {
+        CustomRecord record = CustomRecord.of(context(Map.of()), "voice", "t", "m",
+                Map.of("k", "v"));
+        org.junit.jupiter.api.Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> record.extensions().put("x", "y"));
+    }
+}

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EventCatalogTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EventCatalogTest.java
@@ -1,0 +1,29 @@
+package net.medievalrp.spyglass.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EventCatalogTest {
+
+    @Test
+    void voiceIsRegisteredAsAChatRecord() {
+        // Voice-chat transcripts arrive from an external integration with
+        // event="voice". Without a registry entry the read path's
+        // recordClassOf(...) returns null and every voice row is silently
+        // dropped on decode. Pin it to ChatRecord so a:voice is searchable
+        // and the rows round-trip through both backends.
+        assertThat(EventCatalog.recordClassOf("voice")).isEqualTo(ChatRecord.class);
+    }
+
+    @Test
+    void recordClassLookupIsCaseInsensitive() {
+        assertThat(EventCatalog.recordClassOf("VOICE")).isEqualTo(ChatRecord.class);
+    }
+
+    @Test
+    void unknownEventResolvesToNull() {
+        assertThat(EventCatalog.recordClassOf("not-an-event")).isNull();
+        assertThat(EventCatalog.recordClassOf(null)).isNull();
+    }
+}

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EventCatalogTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EventCatalogTest.java
@@ -7,23 +7,39 @@ import org.junit.jupiter.api.Test;
 class EventCatalogTest {
 
     @Test
-    void voiceIsRegisteredAsAChatRecord() {
-        // Voice-chat transcripts arrive from an external integration with
-        // event="voice". Without a registry entry the read path's
-        // recordClassOf(...) returns null and every voice row is silently
-        // dropped on decode. Pin it to ChatRecord so a:voice is searchable
-        // and the rows round-trip through both backends.
-        assertThat(EventCatalog.recordClassOf("voice")).isEqualTo(ChatRecord.class);
+    void registeredCustomEventResolvesToCustomRecord() {
+        // A custom name an integrator registers must resolve so the read path
+        // (recordClassOf) decodes it instead of silently dropping the row.
+        assertThat(EventCatalog.recordClassOf("unit-test-voice")).isNull();
+        EventCatalog.register("unit-test-voice", "spoke");
+        assertThat(EventCatalog.recordClassOf("unit-test-voice")).isEqualTo(CustomRecord.class);
+        assertThat(EventCatalog.isRegistered("unit-test-voice")).isTrue();
+        assertThat(EventCatalog.pastTenseOf("unit-test-voice")).isEqualTo("spoke");
+        assertThat(EventCatalog.eventNames()).contains("unit-test-voice");
     }
 
     @Test
-    void recordClassLookupIsCaseInsensitive() {
-        assertThat(EventCatalog.recordClassOf("VOICE")).isEqualTo(ChatRecord.class);
+    void registrationIsCaseInsensitiveAndIdempotent() {
+        EventCatalog.register("Unit-Test-Caps", "yelled");
+        assertThat(EventCatalog.recordClassOf("UNIT-TEST-CAPS")).isEqualTo(CustomRecord.class);
+        assertThat(EventCatalog.pastTenseOf("unit-test-caps")).isEqualTo("yelled");
+        // Re-register is a no-op overwrite, not a duplicate.
+        EventCatalog.register("unit-test-caps", "shouted");
+        assertThat(EventCatalog.pastTenseOf("unit-test-caps")).isEqualTo("shouted");
+    }
+
+    @Test
+    void builtinsTakePrecedenceAndCannotBeRedefined() {
+        EventCatalog.register("say", "whispered");
+        // 'say' is a built-in -> still ChatRecord, registration ignored.
+        assertThat(EventCatalog.recordClassOf("say")).isEqualTo(ChatRecord.class);
+        assertThat(EventCatalog.pastTenseOf("say")).isNull();
     }
 
     @Test
     void unknownEventResolvesToNull() {
         assertThat(EventCatalog.recordClassOf("not-an-event")).isNull();
         assertThat(EventCatalog.recordClassOf(null)).isNull();
+        assertThat(EventCatalog.isRegistered("not-an-event")).isFalse();
     }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseFieldMapper.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseFieldMapper.java
@@ -28,6 +28,11 @@ final class ClickHouseFieldMapper {
             Map.entry("expiresAt", "expires_at"),
             Map.entry("target", "target"),
             Map.entry("message", "message"),
+            // CommandRecord's line — a flat column. Without this mapping the
+            // message/content params (which OR message + commandLine) couldn't
+            // push the commandLine clause down, dropping the whole search to
+            // the in-memory post-filter where m:/content: silently missed.
+            Map.entry("commandLine", "command_line"),
             Map.entry("origin.kind", "origin_kind"),
             Map.entry("origin.detail", "origin_detail"),
             Map.entry("source.kind", "source_kind"),
@@ -43,6 +48,11 @@ final class ClickHouseFieldMapper {
             Map.entry("location.y", "location_y"),
             Map.entry("location.z", "location_z"),
             Map.entry("server", "server"),
+            // ChatRecord recipients — an Array(UUID) column. PredicateToSql
+            // translates membership against it with has()/hasAny() (see its
+            // ARRAY_COLUMNS); without this mapping rcp: dropped to the
+            // in-memory post-filter and silently matched nothing.
+            Map.entry("recipients", "recipients"),
             // JoinRecord IP — a flat column on the events table; previously
             // omitted so ip:1.2.3.4 raised UnsupportedPredicateException
             // with a misleading "BSON blob" message.

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -33,6 +33,7 @@ import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerInteractRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EntityHitRecord;
 import net.medievalrp.spyglass.api.event.EntityMountRecord;
@@ -442,6 +443,9 @@ public final class ClickHouseRecordStore implements RecordStore {
             recipients = c.recipients();
         } else if (record instanceof CommandRecord c) {
             commandLine = c.commandLine();
+        } else if (record instanceof CustomRecord custom) {
+            // Custom events reuse the message column for their freeform text.
+            message = custom.message();
         }
         writer.setValue("message", message);
         writer.setList("recipients", recipients);
@@ -933,6 +937,13 @@ public final class ClickHouseRecordStore implements RecordStore {
             return new CommandRecord(id, event, occurred, expiresAt,
                     origin, source, location, server, target,
                     row.getString("command_line"));
+        }
+        if (clazz == CustomRecord.class) {
+            // Registered custom event: reuses target + message + extensions.
+            return new CustomRecord(id, event, occurred, expiresAt,
+                    origin, source, location, server, target,
+                    row.getString("message"),
+                    readStringMap(row, "extensions"));
         }
         if (clazz == JoinRecord.class) {
             return new JoinRecord(id, event, occurred, expiresAt,

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -10,6 +10,7 @@ import net.medievalrp.spyglass.api.event.ChatRecord;
 import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.event.ItemDropRecord;
 import net.medievalrp.spyglass.api.event.ItemPickupRecord;
@@ -114,6 +115,21 @@ final class PredicateEvaluator {
             case "expiresAt" -> record.expiresAt();
             case "target" -> record.target();
             case "server" -> record.server();
+            // Content fields: needed so m:/message:/content: match on the
+            // in-memory post-filter path (SQLite always; CH/Mongo when a
+            // sibling clause can't push down). Without these the evaluator
+            // read message/commandLine as null and never matched.
+            case "message" -> messageOf(record);
+            case "commandLine" -> record instanceof CommandRecord command ? command.commandLine() : null;
+            case "address" -> record instanceof JoinRecord join ? join.address() : null;
+            // Chat recipients (rcp:) — a List, so equalsValue's any-element
+            // match handles membership. Unmapped on CH and blob-stored on
+            // SQLite, so this in-memory path is what makes rcp: work there.
+            case "recipients" -> record instanceof ChatRecord chat ? chat.recipients() : null;
+            // cause: pushes these down (both are mapped columns); resolve them
+            // here too so a cause: combined with a post-filtered sibling match.
+            case "source.entityType" -> record.source() == null ? null : record.source().entityType();
+            case "source.description" -> record.source() == null ? null : record.source().description();
             case "source.kind" -> record.source() == null ? null : record.source().kind();
             case "source.playerId" -> record.source() == null ? null : record.source().playerId();
             case "source.playerName" -> record.source() == null ? null : record.source().playerName();
@@ -151,6 +167,15 @@ final class PredicateEvaluator {
     // These live in opaque blobs on ClickHouse; the store's post-filter
     // fallback (and the synthesis parity filter) resolve them here from
     // the decoded records instead.
+
+    /** Freeform message text — chat and custom events both carry one. */
+    private static @Nullable String messageOf(EventRecord record) {
+        return switch (record) {
+            case ChatRecord chat -> chat.message();
+            case CustomRecord custom -> custom.message();
+            default -> null;
+        };
+    }
 
     private static @Nullable Object itemPathValue(EventRecord record, String field) {
         int dot = field.indexOf('.');

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -115,17 +115,6 @@ final class PredicateEvaluator {
             case "expiresAt" -> record.expiresAt();
             case "target" -> record.target();
             case "server" -> record.server();
-            // Content fields: needed so m:/message:/content: match on the
-            // in-memory post-filter path (SQLite always; CH/Mongo when a
-            // sibling clause can't push down). Without these the evaluator
-            // read message/commandLine as null and never matched.
-            case "message" -> messageOf(record);
-            case "commandLine" -> record instanceof CommandRecord command ? command.commandLine() : null;
-            case "address" -> record instanceof JoinRecord join ? join.address() : null;
-            // Chat recipients (rcp:) — a List, so equalsValue's any-element
-            // match handles membership. Unmapped on CH and blob-stored on
-            // SQLite, so this in-memory path is what makes rcp: work there.
-            case "recipients" -> record instanceof ChatRecord chat ? chat.recipients() : null;
             // cause: pushes these down (both are mapped columns); resolve them
             // here too so a cause: combined with a post-filtered sibling match.
             case "source.entityType" -> record.source() == null ? null : record.source().entityType();
@@ -156,7 +145,7 @@ final class PredicateEvaluator {
             // back to this residual filter. Without these cases they resolved to
             // null and never matched, so m:/rcp: silently returned empty on
             // SQLite. `m:` covers both chat and command lines, so resolve both.
-            case "message" -> record instanceof ChatRecord c ? c.message() : null;
+            case "message" -> messageOf(record);
             case "commandLine" -> record instanceof CommandRecord c ? c.commandLine() : null;
             case "recipients" -> record instanceof ChatRecord c ? c.recipients() : null;
             default -> itemPathValue(record, field);

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToSql.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToSql.java
@@ -31,6 +31,10 @@ final class PredicateToSql {
     private static final DateTimeFormatter CH_TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
+    /** Columns that are ClickHouse arrays: membership uses has()/hasAny(),
+     *  not scalar {@code =}/{@code IN}. */
+    private static final java.util.Set<String> ARRAY_COLUMNS = java.util.Set.of("recipients");
+
     static final class UnsupportedPredicateException extends RuntimeException {
         UnsupportedPredicateException(String message) {
             super(message);
@@ -102,6 +106,9 @@ final class PredicateToSql {
             }
             return "match(toString(" + column + "), " + stringLiteral(rx) + ")";
         }
+        if (ARRAY_COLUMNS.contains(column)) {
+            return "has(" + column + ", " + literal(value) + ")";
+        }
         return column + " = " + literal(value);
     }
 
@@ -109,6 +116,17 @@ final class PredicateToSql {
         String column = column(field);
         if (values.isEmpty()) {
             return "1=0";
+        }
+        if (ARRAY_COLUMNS.contains(column)) {
+            StringBuilder arr = new StringBuilder("hasAny(").append(column).append(", [");
+            for (int i = 0; i < values.size(); i++) {
+                if (i > 0) {
+                    arr.append(", ");
+                }
+                arr.append(literal(values.get(i)));
+            }
+            arr.append("])");
+            return arr.toString();
         }
         StringBuilder sb = new StringBuilder(column).append(" IN (");
         for (int i = 0; i < values.size(); i++) {

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -308,6 +308,66 @@ class ClickHouseRecordStoreIT {
                 store.querySummary(byEvent).records().get(0);
         assertThat(summary.message()).isEqualTo("hello there");
         assertThat(summary.extensions()).containsEntry("voice_session_id", "42");
+
+        // content:/regex/ on the message column pushes down to CH match()
+        // (server-side, no post-filter cap).
+        QueryRequest byRegex = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice"),
+                        new QueryPredicate.Eq("message",
+                                java.util.regex.Pattern.compile("hel+o",
+                                        java.util.regex.Pattern.CASE_INSENSITIVE))),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byRegex).records()).hasSize(1);
+
+        QueryRequest byRegexMiss = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice"),
+                        new QueryPredicate.Eq("message",
+                                java.util.regex.Pattern.compile("^goodbye$",
+                                        java.util.regex.Pattern.CASE_INSENSITIVE))),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byRegexMiss).records()).isEmpty();
+
+        // The exact predicate m: / message: / content: build: an OR across
+        // message + commandLine, each a quoted literal Pattern. commandLine
+        // must be a mapped column or the whole OR drops to the in-memory
+        // post-filter (where message read as null and never matched) — the
+        // regression this fixes.
+        java.util.regex.Pattern lit = java.util.regex.Pattern.compile(
+                java.util.regex.Pattern.quote("hello"), java.util.regex.Pattern.CASE_INSENSITIVE);
+        QueryRequest byContent = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice"),
+                        new QueryPredicate.Or(List.of(
+                                new QueryPredicate.Eq("message", lit),
+                                new QueryPredicate.Eq("commandLine", lit)))),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byContent).records())
+                .as("m:/content: (OR message,commandLine) must match the message column")
+                .hasSize(1);
+    }
+
+    @Test
+    void recipientSearchPushesDownAndMatches() {
+        // rcp: queries the recipients Array(UUID). It must push down via
+        // has()/hasAny() — not drop to the post-filter where it matched nothing.
+        UUID bob = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        Instant now = Instant.now().minusSeconds(60);
+        store.save(List.of(new ChatRecord(
+                UUID.randomUUID(), "say", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(ALICE, "Alice"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "test",
+                "hi", "hi", List.of(ALICE, bob), java.util.Map.of())));
+        flushAsyncInserts();
+
+        QueryRequest hit = new QueryRequest(
+                List.of(new QueryPredicate.Eq("recipients", bob)),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(hit).records()).hasSize(1);
+
+        QueryRequest miss = new QueryRequest(
+                List.of(new QueryPredicate.Eq("recipients",
+                        UUID.fromString("99999999-9999-9999-9999-999999999999"))),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(miss).records()).isEmpty();
     }
 
     @Test

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -269,6 +269,48 @@ class ClickHouseRecordStoreIT {
     }
 
     @Test
+    void roundTripsRegisteredCustomEvent() {
+        // A registered custom event (e.g. voicechat's "voice") must persist
+        // and decode as a CustomRecord, searchable by a:, m:, and
+        // extensions.<key>, with the bag intact on the display path.
+        net.medievalrp.spyglass.api.event.EventCatalog.register("voice", "spoke");
+        Instant now = Instant.now().minusSeconds(60);
+        BlockLocation loc = new BlockLocation(WORLD, "world", 1, 64, 2);
+        net.medievalrp.spyglass.api.event.CustomRecord rec =
+                net.medievalrp.spyglass.api.event.CustomRecord.of(
+                        new net.medievalrp.spyglass.api.event.RecordContext(
+                                UUID.randomUUID(), now, now.plusSeconds(3600),
+                                Origin.player(), Source.player(ALICE, "Alice"), loc, "test",
+                                java.util.Map.of()),
+                        "voice", "voice to 2 players", "hello there",
+                        java.util.Map.of("voice_session_id", "42"));
+        store.save(List.of(rec));
+        flushAsyncInserts();
+
+        QueryRequest byEvent = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        var back = (net.medievalrp.spyglass.api.event.CustomRecord)
+                store.query(byEvent).records().get(0);
+        assertThat(back.message()).isEqualTo("hello there");
+        assertThat(back.target()).isEqualTo("voice to 2 players");
+        assertThat(back.extensions()).containsEntry("voice_session_id", "42");
+
+        // extensions.<key> filtering and m: message search both hit.
+        QueryRequest byExt = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice"),
+                        new QueryPredicate.Eq("extensions.voice_session_id", "42")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byExt).records()).hasSize(1);
+
+        // Display path keeps the bag (no item predicate, no post-filter).
+        var summary = (net.medievalrp.spyglass.api.event.CustomRecord)
+                store.querySummary(byEvent).records().get(0);
+        assertThat(summary.message()).isEqualTo("hello there");
+        assertThat(summary.extensions()).containsEntry("voice_session_id", "42");
+    }
+
+    @Test
     void summaryQueryRetainsItemProjectionsForHover() {
         // Feature: the search hover shows an item's custom name / lore /
         // enchants. The display path (querySummary) must carry the item even

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -375,6 +375,41 @@ class MongoRecordStoreIT {
     }
 
     @Test
+    void roundTripsRegisteredCustomEvent() {
+        net.medievalrp.spyglass.api.event.EventCatalog.register("voice", "spoke");
+        Instant now = Instant.now();
+        BlockLocation loc = new BlockLocation(WORLD, "world", 1, 64, 2);
+        net.medievalrp.spyglass.api.event.CustomRecord rec =
+                net.medievalrp.spyglass.api.event.CustomRecord.of(
+                        new net.medievalrp.spyglass.api.event.RecordContext(
+                                UUID.randomUUID(), now, now.plusSeconds(3600),
+                                Origin.player(), Source.player(ALICE, "Alice"), loc, "test",
+                                java.util.Map.of()),
+                        "voice", "voice to 2 players", "hello there",
+                        java.util.Map.of("voice_session_id", "42"));
+        store.save(List.of(rec));
+
+        QueryRequest byEvent = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        var back = (net.medievalrp.spyglass.api.event.CustomRecord)
+                store.query(byEvent).records().get(0);
+        assertThat(back.message()).isEqualTo("hello there");
+        assertThat(back.target()).isEqualTo("voice to 2 players");
+        assertThat(back.extensions()).containsEntry("voice_session_id", "42");
+
+        QueryRequest byExt = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "voice"),
+                        new QueryPredicate.Eq("extensions.voice_session_id", "42")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(byExt).records()).hasSize(1);
+
+        var summary = (net.medievalrp.spyglass.api.event.CustomRecord)
+                store.querySummary(byEvent).records().get(0);
+        assertThat(summary.extensions()).containsEntry("voice_session_id", "42");
+    }
+
+    @Test
     void summaryQueryRetainsItemProjectionsForHover() {
         // The display path (querySummary) drops the bulky BlockSnapshot
         // payloads but must keep the item so the search hover can show its

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -162,6 +162,34 @@ class SqliteRecordStoreTest {
     // ===== Tests ===============================================
 
     @Test
+    void roundTripsRegisteredCustomEvent() {
+        net.medievalrp.spyglass.api.event.EventCatalog.register("voice", "spoke");
+        Instant occurred = BASE.minusSeconds(5);
+        net.medievalrp.spyglass.api.event.CustomRecord rec =
+                net.medievalrp.spyglass.api.event.CustomRecord.of(
+                        new net.medievalrp.spyglass.api.event.RecordContext(
+                                EventIds.newId(), occurred, occurred.plusSeconds(RETENTION),
+                                Origin.player(), Source.player(UUID.randomUUID(), "Eve"),
+                                new BlockLocation(WORLD, "world", 1, 64, 2), "srv", Map.of()),
+                        "voice", "voice to 2 players", "hello there",
+                        Map.of("voice_session_id", "42"));
+        store.save(List.of(rec));
+
+        var back = (net.medievalrp.spyglass.api.event.CustomRecord) store
+                .query(request(List.of(new QueryPredicate.Eq("event", "voice"))))
+                .records().get(0);
+        assertThat(back.message()).isEqualTo("hello there");
+        assertThat(back.target()).isEqualTo("voice to 2 players");
+        assertThat(back.extensions()).containsEntry("voice_session_id", "42");
+
+        // extensions.<key> filtering (post-filter; extensions live in the blob).
+        var byExt = request(List.of(
+                new QueryPredicate.Eq("event", "voice"),
+                new QueryPredicate.Eq("extensions.voice_session_id", "42")));
+        assertThat(store.query(byExt).records()).hasSize(1);
+    }
+
+    @Test
     void simpleBlockRoundTripsThroughColumnsWithNoBlob() throws SQLException {
         BlockBreakRecord record = simpleBreak(10);
         store.save(List.of(record));

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -162,6 +162,44 @@ class SqliteRecordStoreTest {
     // ===== Tests ===============================================
 
     @Test
+    void recipientSearchMatchesViaPostFilter() {
+        // recipients live in the blob on SQLite -> post-filter. The evaluator
+        // must resolve the list (membership) or rcp: silently matches nothing.
+        UUID alice = UUID.randomUUID();
+        UUID bob = UUID.randomUUID();
+        store.save(List.of(new ChatRecord(
+                EventIds.newId(), "say", BASE, BASE.plusSeconds(3600),
+                Origin.player(), Source.player(alice, "Alice"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv",
+                "hi", "hi", List.of(alice, bob), Map.of())));
+
+        assertThat(store.query(request(List.of(new QueryPredicate.Eq("recipients", bob))))
+                .records()).hasSize(1);
+        assertThat(store.query(request(List.of(new QueryPredicate.Eq("recipients", UUID.randomUUID()))))
+                .records()).isEmpty();
+    }
+
+    @Test
+    void contentSearchMatchesChatMessageViaPostFilter() {
+        // On SQLite the message lives in the blob, so m:/content: always runs
+        // as an in-memory post-filter. The evaluator must resolve `message`
+        // (and commandLine) or the OR never matches.
+        store.save(List.of(chat("hello there world")));
+        Pattern lit = Pattern.compile(Pattern.quote("there"), Pattern.CASE_INSENSITIVE);
+        var req = request(List.of(new QueryPredicate.Or(List.of(
+                new QueryPredicate.Eq("message", lit),
+                new QueryPredicate.Eq("commandLine", lit)))));
+        assertThat(store.query(req).records()).hasSize(1);
+
+        var miss = request(List.of(new QueryPredicate.Or(List.of(
+                new QueryPredicate.Eq("message",
+                        Pattern.compile(Pattern.quote("absent"), Pattern.CASE_INSENSITIVE)),
+                new QueryPredicate.Eq("commandLine",
+                        Pattern.compile(Pattern.quote("absent"), Pattern.CASE_INSENSITIVE))))));
+        assertThat(store.query(miss).records()).isEmpty();
+    }
+
+    @Test
     void roundTripsRegisteredCustomEvent() {
         net.medievalrp.spyglass.api.event.EventCatalog.register("voice", "spoke");
         Instant occurred = BASE.minusSeconds(5);

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyResultRenderer.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/command/ProxyResultRenderer.java
@@ -20,6 +20,7 @@ import net.medievalrp.spyglass.api.event.CommandRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerInteractRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EntityHitRecord;
 import net.medievalrp.spyglass.api.event.EntityMountRecord;
@@ -262,6 +263,7 @@ public final class ProxyResultRenderer {
             case BlockUseRecord r -> r.target();
             case RollbackOpRecord r -> r.mode() == null ? "" : r.mode().toUpperCase(java.util.Locale.ROOT);
             case ChatRecord r -> r.target();
+            case CustomRecord r -> customText(r);
             case CommandRecord r -> "/" + r.target();
             case JoinRecord r -> r.address() == null || r.address().isEmpty()
                     ? ""
@@ -280,6 +282,17 @@ public final class ProxyResultRenderer {
                 yield upperOrEmpty(r.target()) + " " + arrow;
             }
         };
+    }
+
+    /** Inline text for a custom integrator event: "target: message", or just
+     *  whichever is present. Mirrors the Paper renderer. */
+    private static String customText(CustomRecord custom) {
+        String message = custom.message() == null ? "" : custom.message();
+        String target = custom.target();
+        if (target != null && !target.isEmpty() && !target.equals(message)) {
+            return message.isEmpty() ? target : target + ": " + message;
+        }
+        return message;
     }
 
     private static int quantityOf(EventRecord record) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -346,10 +346,14 @@ public final class SpyglassPlugin extends JavaPlugin {
             recorder.setIngestStats(ingestStats);
         }
 
-        Set<String> enabledEvents = config.events().entrySet().stream()
+        // Mutable, thread-safe: SpyglassApi#registerEvent adds custom event
+        // names at runtime, and the same instance is shared with EventParam
+        // so a:<name> parses for them. Seeded from the enabled config events.
+        Set<String> enabledEvents = java.util.concurrent.ConcurrentHashMap.newKeySet();
+        config.events().entrySet().stream()
                 .filter(entry -> entry.getValue().enabled())
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toUnmodifiableSet());
+                .forEach(enabledEvents::add);
 
         // Bind the per-server id stream before any listener can mint a
         // record id (#44): instance bits keep sequences collision-free

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -28,6 +28,7 @@ import net.medievalrp.spyglass.plugin.command.param.ItemLoreParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemMaterialParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemNameParam;
 import net.medievalrp.spyglass.plugin.command.param.ItemTagParam;
+import net.medievalrp.spyglass.plugin.command.param.ContentParam;
 import net.medievalrp.spyglass.plugin.command.param.MessageParam;
 import net.medievalrp.spyglass.plugin.command.param.PlayerParam;
 import net.medievalrp.spyglass.plugin.command.param.QueryStringParser;
@@ -447,6 +448,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         apiImpl.registerQueryParamHandler(new ItemTagParam());
         apiImpl.registerQueryParamHandler(new EnchantParam());
         apiImpl.registerQueryParamHandler(new MessageParam());
+        apiImpl.registerQueryParamHandler(new ContentParam());
         apiImpl.registerQueryParamHandler(new CauseParam());
         apiImpl.registerQueryParamHandler(new ItemMaterialParam());
         apiImpl.registerQueryParamHandler(new CustomItemParam());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.SpyglassLimits;
+import net.medievalrp.spyglass.api.event.EventCatalog;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.extension.DisplayRenderer;
 import net.medievalrp.spyglass.api.extension.FlagHandler;
@@ -49,7 +50,10 @@ public final class SpyglassApiImpl implements SpyglassApi {
         this.recorder = recorder;
         this.recordStore = recordStore;
         this.queryExecutor = queryExecutor;
-        this.enabledEvents = Set.copyOf(enabledEvents);
+        // Live reference, NOT a copy: registerEvent() adds custom names at
+        // runtime and EventParam (which shares this same set instance) must
+        // see them so a:<name> parses.
+        this.enabledEvents = enabledEvents;
         this.limits = limits;
         this.serverName = serverName;
         this.logger = logger;
@@ -58,6 +62,22 @@ public final class SpyglassApiImpl implements SpyglassApi {
     @Override
     public void record(EventRecord record) {
         recorder.record(record);
+    }
+
+    @Override
+    public void registerEvent(String name, String pastTense) {
+        if (name == null || name.isBlank()) {
+            return;
+        }
+        // EventCatalog: makes the read path decode it as a CustomRecord and
+        // supplies the display verb. enabledEvents: makes a:<name> parse.
+        EventCatalog.register(name, pastTense);
+        enabledEvents.add(name.toLowerCase(java.util.Locale.ROOT));
+    }
+
+    @Override
+    public boolean isEventRegistered(String name) {
+        return EventCatalog.isRegistered(name);
     }
 
     @Override
@@ -132,7 +152,7 @@ public final class SpyglassApiImpl implements SpyglassApi {
 
     @Override
     public Set<String> enabledEvents() {
-        return enabledEvents;
+        return Set.copyOf(enabledEvents);
     }
 
     @Override

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ContentParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ContentParam.java
@@ -1,0 +1,73 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.bukkit.command.CommandSender;
+
+/**
+ * {@code content:...} — case-insensitive content search over the message of
+ * chat / command / custom records, with optional regex. The richer sibling of
+ * {@code m:} (which is always a plain literal substring): use {@code content:}
+ * when you need a pattern.
+ *
+ * <ul>
+ *   <li>{@code content:slur} or {@code content:"how are we today"} — literal,
+ *       case-insensitive substring.</li>
+ *   <li>{@code content:/(slur1|slur2)/} — the {@code /.../}-delimited form is
+ *       compiled as a case-insensitive regular expression.</li>
+ * </ul>
+ *
+ * <p>Fans across {@link net.medievalrp.spyglass.api.event.ChatRecord#message()},
+ * {@link net.medievalrp.spyglass.api.event.CustomRecord#message()}, and
+ * {@link net.medievalrp.spyglass.api.event.CommandRecord#commandLine()} — both
+ * live in the {@code message} / {@code commandLine} columns. On the ClickHouse
+ * and Mongo backends the pattern pushes down to a server-side regex; on SQLite
+ * (message in the blob) it runs as an in-memory post-filter.
+ */
+public final class ContentParam implements QueryParamHandler {
+
+    @Override
+    public List<String> aliases() {
+        return List.of("content");
+    }
+
+    @Override
+    public QueryPredicate parse(String alias, String value, ParamContext context) throws ParamParseException {
+        if (value == null || value.isBlank()) {
+            throw new ParamParseException("content requires a value.");
+        }
+        String safe = ItemFieldParams.requireSafeTerm(alias, value.trim());
+        Pattern pattern = isRegexForm(safe) ? compileRegex(safe) : literal(safe);
+        return new QueryPredicate.Or(List.of(
+                new QueryPredicate.Eq("message", pattern),
+                new QueryPredicate.Eq("commandLine", pattern)));
+    }
+
+    /** {@code /.../} with something between the slashes is the regex form. */
+    private static boolean isRegexForm(String value) {
+        return value.length() >= 3 && value.startsWith("/") && value.endsWith("/");
+    }
+
+    private static Pattern compileRegex(String value) throws ParamParseException {
+        String body = value.substring(1, value.length() - 1);
+        try {
+            return Pattern.compile(body, Pattern.CASE_INSENSITIVE);
+        } catch (PatternSyntaxException ex) {
+            throw new ParamParseException("Invalid content regex: " + ex.getMessage());
+        }
+    }
+
+    /** Plain case-insensitive substring — Pattern.quote defangs any metachars. */
+    private static Pattern literal(String value) {
+        return Pattern.compile(Pattern.quote(value), Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    public List<String> suggestions(CommandSender sender, String input) {
+        return List.of();
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
@@ -12,7 +12,9 @@ public final class EventParam implements QueryParamHandler {
     private final Set<String> enabledEvents;
 
     public EventParam(Set<String> enabledEvents) {
-        this.enabledEvents = Set.copyOf(enabledEvents);
+        // Live reference, NOT a copy: SpyglassApi#registerEvent adds custom
+        // event names to this same set at runtime so a:<name> parses for them.
+        this.enabledEvents = enabledEvents;
     }
 
     @Override

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -17,6 +17,7 @@ import net.medievalrp.spyglass.api.event.BlockUseRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.ContainerInteractRecord;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EntityHitRecord;
 import net.medievalrp.spyglass.api.event.EntityMountRecord;
@@ -423,6 +424,9 @@ public final class ResultRenderer {
             // mode rides in target. Renders "<operator> ran ROLLBACK".
             case RollbackOpRecord op -> upperOrEmpty(op.mode());
             case ChatRecord chat -> chatText(chat);
+            // Generic integrator event: render "target: message" (like chat),
+            // so a voice transcript reads "spoke voice to 3 players: <text>".
+            case CustomRecord custom -> customText(custom);
             case CommandRecord command -> "/" + command.target();
             // Join's "target" in the data model is the player's own
             // name, which duplicates the source — show the IP instead
@@ -473,6 +477,20 @@ public final class ResultRenderer {
      * Vanilla chat stores target == message (its aggregation key), so this just
      * yields the message.
      */
+    /**
+     * Inline text for a custom integrator event: the freeform message is the
+     * content; when {@code target} is a distinct summary it prefixes it
+     * ("voice to 3 players: hello there"). Mirrors {@link #chatText}.
+     */
+    private static String customText(CustomRecord custom) {
+        String message = custom.message() == null ? "" : custom.message();
+        String target = custom.target();
+        if (target != null && !target.isEmpty() && !target.equals(message)) {
+            return message.isEmpty() ? target : target + ": " + message;
+        }
+        return message;
+    }
+
     private static String chatText(ChatRecord chat) {
         String message = chat.message() == null ? "" : chat.message();
         String channel = chat.target();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -187,7 +187,14 @@ public record SpyglassConfig(
     }
 
     public String pastTense(String eventName) {
-        return events.getOrDefault(eventName, new EventSettings(false, eventName)).pastTense();
+        EventSettings settings = events.get(eventName);
+        if (settings != null) {
+            return settings.pastTense();
+        }
+        // Custom events registered at runtime via SpyglassApi#registerEvent
+        // aren't in config; their verb lives in the EventCatalog registry.
+        String custom = net.medievalrp.spyglass.api.event.EventCatalog.pastTenseOf(eventName);
+        return custom != null ? custom : eventName;
     }
 
     /**

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -267,6 +267,9 @@ events {
   use = { enabled = true, past-tense = "used" }
   useSign = { enabled = true, past-tense = "activated" }
   say = { enabled = true, past-tense = "said" }
+  # Spoken voice-chat transcripts pushed in by an external integration
+  # (e.g. voicechat) via the API. Searchable as a:voice.
+  voice = { enabled = true, past-tense = "spoke" }
   # redact: command heads whose ARGUMENTS are masked before recording —
   # "/login hunter2" is stored as "/login ***" so auth-plugin passwords
   # never reach the database, the WAL, or a search hover. Heads match

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
@@ -1,0 +1,46 @@
+package net.medievalrp.spyglass.plugin.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.CustomRecord;
+import net.medievalrp.spyglass.api.event.EventCatalog;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import org.junit.jupiter.api.Test;
+
+class SpyglassApiImplTest {
+
+    private SpyglassApiImpl api(Set<String> enabled) {
+        return new SpyglassApiImpl(
+                mock(Recorder.class), mock(RecordStore.class), Runnable::run,
+                enabled, null, "srv", Logger.getLogger("test"));
+    }
+
+    @Test
+    void registerEventMakesItKnownEnabledAndDecodable() {
+        Set<String> enabled = ConcurrentHashMap.newKeySet();
+        SpyglassApiImpl api = api(enabled);
+
+        assertThat(api.isEventRegistered("apitest-voice")).isFalse();
+
+        api.registerEvent("apitest-voice", "spoke");
+
+        assertThat(api.isEventRegistered("apitest-voice")).isTrue();
+        // Added to the live enabled set so EventParam (sharing it) parses a:.
+        assertThat(enabled).contains("apitest-voice");
+        // Resolves on the read path as a CustomRecord.
+        assertThat(EventCatalog.recordClassOf("apitest-voice")).isEqualTo(CustomRecord.class);
+        assertThat(EventCatalog.pastTenseOf("apitest-voice")).isEqualTo("spoke");
+    }
+
+    @Test
+    void builtinEventsReportAsRegistered() {
+        SpyglassApiImpl api = api(ConcurrentHashMap.newKeySet());
+        assertThat(api.isEventRegistered("say")).isTrue();
+        assertThat(api.isEventRegistered("not-a-real-event")).isFalse();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ContentParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ContentParamTest.java
@@ -1,0 +1,76 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.Pattern;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.junit.jupiter.api.Test;
+
+class ContentParamTest {
+
+    private static Pattern messagePattern(QueryPredicate predicate) {
+        assertThat(predicate).isInstanceOf(QueryPredicate.Or.class);
+        QueryPredicate.Or or = (QueryPredicate.Or) predicate;
+        assertThat(or.predicates()).hasSize(2);
+        QueryPredicate first = or.predicates().get(0);
+        QueryPredicate second = or.predicates().get(1);
+        assertThat(((QueryPredicate.Eq) first).field()).isEqualTo("message");
+        assertThat(((QueryPredicate.Eq) second).field()).isEqualTo("commandLine");
+        Object value = ((QueryPredicate.Eq) first).value();
+        assertThat(value).isInstanceOf(Pattern.class);
+        return (Pattern) value;
+    }
+
+    @Test
+    void literalIsQuotedAndCaseInsensitive() throws Exception {
+        Pattern pattern = messagePattern(new ContentParam().parse("content", "how are we today", ctx()));
+        // Pattern.quote wraps in \Q...\E so metacharacters are literal.
+        assertThat(pattern.pattern()).isEqualTo(Pattern.quote("how are we today"));
+        assertThat(pattern.flags() & Pattern.CASE_INSENSITIVE).isNotZero();
+    }
+
+    @Test
+    void slashDelimitedFormIsCompiledAsRegex() throws Exception {
+        Pattern pattern = messagePattern(new ContentParam().parse("content", "/(slur1|slur2)/", ctx()));
+        // Regex body is used verbatim (not quoted), case-insensitive.
+        assertThat(pattern.pattern()).isEqualTo("(slur1|slur2)");
+        assertThat(pattern.flags() & Pattern.CASE_INSENSITIVE).isNotZero();
+        assertThat(pattern.matcher("a SLUR2 here").find()).isTrue();
+    }
+
+    @Test
+    void literalMetacharsAreNotTreatedAsRegex() throws Exception {
+        // A bare value with regex metachars stays literal: "a.b" matches "a.b",
+        // not "axb".
+        Pattern pattern = messagePattern(new ContentParam().parse("content", "a.b", ctx()));
+        assertThat(pattern.matcher("a.b").find()).isTrue();
+        assertThat(pattern.matcher("axb").find()).isFalse();
+    }
+
+    @Test
+    void invalidRegexRejected() {
+        assertThatThrownBy(() -> new ContentParam().parse("content", "/(unclosed/", ctx()))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("regex");
+    }
+
+    @Test
+    void emptyValueRejected() {
+        assertThatThrownBy(() -> new ContentParam().parse("content", "  ", ctx()))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void loneSlashesAreLiteralNotRegex() throws Exception {
+        // "//" is too short to be the /regex/ form; treat as a literal "//".
+        Pattern pattern = messagePattern(new ContentParam().parse("content", "//", ctx()));
+        assertThat(pattern.pattern()).isEqualTo(Pattern.quote("//"));
+    }
+
+    private static ParamContext ctx() {
+        return new ParamContext(null, null, 100);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
@@ -139,6 +139,24 @@ class EventParamTest {
                 .isInstanceOf(ParamParseException.class);
     }
 
+    @Test
+    void liveEnabledSetReflectsRuntimeRegistration() throws Exception {
+        // EventParam holds the enabled set by reference (not a copy), so a
+        // custom event registered at runtime via SpyglassApi#registerEvent
+        // (which adds to this same set) makes a:<name> parse without a restart.
+        Set<String> live = java.util.concurrent.ConcurrentHashMap.newKeySet();
+        live.add("break");
+        EventParam param = new EventParam(live);
+
+        assertThatThrownBy(() -> param.parse("a", "voice", ctx()))
+                .isInstanceOf(ParamParseException.class);
+
+        live.add("voice"); // simulate registerEvent("voice", ...)
+
+        QueryPredicate predicate = param.parse("a", "voice", ctx());
+        assertThat(((QueryPredicate.Eq) predicate).value()).isEqualTo("voice");
+    }
+
     private static ParamContext ctx() {
         return new ParamContext(null, null, 100);
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -374,6 +374,31 @@ class ResultRendererTest {
         assertThat(hover).doesNotContain(big);
     }
 
+    @Test
+    void rendersCustomEventWithVerbTargetMessageAndBagInHover() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("voice")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("voice", "spoke"));
+
+        Instant now = Instant.now();
+        net.medievalrp.spyglass.api.event.CustomRecord record =
+                new net.medievalrp.spyglass.api.event.CustomRecord(
+                        UUID.randomUUID(), "voice", now, now.plusSeconds(60),
+                        Origin.player(), Source.player(PLAYER_ID, "Alice"),
+                        new BlockLocation(WORLD_ID, "world", 1, 64, 2), "srv",
+                        "voice to 2 players", "hello there",
+                        java.util.Map.of("voice_session_id", "42"));
+
+        Component rendered = renderer.renderSingle(record, EnumSet.noneOf(Flag.class), true);
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+
+        assertThat(plain).contains("Alice").contains("spoke")
+                .contains("voice to 2 players").contains("hello there");
+        // The bag rides into the hover as first-class key/value lines.
+        String hover = hoverPlain(rendered);
+        assertThat(hover).contains("session_id").contains("42");
+    }
+
     private static String findRunCommand(Component component) {
         net.kyori.adventure.text.event.ClickEvent click = component.clickEvent();
         if (click != null


### PR DESCRIPTION
The60th's `voicechat-dev` work rebased onto current `dev` (it was on a pre-rewrite lineage with no common history, so a straight merge was impossible). The 4 feature commits are The60th's, as-authored: hardcoded voice event, on-the-fly event-registration API (`SpyglassApi#registerEvent` + `CustomRecord`), ClickHouse/voice hotfixes, death-model spec.

Two mechanical conflicts resolved while rebasing (no API redesign):
- `SpyglassPlugin`: keep both `dev`'s #168 analytics block and The60th's mutable `ConcurrentHashMap.newKeySet()` for the runtime-registered events.
- `PredicateEvaluator`: `dev`'s #156 residual block and The60th's content-field block both added the same cases; kept `dev`'s canonical block but routed `message` through `messageOf()` so custom-event messages stay searchable.

`./gradlew check` green (incl. The60th's new CustomRecord/SpyglassApiImpl/EventParam tests + the Docker store ITs). Ready to merge; opened as a PR so the integration is reviewable rather than force-merged.