### PR TITLE
fix(pipeline): reclaim the disk spill while the queue is busy so it can't grow unbounded (#180)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -311,6 +311,9 @@ public final class SpyglassPlugin extends JavaPlugin {
         recorder = new AsyncRecorder(
                 config.storage().queueCapacity(), config.storage().queueMax(),
                 recordStore, wal, spill, Bukkit::isPrimaryThread, getLogger());
+        // #180: cap how fast the drain reclaims a large on-disk spill backlog in
+        // the background, so it never saturates the store on a live server.
+        recorder.setSpillDrainRate(config.storage().spillDrainRate());
         // Publish RecordCommittedEvent to Bukkit listeners on every
         // intake. Done via a hook (rather than a direct Bukkit call
         // inside AsyncRecorder) so the recorder stays unit-testable
@@ -608,7 +611,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 salvageStore, salvageGui, config.limits().searchResult(), serviceSupport);
         // #168: /spyglass stats. Null ingestStats (analytics off) => the command
         // explains how to enable it.
-        StatsService statsService = new StatsService(ingestStats);
+        StatsService statsService = new StatsService(ingestStats, recorder::spillSnapshot);
 
         SpyglassCommands commands = new SpyglassCommands(
                 this,

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/StatsService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/StatsService.java
@@ -1,33 +1,45 @@
 package net.medievalrp.spyglass.plugin.command.service;
 
+import java.util.Locale;
+import java.util.function.Supplier;
 import net.medievalrp.spyglass.plugin.command.render.Feedback;
+import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
 import net.medievalrp.spyglass.plugin.pipeline.IngestStats;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Renders the on-demand ingest analytics snapshot for {@code /spyglass stats}
- * (#168). A {@code null} {@link IngestStats} means analytics is disabled, in
- * which case the command explains how to turn it on.
+ * Renders {@code /spyglass stats}: the on-disk spill backlog (#180) followed by
+ * the opt-in ingest analytics snapshot (#168).
+ *
+ * <p>The spill backlog is shown <b>regardless</b> of whether analytics is
+ * enabled — it is the operator's gauge for reclaiming an on-disk overflow (a big
+ * WorldEdit paste that spilled), and analytics is off by default. A {@code null}
+ * {@link IngestStats} means analytics is disabled, in which case the analytics
+ * section is replaced by a hint on how to turn it on.
  *
  * <p>Rates are reported as the average since analytics was enabled (a stable
  * figure that needs no main-thread sleep); the periodic console report carries
- * the live per-interval rates. Gauges (queue depth, totals, allocation) are the
- * current values either way.
+ * the live per-interval rates. Gauges (queue depth, totals, allocation, spill
+ * backlog) are the current values either way.
  */
 @ApiStatus.Internal
 public final class StatsService {
 
     private final IngestStats stats;             // null when analytics is disabled
     private final IngestStats.Snapshot baseline; // captured at enable time
+    private final Supplier<AsyncRecorder.SpillSnapshot> spill;
 
-    public StatsService(@Nullable IngestStats stats) {
+    public StatsService(@Nullable IngestStats stats,
+                        Supplier<AsyncRecorder.SpillSnapshot> spill) {
         this.stats = stats;
         this.baseline = stats == null ? null : stats.capture(System.nanoTime());
+        this.spill = spill;
     }
 
     public void execute(CommandSender sender) {
+        renderSpillBacklog(sender);
         if (stats == null) {
             sender.sendMessage(Feedback.warn(
                     "Spyglass analytics is disabled. Set analytics.enabled = true in "
@@ -39,5 +51,24 @@ public final class StatsService {
         for (String line : IngestStats.describe(baseline, now)) {
             sender.sendMessage(Feedback.bonus(line));
         }
+    }
+
+    private void renderSpillBacklog(CommandSender sender) {
+        AsyncRecorder.SpillSnapshot snap = spill.get();
+        if (!snap.enabled()) {
+            return; // spill-to-disk off (or no queue ceiling): nothing to report
+        }
+        if (snap.records() <= 0) {
+            sender.sendMessage(Feedback.success("Spill backlog: empty (all overflow drained)."));
+            return;
+        }
+        String rate = snap.drainRatePerSec() <= 0
+                ? "unlimited"
+                : snap.drainRatePerSec() + " rec/s";
+        sender.sendMessage(Feedback.warn(String.format(Locale.ROOT,
+                "Spill backlog: %d record(s) in %d segment(s), %.1f MiB on disk, draining at "
+                        + "up to %s. These records are durable but not queryable until replayed; "
+                        + "raise storage.spill-drain-rate to recover faster.",
+                snap.records(), snap.segments(), snap.bytes() / 1_048_576.0, rate)));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -101,6 +101,7 @@ public record SpyglassConfig(
                         root.node("storage", "queue-capacity").getInt(100_000),
                         root.node("storage", "queue-max").getInt(500_000),
                         root.node("storage", "spill-to-disk").getBoolean(true),
+                        root.node("storage", "spill-drain-rate").getInt(20_000),
                         Duration.parse(root.node("storage", "flush-timeout").getString("5s")),
                         parseDurability(root.node("storage", "durability").getString("ram")),
                         "synthesized".equalsIgnoreCase(
@@ -309,6 +310,15 @@ public record SpyglassConfig(
      *                      WorldEdit paste heap-flat without dropping records:
      *                      the drain replays spilled segments. Requires
      *                      {@code queueMax > 0}; needs a fast local disk.
+     * @param spillDrainRate cap, in records/sec, on how fast the drain reclaims
+     *                      the on-disk spill backlog in the background (#180). The
+     *                      drain replays spilled segments using spare capacity (it
+     *                      keeps live events fresh and pauses while the queue is at
+     *                      the ceiling) but no faster than this, so reclaiming a
+     *                      large backlog never saturates the store on a live
+     *                      server. {@code 0} = unlimited (drain as fast as the
+     *                      store accepts); raise it or set 0 during a maintenance
+     *                      window to recover a big backlog faster.
      * @param flushTimeout  upper bound on how long {@code onDisable} will
      *                      wait for the queue to drain before returning.
      * @param durability    how aggressive the write path is about
@@ -326,7 +336,7 @@ public record SpyglassConfig(
      *                      cheap; per-event overhead is negligible.
      */
     public record Storage(Duration retention, int queueCapacity, int queueMax,
-                          boolean spillToDisk, Duration flushTimeout,
+                          boolean spillToDisk, int spillDrainRate, Duration flushTimeout,
                           Durability durability, boolean rolledAuditSynthesized) {
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -115,6 +115,14 @@ public final class AsyncRecorder implements Recorder {
     // hot path is a single volatile read + null check when off - the same shape
     // as committedHook above. Set once at startup via setIngestStats.
     private volatile IngestStats ingestStats = null;
+    // Background spill-drain rate cap (records/sec). When reclaiming a large
+    // on-disk backlog on a live server, the drain replays spilled segments using
+    // spare capacity but no faster than this, so the backfill never saturates the
+    // store. 0 = unlimited (drain as fast as the store accepts). Set from config
+    // after construction; volatile because the drain thread reads it.
+    private volatile long spillDrainRatePerSec = 0L;
+    // Rate-limited spill-backlog warning state, mirroring lastWarnedDepth.
+    private final AtomicLong lastSpillWarn = new AtomicLong();
 
     /**
      * Pre-flush gate. {@link #flush} awaits this before snapshotting the
@@ -258,6 +266,27 @@ public final class AsyncRecorder implements Recorder {
         return dropped.get();
     }
 
+    /**
+     * Cap how fast the drain replays on-disk spill overflow in the background
+     * (#180), in records/sec. {@code 0} = unlimited. Keeps reclaiming a large
+     * backlog from saturating the store on a live server; raise it (or set 0)
+     * during a maintenance window to recover faster.
+     */
+    public void setSpillDrainRate(long recordsPerSecond) {
+        this.spillDrainRatePerSec = Math.max(0L, recordsPerSecond);
+    }
+
+    /** Operator gauge (#180): current on-disk spill backlog and its drain cap. */
+    public SpillSnapshot spillSnapshot() {
+        return new SpillSnapshot(spill.enabled(), spill.pendingSegments(),
+                spill.pendingRecordCount(), spill.pendingByteCount(), spillDrainRatePerSec);
+    }
+
+    /** Immutable view of the spill backlog for {@code /spyglass stats}. */
+    public record SpillSnapshot(boolean enabled, long segments, long records,
+                                long bytes, long drainRatePerSec) {
+    }
+
     @Override
     public void record(EventRecord record) {
         // Backpressure an off-main firehose (FAWE worker threads reach the
@@ -314,6 +343,7 @@ public final class AsyncRecorder implements Recorder {
         if (spill.enabled() && queueMax > 0 && queue.size() >= queueMax) {
             try {
                 spill.spill(records);
+                warnIfSpillBacklog();
                 return;
             } catch (java.io.IOException spillFailure) {
                 // Disk full / I/O error: fall back to in-RAM backpressure
@@ -359,6 +389,33 @@ public final class AsyncRecorder implements Recorder {
                         + " (warn threshold " + warnThreshold + "). The drain is"
                         + " falling behind" + ceiling + ". No records dropped — check the"
                         + " storage backend's reachability and drain latency.");
+            }
+        }
+    }
+
+    // Warn as the on-disk spill backlog grows (#180), at the first crossing of
+    // the warn threshold and at each doubling thereafter — same shape as the
+    // queue warning. The drain resets lastSpillWarn to 0 once the backlog clears,
+    // so a later backlog warns afresh. Spilled records are durable but not yet in
+    // the store (not queryable until the drain replays them), so this is the
+    // operator's signal to watch /spyglass stats and consider raising the rate.
+    private void warnIfSpillBacklog() {
+        long pending = spill.pendingRecordCount();
+        if (pending > warnThreshold) {
+            long last = lastSpillWarn.get();
+            boolean firstCrossing = last == 0;
+            boolean doubledSinceLast = last > 0 && pending >= last * 2;
+            if ((firstCrossing || doubledSinceLast)
+                    && lastSpillWarn.compareAndSet(last, pending)) {
+                String rate = spillDrainRatePerSec <= 0
+                        ? "unlimited"
+                        : spillDrainRatePerSec + " rec/s";
+                logger.warning("Spyglass spill backlog " + pending + " record(s) in "
+                        + spill.pendingSegments() + " segment(s) on disk. The drain is"
+                        + " reclaiming it in the background (up to " + rate + "); spilled"
+                        + " records are durable but not queryable until replayed. No records"
+                        + " dropped — raise storage.spill-drain-rate to recover faster, or"
+                        + " check store/drain latency.");
             }
         }
     }
@@ -476,42 +533,80 @@ public final class AsyncRecorder implements Recorder {
     }
 
     private void drainLoop() {
+        // Rate-limit state for the background spill backfill (drain thread only,
+        // so no synchronization). Start with a full second of budget (refill timer
+        // one second in the past) so a backlog begins draining immediately.
+        double spillBudget = 0;
+        long spillRefillNanos = System.nanoTime() - 1_000_000_000L;
         try {
             while (running.get() || !queue.isEmpty() || spill.hasPending()) {
-                // Hot path first: drain the in-RAM queue non-blocking so, while
-                // a burst is live, batches keep cycling through RAM and the
-                // freed space lets producers stay off the (slower) spill path.
+                boolean didWork = false;
+
+                // 1. In-RAM queue first, for freshness: live events reach the
+                //    store promptly even while a backlog is reclaimed underneath.
                 EventRecord first = queue.poll();
                 if (first != null) {
                     if (!drainQueueBatch(first)) {
                         return; // shutdown mid-retry; batch re-queued for the flush
                     }
-                    continue;
+                    didWork = true;
                 }
-                // Queue empty: replay one spilled overflow segment (older than
-                // anything still arriving). Reclaims disk + honours the flush
-                // high-water mark. One segment in RAM at a time keeps heap flat.
+
+                // 2. Reclaim on-disk spill overflow using SPARE capacity. The old
+                //    loop only replayed when the queue was empty, so a continuously
+                //    busy server never drained the backlog and the spill grew
+                //    unbounded (#180). This replays while the queue is non-empty
+                //    too — just not while it is at the backpressure ceiling (an
+                //    active firehose: let the queue cycle and free space first) and
+                //    no faster than the configured rate cap, so reclaiming a huge
+                //    backlog never saturates the store. Shutdown drains at full
+                //    speed to save as much as possible before the deadline. One
+                //    segment in RAM at a time keeps the heap flat.
                 if (spill.hasPending()) {
-                    SpillBuffer.Spilled spilled = spill.poll();
-                    if (spilled != null) {
-                        if (!persistWithRetry(spilled.records())) {
-                            // Shutdown mid-retry: leave the segment on disk; it
-                            // replays on next startup. Don't ack (delete) it.
-                            return;
-                        }
-                        spill.ack(spilled);
-                        wakeBackpressureWaiters();
-                        continue;
+                    boolean shuttingDown = !running.get();
+                    boolean spareCapacity = shuttingDown || queueMax <= 0
+                            || queue.size() < queueMax;
+                    long rate = spillDrainRatePerSec;
+                    if (rate > 0) {
+                        long now = System.nanoTime();
+                        spillBudget = Math.min(rate,
+                                spillBudget + (now - spillRefillNanos) / 1_000_000_000.0 * rate);
+                        spillRefillNanos = now;
                     }
-                    // hasPending() but nothing polled (all-corrupt or a
-                    // counter/file skew): fall through to the blocking poll so
-                    // we throttle instead of busy-spinning.
+                    boolean withinRate = shuttingDown || rate <= 0 || spillBudget >= 1.0;
+                    if (spareCapacity && withinRate) {
+                        SpillBuffer.Spilled spilled = spill.poll();
+                        if (spilled != null) {
+                            if (!persistWithRetry(spilled.records())) {
+                                // Shutdown mid-retry: leave the segment on disk; it
+                                // replays on next startup. Don't ack (delete) it.
+                                return;
+                            }
+                            spill.ack(spilled);
+                            if (rate > 0) {
+                                spillBudget -= spilled.records().size();
+                            }
+                            wakeBackpressureWaiters();
+                            didWork = true;
+                        }
+                        // poll() == null with hasPending() (all-corrupt / counter
+                        // skew): didWork stays false, so we fall through to the
+                        // blocking poll below and throttle instead of busy-spinning.
+                    }
+                } else {
+                    // Backlog cleared: re-arm the growth warning for next time.
+                    lastSpillWarn.set(0L);
                 }
-                // Nothing in queue or spill: block briefly for new queue work
-                // rather than spin.
-                EventRecord waited = queue.poll(250, TimeUnit.MILLISECONDS);
-                if (waited != null && !drainQueueBatch(waited)) {
-                    return;
+
+                // 3. Nothing moved this cycle (queue empty, or spill paused / rate-
+                //    limited with an empty queue): block briefly for new queue work
+                //    rather than busy-spin. While parked the rate budget refills and
+                //    any ceiling backlog subsides.
+                if (!didWork) {
+                    EventRecord waited = queue.poll(250, TimeUnit.MILLISECONDS);
+                    if (waited != null && !drainQueueBatch(waited)) {
+                        return;
+                    }
                 }
             }
         } catch (InterruptedException interrupted) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
@@ -64,6 +64,7 @@ public final class SpillBuffer {
     private final AtomicLong seq = new AtomicLong();
     private final AtomicLong pendingRecords = new AtomicLong();
     private final AtomicLong pendingFiles = new AtomicLong();
+    private final AtomicLong pendingBytes = new AtomicLong();
 
     public SpillBuffer(@Nullable Path dataFolder, boolean enabled, Logger logger) {
         this.logger = logger;
@@ -94,6 +95,16 @@ public final class SpillBuffer {
         return pendingRecords.get();
     }
 
+    /** Number of overflow segments currently on disk (operator gauge). */
+    long pendingSegments() {
+        return pendingFiles.get();
+    }
+
+    /** Approximate bytes of overflow currently on disk (operator gauge). */
+    long pendingByteCount() {
+        return pendingBytes.get();
+    }
+
     /**
      * Append a batch to a new on-disk segment (fsync + atomic rename) and
      * return. Off-main producers call this instead of holding the overflow in
@@ -117,6 +128,7 @@ public final class SpillBuffer {
         Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE);
         pendingRecords.addAndGet(batch.size());
         pendingFiles.incrementAndGet();
+        pendingBytes.addAndGet(bytes.length);
     }
 
     /**
@@ -133,7 +145,7 @@ public final class SpillBuffer {
         for (Path oldest = oldestSegment(); oldest != null; oldest = oldestSegment()) {
             try {
                 byte[] bytes = Files.readAllBytes(oldest);
-                return new Spilled(oldest, EventBatchCodec.decode(bytes));
+                return new Spilled(oldest, bytes.length, EventBatchCodec.decode(bytes));
             } catch (IOException | RuntimeException ex) {
                 // A segment that won't decode would wedge the drain forever;
                 // its records are unrecoverable, so drop it and move to the next.
@@ -141,6 +153,7 @@ public final class SpillBuffer {
                         + oldest.getFileName() + " (" + ex.getMessage() + ")");
                 pendingRecords.addAndGet(-recordCountOf(oldest));
                 pendingFiles.decrementAndGet();
+                pendingBytes.addAndGet(-byteSizeOf(oldest));
                 deleteQuietly(oldest);
             }
         }
@@ -151,6 +164,7 @@ public final class SpillBuffer {
     void ack(Spilled spilled) {
         pendingRecords.addAndGet(-spilled.records().size());
         pendingFiles.decrementAndGet();
+        pendingBytes.addAndGet(-spilled.bytes());
         deleteQuietly(spilled.file());
     }
 
@@ -178,6 +192,7 @@ public final class SpillBuffer {
         long maxSeq = -1L;
         long files = 0;
         long records = 0;
+        long bytes = 0;
         for (Path p : all) {
             String name = p.getFileName().toString();
             if (name.endsWith(TMP_SUFFIX)) {
@@ -189,11 +204,13 @@ public final class SpillBuffer {
             }
             files++;
             records += recordCountOf(p);
+            bytes += byteSizeOf(p);
             maxSeq = Math.max(maxSeq, seqOf(p));
         }
         seq.set(maxSeq + 1);
         pendingFiles.set(files);
         pendingRecords.set(records);
+        pendingBytes.set(bytes);
         if (files > 0) {
             logger.info("Spyglass spill: " + records + " overflow record(s) in " + files
                     + " segment(s) left from a prior run; the drain will replay them.");
@@ -216,6 +233,14 @@ public final class SpillBuffer {
         }
     }
 
+    private static long byteSizeOf(Path p) {
+        try {
+            return Files.size(p);
+        } catch (IOException ex) {
+            return 0L;
+        }
+    }
+
     private void deleteQuietly(Path p) {
         try {
             Files.deleteIfExists(p);
@@ -224,7 +249,8 @@ public final class SpillBuffer {
         }
     }
 
-    /** A decoded segment paired with its file, so the drain can {@link #ack} it. */
-    record Spilled(Path file, List<EventRecord> records) {
+    /** A decoded segment paired with its file + on-disk byte size, so the drain
+     *  can {@link #ack} it and keep the byte gauge accurate. */
+    record Spilled(Path file, long bytes, List<EventRecord> records) {
     }
 }

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -135,6 +135,17 @@ storage {
   # it off, an over-ceiling op buffers overflow in RAM and a big enough one can
   # still OOM. Requires queue-max > 0 (no ceiling, no overflow to spill).
   spill-to-disk = true
+  # BACKGROUND SPILL DRAIN RATE, in records/sec. The drain reclaims whatever is
+  # in plugins/Spyglass/spill/ continuously, using spare capacity (live events
+  # stay fresh, and it pauses while the queue is at the ceiling during an active
+  # edit), but no faster than this — so reclaiming a large backlog never
+  # saturates the database on a live, populated server. Watch the backlog shrink
+  # with /spyglass stats. The default is gentle and safe to leave on any backend;
+  # raise it (or set 0 = unlimited) during a maintenance window to recover a big
+  # backlog faster. Spilled records are durable on disk but are not queryable or
+  # rollbackable until the drain replays them, so a persistent backlog means some
+  # recent history is not yet searchable.
+  spill-drain-rate = 20000
   # Shutdown drain deadline. On server stop the recorder keeps retrying to
   # flush any not-yet-stored events for up to this long (with backoff)
   # before giving up; whatever cannot drain in time is counted as lost and

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/StatsServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/StatsServiceTest.java
@@ -6,22 +6,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
+import net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder;
 import net.medievalrp.spyglass.plugin.pipeline.IngestStats;
 import org.bukkit.command.CommandSender;
 import org.junit.jupiter.api.Test;
 
 /**
- * #168: /spyglass stats rendering. A null {@link IngestStats} (analytics off)
- * sends one "disabled" message; an enabled stats object sends a header plus the
- * snapshot lines.
+ * #168 / #180: /spyglass stats rendering. The spill backlog line shows whenever
+ * spill is enabled (regardless of analytics); a null {@link IngestStats}
+ * (analytics off) sends one "disabled" hint; an enabled stats object sends a
+ * header plus the snapshot lines.
  */
 class StatsServiceTest {
+
+    /** Spill disabled — renderSpillBacklog sends nothing. */
+    private static Supplier<AsyncRecorder.SpillSnapshot> noSpill() {
+        return () -> new AsyncRecorder.SpillSnapshot(false, 0, 0, 0, 0);
+    }
 
     @Test
     void disabledStatsSendsASingleEnableHint() {
         CommandSender sender = mock(CommandSender.class);
-        new StatsService(null).execute(sender);
+        new StatsService(null, noSpill()).execute(sender);
         verify(sender, times(1)).sendMessage(any(Component.class));
     }
 
@@ -30,12 +38,23 @@ class StatsServiceTest {
         IngestStats stats = new IngestStats(() -> 3, () -> 42L, () -> 0L, () -> -1L);
         stats.onRecord("break");
         stats.onRecord("place");
-        StatsService service = new StatsService(stats);
+        StatsService service = new StatsService(stats, noSpill());
 
         CommandSender sender = mock(CommandSender.class);
         service.execute(sender);
 
         // Header + at least the summary line (>= 2 messages).
         verify(sender, atLeast(2)).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void spillBacklogLineShowsEvenWhenAnalyticsIsOff() {
+        // #180: a non-empty backlog must be visible without analytics enabled —
+        // the spill line plus the analytics-disabled hint = two messages.
+        Supplier<AsyncRecorder.SpillSnapshot> backlog =
+                () -> new AsyncRecorder.SpillSnapshot(true, 3, 300, 12_345, 20_000);
+        CommandSender sender = mock(CommandSender.class);
+        new StatsService(null, backlog).execute(sender);
+        verify(sender, times(2)).sendMessage(any(Component.class));
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -478,6 +478,141 @@ class AsyncRecorderTest {
         }
     }
 
+    @Test
+    @Timeout(25)
+    void spillBacklogDrainsWhileTheQueueKeepsReceivingRecords(@TempDir Path dataFolder)
+            throws Exception {
+        // #180: the old drain only replayed spill when the in-RAM queue was
+        // EMPTY, so a continuously-busy server never reclaimed the on-disk
+        // backlog and the spill grew without bound (140 GB seen in prod). With a
+        // steady stream of live records keeping the queue non-empty, the spill
+        // backlog must still drain to empty.
+        long queueMax = 1_000L;
+        int segments = 6;
+        int perSegment = 50;
+        SpillBuffer spill = new SpillBuffer(dataFolder, true, Logger.getLogger("test"));
+        // Pre-seed a backlog of spilled segments directly on disk.
+        for (int s = 0; s < segments; s++) {
+            spill.spill(sampleBatch(perSegment));
+        }
+        SlowGatedStore store = new SlowGatedStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000_000L, queueMax, store, new WalDurability(null, false, Logger.getLogger("test")),
+                spill, () -> true, Logger.getLogger("test"));
+        AtomicBoolean producing = new AtomicBoolean(true);
+        Thread producer = new Thread(() -> {
+            while (producing.get()) {
+                recorder.record(sampleRecord());
+                try {
+                    Thread.sleep(2L);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }, "live-ingest");
+        try {
+            producer.start();
+            // Let the producer fill the queue BEFORE the (slow) store is allowed to
+            // drain, so the queue is already non-empty when the drain starts
+            // looping — the busy-server condition the bug starved under. The gate
+            // also guarantees no spill segment is acked before this point.
+            Thread.sleep(200L);
+            store.open(20L); // 20 ms/save keeps the queue non-empty at poll time
+
+            // The backlog must drain to empty WHILE the producer is still feeding
+            // the queue. The old queue-empty-only logic would leave it pending.
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline && spill.hasPending()) {
+                Thread.sleep(50L);
+            }
+            assertThat(spill.hasPending())
+                    .as("spill backlog must drain even while the queue keeps receiving records")
+                    .isFalse();
+            assertThat(store.totalSaved())
+                    .as("queue records flowed too — the queue was genuinely active while the "
+                            + "backlog drained, not idle")
+                    .isGreaterThan(segments * perSegment);
+        } finally {
+            producing.set(false);
+            producer.join(2_000L);
+            recorder.shutdown(Duration.parse("3s"));
+        }
+    }
+
+    @Test
+    @Timeout(15)
+    void spillDrainRateCapPausesReplayWhenBudgetIsExhausted(@TempDir Path dataFolder)
+            throws Exception {
+        // #180: with a tiny rate cap the drain must NOT replay the whole backlog
+        // at once — it paces the backfill. A 1 rec/s cap means a 300-record
+        // backlog cannot fully drain within a short window; most of it stays on
+        // disk. (The default cap is far higher; this just proves the throttle.)
+        SpillBuffer spill = new SpillBuffer(dataFolder, true, Logger.getLogger("test"));
+        for (int s = 0; s < 6; s++) {
+            spill.spill(sampleBatch(50));
+        }
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(
+                1_000_000L, 1_000L, store, new WalDurability(null, false, Logger.getLogger("test")),
+                spill, () -> true, Logger.getLogger("test"));
+        recorder.setSpillDrainRate(1L); // 1 record/sec — extremely slow on purpose
+        try {
+            // Initial budget is one second (one segment), then the cap throttles.
+            // After a short wait, a strict cap must leave most of the backlog on disk.
+            Thread.sleep(1_500L);
+            assertThat(spill.pendingRecordCount())
+                    .as("a 1 rec/s cap must pace the backfill, not flush 300 records at once")
+                    .isGreaterThan(100L);
+        } finally {
+            recorder.setSpillDrainRate(0L); // uncap so shutdown drains it promptly
+            recorder.shutdown(Duration.parse("5s"));
+        }
+    }
+
+    /**
+     * Store whose save() blocks until {@link #open(long)} is called, then sleeps
+     * a fixed time per save — models a slow live store so the in-RAM queue stays
+     * non-empty at poll time the way a real DB round-trip keeps it (#180).
+     */
+    private static final class SlowGatedStore implements RecordStore {
+        private final CountDownLatch gate = new CountDownLatch(1);
+        private volatile long sleepMillis = 0L;
+        private final AtomicInteger saved = new AtomicInteger();
+
+        void open(long perSaveSleepMillis) {
+            this.sleepMillis = perSaveSleepMillis;
+            gate.countDown();
+        }
+
+        int totalSaved() {
+            return saved.get();
+        }
+
+        @Override
+        public void save(List<EventRecord> records) {
+            try {
+                gate.await();
+                if (sleepMillis > 0L) {
+                    Thread.sleep(sleepMillis);
+                }
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            saved.addAndGet(records.size());
+        }
+
+        @Override
+        public QueryResult query(QueryRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     /**
      * Store whose save() blocks until {@link #open()} is called — models a
      * wedged drain so the backpressure ceiling engages deterministically. No


### PR DESCRIPTION
The drain only replayed spilled overflow when the in-RAM queue was empty.
On a populated server the queue is effectively never empty (main-thread
listeners always enqueue, and a slow store round-trip lets new events
arrive during every save), so the on-disk spill was starved and grew
without bound (140 GB seen in prod). Spilled records are durable but not
queryable until replayed, so the backlog was also un-ingested history.

Interleave spill replay with the queue instead of gating it on an empty
queue: replay using spare capacity (queue below the backpressure ceiling)
at a configurable rate cap (storage.spill-drain-rate, default 20000 rec/s;
0 = unlimited) so reclaiming a large backlog never saturates the store on
a live server. Shutdown drains the spill at full speed. Surface the backlog
(segments, records, bytes, drain rate) in /spyglass stats regardless of
analytics state, and warn as it grows.

Adds a red/green regression test that the backlog drains while the queue
keeps receiving records, plus a rate-cap pacing test. Heap-flat and no-drop
guarantees from #119/#121/#122 are unchanged (one segment in RAM at a time;
segments acked only after a successful save).
