### PR TITLE
feat(storage): per-event-type retention; default retention 4w -> 26w (#181)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -226,9 +226,20 @@ public final class ClickHouseRecordStore implements RecordStore {
     private final String rollbackSelect;
     private final String rollbackReadSelect;
     private final String restoreReadSelect;
+    // Per-event-type retention (#181). Null = use the record's own expiresAt
+    // (legacy global-retention behaviour, kept for tests/ITs); set = compute the
+    // stored expires_at per event type from the policy.
+    private final RetentionPolicy retentionPolicy;
 
     public ClickHouseRecordStore(String host, int port, String database, String table,
                                  String user, String password, boolean ssl) {
+        this(host, port, database, table, user, password, ssl, null);
+    }
+
+    public ClickHouseRecordStore(String host, int port, String database, String table,
+                                 String user, String password, boolean ssl,
+                                 RetentionPolicy retentionPolicy) {
+        this.retentionPolicy = retentionPolicy;
         this.database = database;
         this.table = table;
         this.qualifiedTable = ClickHouseSchema.qualifiedTable(database, table);
@@ -341,7 +352,12 @@ public final class ClickHouseRecordStore implements RecordStore {
         writer.setValue("id", net.medievalrp.spyglass.api.util.EventIds.sequenceOf(record.id()));
         writer.setString("event", record.event());
         writer.setDateTime("occurred", toLocalDateTime(record.occurred()));
-        writer.setDateTime("expires_at", toLocalDateTime(record.expiresAt()));
+        // #181: per-event-type expiry. The ClickHouse table TTL is on expires_at,
+        // so stamping it per type makes each row expire on its type's schedule.
+        java.time.Instant expiresAt = retentionPolicy != null
+                ? retentionPolicy.expiresAt(record.occurred(), record.event())
+                : record.expiresAt();
+        writer.setDateTime("expires_at", toLocalDateTime(expiresAt));
         writer.setString("origin_kind", nullToEmpty(origin == null ? null : origin.kind()));
         writer.setValue("origin_detail", origin == null ? null : origin.detail());
         writer.setString("source_kind", nullToEmpty(source == null ? null : source.kind()));

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -118,7 +118,7 @@ public final class MariaDbRecordStore implements RecordStore {
     }
 
     private static final int DEFAULT_READ_POOL = 4;
-    private static final long DEFAULT_RETENTION_SECONDS = 28L * 24 * 3600; // 4 weeks
+    private static final long DEFAULT_RETENTION_SECONDS = 182L * 24 * 3600; // 26 weeks (~6 months)
     private static final long RETENTION_SWEEP_MINUTES = 60L;
     private static final int POST_FILTER_SCAN_CAP = 20_000;
 
@@ -140,7 +140,7 @@ public final class MariaDbRecordStore implements RecordStore {
     private final String user;
     private final String password;
     private final boolean readOnly;
-    private final long retentionSeconds;
+    private final RetentionPolicy retentionPolicy;
 
     private final Connection writeConn;
     private final Object writeLock = new Object();
@@ -196,11 +196,23 @@ public final class MariaDbRecordStore implements RecordStore {
     public MariaDbRecordStore(String host, int port, String database, String user,
                               String password, boolean ssl, boolean readOnly,
                               int readPoolSize, long retentionSeconds) {
+        this(host, port, database, user, password, ssl, readOnly, readPoolSize,
+                RetentionPolicy.uniform(retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS));
+    }
+
+    public MariaDbRecordStore(String host, int port, String database, String user,
+                              String password, boolean ssl, RetentionPolicy retentionPolicy) {
+        this(host, port, database, user, password, ssl, false, DEFAULT_READ_POOL, retentionPolicy);
+    }
+
+    public MariaDbRecordStore(String host, int port, String database, String user,
+                              String password, boolean ssl, boolean readOnly,
+                              int readPoolSize, RetentionPolicy retentionPolicy) {
         this.database = validateIdentifier(database);
         this.user = user;
         this.password = password;
         this.readOnly = readOnly;
-        this.retentionSeconds = retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS;
+        this.retentionPolicy = retentionPolicy;
         // rewriteBatchedStatements folds the drain's addBatch into one
         // multi-row INSERT (the throughput lever); sslMode=trust encrypts an
         // ssl=true connection without demanding a verified CA (operators on a
@@ -770,7 +782,7 @@ public final class MariaDbRecordStore implements RecordStore {
         }
         UUID id = EventIds.uuidOf(rs.getLong("seq"));
         Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
-        Instant expiresAt = occurred.plusSeconds(retentionSeconds);
+        Instant expiresAt = retentionPolicy.expiresAt(occurred, event);
         Origin origin = new Origin(dictValueOrNull(rs, "origin_kind"), null);
         int playerRef = rs.getInt("player");
         boolean hasPlayer = !rs.wasNull();
@@ -1158,17 +1170,50 @@ public final class MariaDbRecordStore implements RecordStore {
         }
     }
 
-    /** Drop records past the retention horizon; the TTL analogue. */
+    /**
+     * Drop records past their retention horizon; the TTL analogue. Each event
+     * type with a per-event {@code retention} override (#181) is swept at its own
+     * cutoff; everything else at the global default. With no overrides this is a
+     * single {@code DELETE ... WHERE occurred < cutoff}, identical to before.
+     */
     public long pruneExpired() {
         if (readOnly) {
             return 0L;
         }
-        long thresholdSec = (System.currentTimeMillis() / 1000L) - retentionSeconds;
+        long nowSec = System.currentTimeMillis() / 1000L;
         synchronized (writeLock) {
-            try (PreparedStatement ps = writeConn.prepareStatement(
-                    "DELETE FROM records WHERE occurred < ?")) {
-                ps.setLong(1, thresholdSec);
-                return ps.executeUpdate();
+            try {
+                long deleted = 0L;
+                List<Integer> overrideIds = new ArrayList<>();
+                for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
+                    Integer dictId = resolveDictId(override.getKey());
+                    if (dictId == null) {
+                        continue; // this event type has never been recorded yet
+                    }
+                    overrideIds.add(dictId);
+                    try (PreparedStatement ps = writeConn.prepareStatement(
+                            "DELETE FROM records WHERE event = ? AND occurred < ?")) {
+                        ps.setInt(1, dictId);
+                        ps.setLong(2, nowSec - override.getValue());
+                        deleted += ps.executeUpdate();
+                    }
+                }
+                long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
+                StringBuilder sql = new StringBuilder("DELETE FROM records WHERE occurred < ?");
+                if (!overrideIds.isEmpty()) {
+                    sql.append(" AND event NOT IN (");
+                    sql.append("?,".repeat(overrideIds.size()));
+                    sql.setLength(sql.length() - 1);
+                    sql.append(')');
+                }
+                try (PreparedStatement ps = writeConn.prepareStatement(sql.toString())) {
+                    ps.setLong(1, defaultCutoff);
+                    for (int i = 0; i < overrideIds.size(); i++) {
+                        ps.setInt(2 + i, overrideIds.get(i));
+                    }
+                    deleted += ps.executeUpdate();
+                }
+                return deleted;
             } catch (SQLException ex) {
                 throw new RuntimeException("MariaDB retention prune failed: " + ex.getMessage(), ex);
             }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -37,12 +37,16 @@ import net.medievalrp.spyglass.api.query.Sort;
 import net.medievalrp.spyglass.api.rollback.RollbackEffect;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 import org.bson.BsonArray;
+import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.UuidRepresentation;
+import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.jsr310.Jsr310CodecProvider;
@@ -77,6 +81,11 @@ public final class MongoRecordStore implements RecordStore {
     private final MongoCollection<BsonDocument> rawCollection;
     private final MongoCollection<EventRecord> polymorphicCollection;
     private final CodecRegistry codecRegistry;
+    // Per-event-type retention (#181). Null = serialize the record's own
+    // expiresAt via the typed insert (legacy global behaviour, kept for
+    // tests/ITs); set = encode + stamp expires_at per event type before insert.
+    private final RetentionPolicy retentionPolicy;
+    private final Codec<EventRecord> eventCodec;
 
     /**
      * Opens a store that performs write-side setup on startup: collection
@@ -85,7 +94,18 @@ public final class MongoRecordStore implements RecordStore {
      */
     public MongoRecordStore(String uri, String databaseName, String collectionName,
                             IndexManager indexManager) {
-        this(uri, databaseName, collectionName, indexManager, true);
+        this(uri, databaseName, collectionName, indexManager, true, null);
+    }
+
+    /** Primary-backend opener with per-event retention (#181). */
+    public MongoRecordStore(String uri, String databaseName, String collectionName,
+                            IndexManager indexManager, RetentionPolicy retentionPolicy) {
+        this(uri, databaseName, collectionName, indexManager, true, retentionPolicy);
+    }
+
+    public MongoRecordStore(String uri, String databaseName, String collectionName,
+                            IndexManager indexManager, boolean performSetup) {
+        this(uri, databaseName, collectionName, indexManager, performSetup, null);
     }
 
     /**
@@ -98,7 +118,9 @@ public final class MongoRecordStore implements RecordStore {
      *     {@code updateMany}) on startup.
      */
     public MongoRecordStore(String uri, String databaseName, String collectionName,
-                            IndexManager indexManager, boolean performSetup) {
+                            IndexManager indexManager, boolean performSetup,
+                            RetentionPolicy retentionPolicy) {
+        this.retentionPolicy = retentionPolicy;
         this.codecRegistry = CodecRegistries.fromRegistries(
                 // First, so it wins for BlockLocation over both the default
                 // registry's record support and RecordCodecProvider below — it
@@ -113,6 +135,15 @@ public final class MongoRecordStore implements RecordStore {
                         EventRecordCodec.provider(),
                         RollbackEffectCodec.provider(),
                         PojoCodecProvider.builder().automatic(true).build()));
+        // Cached for the per-event-retention write path (#181): encodes a record
+        // to BSON so we can stamp expires_at per type before insert. The UUID
+        // representation lives on the client settings, not the registry, so a
+        // raw encode would throw on the record's UUID fields - prepend a STANDARD
+        // UuidCodec so the manual encode matches what insertMany() writes.
+        this.eventCodec = CodecRegistries.fromRegistries(
+                CodecRegistries.fromCodecs(
+                        new org.bson.codecs.UuidCodec(UuidRepresentation.STANDARD)),
+                codecRegistry).get(EventRecord.class);
         MongoClientSettings settings = MongoClientSettings.builder()
                 .uuidRepresentation(UuidRepresentation.STANDARD)
                 .codecRegistry(codecRegistry)
@@ -218,7 +249,23 @@ public final class MongoRecordStore implements RecordStore {
         if (records.isEmpty()) {
             return;
         }
-        polymorphicCollection.insertMany(records);
+        if (retentionPolicy == null) {
+            polymorphicCollection.insertMany(records);
+            return;
+        }
+        // #181: per-event-type expiry. The TTL index is on expiresAt, so encode
+        // each record and overwrite that field per type before insert. Same BSON
+        // as the typed path (same codec), just a per-type expiresAt - so the
+        // chunk-bucket fields, _id mapping, and zstd compression are unchanged.
+        List<BsonDocument> docs = new ArrayList<>(records.size());
+        for (EventRecord record : records) {
+            BsonDocument doc = new BsonDocument();
+            eventCodec.encode(new BsonDocumentWriter(doc), record, EncoderContext.builder().build());
+            doc.put(RecordFields.EXPIRES_AT, new BsonDateTime(
+                    retentionPolicy.expiresAt(record.occurred(), record.event()).toEpochMilli()));
+            docs.add(doc);
+        }
+        rawCollection.insertMany(docs);
     }
 
     @Override

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicy.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicy.java
@@ -1,0 +1,82 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.time.Instant;
+import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Per-event-type retention (#181). Resolves how long a record of a given event
+ * type is kept before automatic deletion: a per-event override if one is
+ * configured under {@code events.<name>.retention}, otherwise the global
+ * {@code storage.retention} default.
+ *
+ * <p>Every {@link RecordStore} consults this when it stamps or prunes a row, so
+ * the behaviour is identical across SQLite, MariaDB, ClickHouse, and Mongo - the
+ * expiry is always {@code occurred + retentionFor(event)}.
+ *
+ * <p>"Keep forever" is expressed as {@link #NEVER_SECONDS}, a 100-year horizon.
+ * That is effectively never for a forensic log while staying inside every
+ * backend's date range, so a never-expiring type needs no per-backend TTL-skip
+ * special case - it is simply stamped with a far-future expiry that no TTL or
+ * prune sweep ever reaches.
+ */
+@ApiStatus.Internal
+public final class RetentionPolicy {
+
+    /** A type configured "never" / "0" is kept this long: ~100 years (then
+     *  clamped to {@link #MAX_EXPIRY} below, so the actual horizon is ~2105). */
+    public static final long NEVER_SECONDS = 100L * 365L * 24L * 60L * 60L;
+
+    /**
+     * Hard ceiling on any computed expiry. ClickHouse's table TTL is
+     * {@code TTL toDateTime(expires_at)}, and {@code toDateTime()} is a 32-bit
+     * DateTime capped at 2106-02-07; an expiry past that overflows and the row's
+     * insert fails. So every expiry is clamped to just under it - which also caps
+     * the keep-forever horizon uniformly across all four backends.
+     */
+    public static final Instant MAX_EXPIRY = Instant.parse("2105-01-01T00:00:00Z");
+
+    private final long defaultSeconds;
+    private final Map<String, Long> perEventSeconds;
+
+    /**
+     * @param defaultSeconds  global retention (the {@code storage.retention}
+     *                        default), in seconds; must be positive.
+     * @param perEventSeconds event-name -> retention seconds for the types that
+     *                        override the default ({@link #NEVER_SECONDS} for a
+     *                        never-expiring type). Types absent from the map
+     *                        inherit {@code defaultSeconds}.
+     */
+    public RetentionPolicy(long defaultSeconds, Map<String, Long> perEventSeconds) {
+        this.defaultSeconds = defaultSeconds;
+        this.perEventSeconds = Map.copyOf(perEventSeconds);
+    }
+
+    /** A policy with no per-event overrides - every type uses {@code seconds}. */
+    public static RetentionPolicy uniform(long seconds) {
+        return new RetentionPolicy(seconds, Map.of());
+    }
+
+    /** Retention in seconds for {@code event} - its override, or the default. */
+    public long secondsFor(String event) {
+        Long override = perEventSeconds.get(event);
+        return override != null ? override : defaultSeconds;
+    }
+
+    /** When a record of {@code event} fired at {@code occurred} expires, clamped
+     *  to {@link #MAX_EXPIRY} so a never-horizon stays inside ClickHouse's TTL range. */
+    public Instant expiresAt(Instant occurred, String event) {
+        Instant expiry = occurred.plusSeconds(secondsFor(event));
+        return expiry.isAfter(MAX_EXPIRY) ? MAX_EXPIRY : expiry;
+    }
+
+    /** The global default retention in seconds (used for the bulk prune sweep). */
+    public long defaultSeconds() {
+        return defaultSeconds;
+    }
+
+    /** The per-event overrides (event-name -> seconds); never null, may be empty. */
+    public Map<String, Long> overrides() {
+        return perEventSeconds;
+    }
+}

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -115,7 +115,7 @@ public final class SqliteRecordStore implements RecordStore {
     }
 
     private static final int DEFAULT_READ_POOL = 4;
-    private static final long DEFAULT_RETENTION_SECONDS = 28L * 24 * 3600; // 4 weeks
+    private static final long DEFAULT_RETENTION_SECONDS = 182L * 24 * 3600; // 26 weeks (~6 months)
     private static final long RETENTION_SWEEP_MINUTES = 60L;
     private static final int POST_FILTER_SCAN_CAP = 20_000;
 
@@ -133,7 +133,7 @@ public final class SqliteRecordStore implements RecordStore {
 
     private final Path dbFile;
     private final boolean readOnly;
-    private final long retentionSeconds;
+    private final RetentionPolicy retentionPolicy;
 
     private final Connection writeConn;
     private final Object writeLock = new Object();
@@ -188,9 +188,18 @@ public final class SqliteRecordStore implements RecordStore {
     }
 
     public SqliteRecordStore(Path dbFile, boolean readOnly, int readPoolSize, long retentionSeconds) {
+        this(dbFile, readOnly, readPoolSize, RetentionPolicy.uniform(
+                retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS));
+    }
+
+    public SqliteRecordStore(Path dbFile, boolean readOnly, RetentionPolicy retentionPolicy) {
+        this(dbFile, readOnly, DEFAULT_READ_POOL, retentionPolicy);
+    }
+
+    public SqliteRecordStore(Path dbFile, boolean readOnly, int readPoolSize, RetentionPolicy retentionPolicy) {
         this.dbFile = dbFile.toAbsolutePath();
         this.readOnly = readOnly;
-        this.retentionSeconds = retentionSeconds > 0 ? retentionSeconds : DEFAULT_RETENTION_SECONDS;
+        this.retentionPolicy = retentionPolicy;
         this.rollbackableEvents = rollbackableEventNames();
         this.chatEvents = EventCatalog.eventsStoredAs(ChatRecord.class);
         try {
@@ -692,7 +701,7 @@ public final class SqliteRecordStore implements RecordStore {
         }
         UUID id = EventIds.uuidOf(rs.getLong("seq"));
         Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
-        Instant expiresAt = occurred.plusSeconds(retentionSeconds);
+        Instant expiresAt = retentionPolicy.expiresAt(occurred, event);
         Origin origin = new Origin(dictValueOrNull(rs, "origin_kind"), null);
         int playerRef = rs.getInt("player");
         boolean hasPlayer = !rs.wasNull();
@@ -1044,17 +1053,53 @@ public final class SqliteRecordStore implements RecordStore {
         }
     }
 
-    /** Drop records past the retention horizon; the SQLite TTL analogue. */
+    /**
+     * Drop records past their retention horizon; the SQLite TTL analogue. Each
+     * event type with a per-event {@code retention} override (#181) is swept at
+     * its own cutoff; everything else at the global default. With no overrides
+     * this is a single {@code DELETE ... WHERE occurred < cutoff}, identical to
+     * before. The {@code event} dict id is reused, so the sweep filters on the
+     * interned event column directly - no extra schema.
+     */
     public long pruneExpired() {
         if (readOnly) {
             return 0L;
         }
-        long thresholdSec = (System.currentTimeMillis() / 1000L) - retentionSeconds;
+        long nowSec = System.currentTimeMillis() / 1000L;
         synchronized (writeLock) {
-            try (PreparedStatement ps = writeConn.prepareStatement(
-                    "DELETE FROM records WHERE occurred < ?")) {
-                ps.setLong(1, thresholdSec);
-                return ps.executeUpdate();
+            try {
+                long deleted = 0L;
+                List<Integer> overrideIds = new ArrayList<>();
+                for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
+                    Integer dictId = resolveDictId(override.getKey());
+                    if (dictId == null) {
+                        continue; // this event type has never been recorded yet
+                    }
+                    overrideIds.add(dictId);
+                    try (PreparedStatement ps = writeConn.prepareStatement(
+                            "DELETE FROM records WHERE event = ? AND occurred < ?")) {
+                        ps.setInt(1, dictId);
+                        ps.setLong(2, nowSec - override.getValue());
+                        deleted += ps.executeUpdate();
+                    }
+                }
+                // Everything without an override: the global default cutoff.
+                long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
+                StringBuilder sql = new StringBuilder("DELETE FROM records WHERE occurred < ?");
+                if (!overrideIds.isEmpty()) {
+                    sql.append(" AND event NOT IN (");
+                    sql.append("?,".repeat(overrideIds.size()));
+                    sql.setLength(sql.length() - 1);
+                    sql.append(')');
+                }
+                try (PreparedStatement ps = writeConn.prepareStatement(sql.toString())) {
+                    ps.setLong(1, defaultCutoff);
+                    for (int i = 0; i < overrideIds.size(); i++) {
+                        ps.setInt(2 + i, overrideIds.get(i));
+                    }
+                    deleted += ps.executeUpdate();
+                }
+                return deleted;
             } catch (SQLException ex) {
                 throw new RuntimeException("SQLite retention prune failed: " + ex.getMessage(), ex);
             }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -94,6 +94,59 @@ class ClickHouseRecordStoreIT {
     }
 
     @Test
+    void perEventTypeRetentionStampsExpiresAtPerType() throws Exception {
+        // #181: ClickHouse's TTL is on expires_at, so per-event retention is the
+        // stored expires_at per type. Write break (100s) + say (never) and read
+        // the stored expiry back - this is the prod backend's per-type behaviour.
+        RetentionPolicy policy = new RetentionPolicy(3600L, java.util.Map.of(
+                "break", 100L, "say", RetentionPolicy.NEVER_SECONDS));
+        ClickHouseRecordStore policyStore = new ClickHouseRecordStore(
+                container.getHost(), container.getMappedPort(8123), "spyglass_it",
+                "event_records_it", container.getUsername(), container.getPassword(), false, policy);
+        try {
+            // occurred must be current: break's occurred+100s expiry has to be in
+            // the future or ClickHouse's TTL drops the already-expired row.
+            Instant now = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
+            BlockLocation loc = new BlockLocation(WORLD, "world", 91001, 64, 91001);
+            Origin origin = Origin.player();
+            Source source = Source.player(ALICE, "Alice");
+            BlockSnapshot stone = new BlockSnapshot(org.bukkit.Material.STONE, "minecraft:stone",
+                    List.of(), List.of(), List.of(), List.of(), null);
+            BlockSnapshot air = new BlockSnapshot(org.bukkit.Material.AIR, "minecraft:air",
+                    List.of(), List.of(), List.of(), List.of(), null);
+            policyStore.save(List.of(
+                    new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "STONE", stone, air),
+                    new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "Alice", "hi", List.of(), java.util.Map.of())));
+            flushAsyncInserts();
+
+            // Read back through the field store (same table); it reconstructs
+            // expiresAt from the stored expires_at column - so this proves the
+            // per-type value policyStore wrote actually landed.
+            QueryResult res = store.query(new QueryRequest(
+                    List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
+                    Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
+            assertThat(res.records())
+                    .as("records returned (events seen: "
+                            + res.records().stream().map(EventRecord::event).toList() + ")")
+                    .hasSize(2);
+            EventRecord brk = res.records().stream()
+                    .filter(r -> r.event().equals("break")).findFirst().orElseThrow();
+            EventRecord say = res.records().stream()
+                    .filter(r -> r.event().equals("say")).findFirst().orElseThrow();
+            assertThat(brk.expiresAt())
+                    .as("break stored expires_at = occurred + its 100s retention")
+                    .isEqualTo(now.plusSeconds(100L));
+            assertThat(say.expiresAt())
+                    .as("say stored expires_at = the clamped never ceiling (under CH's TTL range)")
+                    .isEqualTo(RetentionPolicy.MAX_EXPIRY);
+        } finally {
+            policyStore.close();
+        }
+    }
+
+    @Test
     void savesAndQueriesAllRecordTypes() {
         Instant now = Instant.now().minusSeconds(60);
         BlockLocation location = new BlockLocation(WORLD, "world", 10, 64, 20);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStoreIT.java
@@ -167,6 +167,35 @@ class MariaDbRecordStoreIT {
                 EnumSet.noneOf(Flag.class), false);
     }
 
+    @Test
+    void perEventRetentionPrunesEachTypeAtItsOwnHorizon() throws Exception {
+        // #181: break expires after 100s, say is kept forever, deposit inherits
+        // the 3600s default - the per-event prune sweep on the real MariaDB.
+        store.close();
+        RetentionPolicy policy = new RetentionPolicy(RETENTION, java.util.Map.of(
+                "break", 100L, "say", RetentionPolicy.NEVER_SECONDS));
+        store = new MariaDbRecordStore(host, port, db, user, pw, false, policy);
+
+        BlockBreakRecord oldBreak = breakAt(UUID.randomUUID(), "Old", 1, 500,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        BlockBreakRecord recentBreak = breakAt(UUID.randomUUID(), "New", 2, 50,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        ChatRecord say = chat("kept-forever");          // never -> survives
+        ContainerDepositRecord deposit = deposit(500);   // 500s < 3600 default -> survives
+        store.save(List.of(oldBreak, recentBreak, say, deposit));
+        assertThat(rawCount("records")).isEqualTo(4L);
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned)
+                .as("only the 500s-old break exceeds its 100s per-event retention")
+                .isEqualTo(1L);
+        List<UUID> surviving = store.query(request(List.of())).records().stream()
+                .map(EventRecord::id).toList();
+        assertThat(surviving)
+                .doesNotContain(oldBreak.id())
+                .contains(recentBreak.id(), say.id(), deposit.id());
+    }
+
     private byte[] rawPayload(long seq) throws SQLException {
         try (Connection conn = direct();
              var ps = conn.prepareStatement("SELECT payload FROM records WHERE seq = ?")) {

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -80,6 +80,52 @@ class MongoRecordStoreIT {
     }
 
     @Test
+    void perEventTypeRetentionStampsExpiresAtPerType() {
+        // #181: Mongo's TTL index is on expiresAt, so per-event retention is the
+        // stored expiresAt per type. break (100s) + say (never), read back raw.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of(
+                "break", 100L, "say", RetentionPolicy.NEVER_SECONDS));
+        MongoRecordStore policyStore = new MongoRecordStore(
+                container.getReplicaSetUrl(), "IT", "EventRecords", new IndexManager(), policy);
+        try {
+            Instant now = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
+            Origin origin = Origin.player();
+            Source source = Source.player(ALICE, "Alice");
+            BlockSnapshot stone = new BlockSnapshot(org.bukkit.Material.STONE, "minecraft:stone",
+                    List.of(), List.of(), List.of(), List.of(), null);
+            BlockSnapshot air = new BlockSnapshot(org.bukkit.Material.AIR, "minecraft:air",
+                    List.of(), List.of(), List.of(), List.of(), null);
+            BlockLocation loc = new BlockLocation(WORLD, "world", 92001, 64, 92001);
+            // Clean slate so the typed query below returns only these two.
+            policyStore.database().getCollection("EventRecords", org.bson.BsonDocument.class)
+                    .deleteMany(new org.bson.BsonDocument());
+            policyStore.save(List.of(
+                    new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "STONE", stone, air),
+                    new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "Alice", "hi", List.of(), Map.of())));
+
+            // Read back through the store's typed query; expiresAt is the stored
+            // per-type value the encode-and-patch write produced.
+            QueryResult res = policyStore.query(new QueryRequest(
+                    List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
+                    Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
+            EventRecord brk = res.records().stream()
+                    .filter(r -> r.event().equals("break")).findFirst().orElseThrow();
+            EventRecord say = res.records().stream()
+                    .filter(r -> r.event().equals("say")).findFirst().orElseThrow();
+            assertThat(brk.expiresAt())
+                    .as("break stored expiresAt = occurred + its 100s retention")
+                    .isEqualTo(now.plusSeconds(100L));
+            assertThat(say.expiresAt())
+                    .as("say stored expiresAt = the clamped never ceiling")
+                    .isEqualTo(RetentionPolicy.MAX_EXPIRY);
+        } finally {
+            policyStore.close();
+        }
+    }
+
+    @Test
     void savesAndQueriesAllRecordTypes() {
         Instant now = Instant.parse("2026-04-23T12:00:00Z");
         BlockLocation location = new BlockLocation(WORLD, "world", 10, 64, 20);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicyTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicyTest.java
@@ -1,0 +1,53 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** #181: per-event retention resolution and the keep-forever horizon. */
+class RetentionPolicyTest {
+
+    private static final Instant T = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void overrideWinsAndOthersInheritTheDefault() {
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        assertThat(policy.secondsFor("break")).isEqualTo(100L);
+        assertThat(policy.secondsFor("place")).isEqualTo(3600L);
+        assertThat(policy.defaultSeconds()).isEqualTo(3600L);
+    }
+
+    @Test
+    void expiresAtIsOccurredPlusTheTypeRetention() {
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("say", 60L));
+        assertThat(policy.expiresAt(T, "say")).isEqualTo(T.plusSeconds(60L));
+        assertThat(policy.expiresAt(T, "break")).isEqualTo(T.plusSeconds(3600L));
+    }
+
+    @Test
+    void neverIsClampedToTheCeilingUnderClickHousesTtlRange() {
+        RetentionPolicy policy = new RetentionPolicy(
+                3600L, Map.of("command", RetentionPolicy.NEVER_SECONDS));
+        Instant expiry = policy.expiresAt(T, "command");
+        // The never horizon is clamped to MAX_EXPIRY, which stays under
+        // ClickHouse's toDateTime() ceiling of 2106-02-07.
+        assertThat(expiry).isEqualTo(RetentionPolicy.MAX_EXPIRY);
+        assertThat(expiry).isBefore(Instant.parse("2106-02-07T00:00:00Z"));
+    }
+
+    @Test
+    void normalRetentionIsNotClamped() {
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("say", 60L));
+        assertThat(policy.expiresAt(T, "say")).isEqualTo(T.plusSeconds(60L));
+    }
+
+    @Test
+    void uniformHasNoOverrides() {
+        RetentionPolicy policy = RetentionPolicy.uniform(42L);
+        assertThat(policy.overrides()).isEmpty();
+        assertThat(policy.secondsFor("anything")).isEqualTo(42L);
+        assertThat(policy.defaultSeconds()).isEqualTo(42L);
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -480,6 +480,60 @@ class SqliteRecordStoreTest {
         assertThat(store.query(request(List.of())).records()).containsExactly(fresh);
     }
 
+    @Test
+    void perEventRetentionPrunesEachTypeAtItsOwnHorizon() throws SQLException {
+        // #181: break expires after 100s, say is kept forever, everything else
+        // (deposit) inherits the 3600s default. A 500s-old row of each type:
+        // only the break is past its horizon.
+        store.close();
+        RetentionPolicy policy = new RetentionPolicy(RETENTION, Map.of(
+                "break", 100L, "say", RetentionPolicy.NEVER_SECONDS));
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"), false, policy);
+
+        Instant old = BASE.minusSeconds(500);
+        BlockBreakRecord oldBreak = breakAt(UUID.randomUUID(), "Old", 1, 500,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        BlockBreakRecord recentBreak = breakAt(UUID.randomUUID(), "New", 2, 50,
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        ChatRecord oldSay = new ChatRecord(EventIds.newId(), "say", old, old.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Dan"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv", null,
+                "hello", List.of(), Map.of());
+        ContainerDepositRecord oldDeposit = deposit(500);
+        store.save(List.of(oldBreak, recentBreak, oldSay, oldDeposit));
+        assertThat(rawCount("records")).isEqualTo(4L);
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned)
+                .as("only the 500s-old break exceeds its 100s per-event retention")
+                .isEqualTo(1L);
+
+        List<UUID> surviving = store.query(request(List.of())).records().stream()
+                .map(EventRecord::id).toList();
+        assertThat(surviving)
+                .as("break past its 100s horizon is pruned; recent break, never-say, "
+                        + "and default-deposit survive")
+                .doesNotContain(oldBreak.id())
+                .contains(recentBreak.id(), oldSay.id(), oldDeposit.id());
+
+        // Column-stored block events reconstruct their expiry per type on read.
+        EventRecord readBreak = store.query(request(List.of())).records().stream()
+                .filter(r -> r.id().equals(recentBreak.id())).findFirst().orElseThrow();
+        assertThat(readBreak.expiresAt())
+                .as("a column-stored break reconstructs expiry as occurred + its 100s retention")
+                .isEqualTo(recentBreak.occurred().plusSeconds(100L));
+        // Blob-stored events (chat) carry the write-time expiry inside the blob,
+        // so SQLite reads that back rather than the per-type horizon. Deletion is
+        // still per-type (the never-say survived the prune above); only the
+        // displayed expiresAt differs. ClickHouse/Mongo store expires_at per type
+        // and have no such gap.
+        EventRecord readSay = store.query(request(List.of())).records().stream()
+                .filter(r -> r.id().equals(oldSay.id())).findFirst().orElseThrow();
+        assertThat(readSay.expiresAt())
+                .as("blob-stored say keeps its write-time expiry on read (prune still per-type)")
+                .isEqualTo(old.plusSeconds(3600));
+    }
+
     private static final class CapturingSink implements RecordStore.RollbackEffectSink {
         record Block(UUID world, int x, int y, int z, String data) {
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -198,12 +198,16 @@ public final class SpyglassPlugin extends JavaPlugin {
             return;
         }
 
+        // Per-event-type retention (#181): global storage.retention as the
+        // default, with per-event overrides. Drives every backend's expiry.
+        net.medievalrp.spyglass.plugin.storage.RetentionPolicy retentionPolicy =
+                config.retentionPolicy();
         try {
             switch (config.database().backend()) {
                 case MONGO -> {
                     SpyglassConfig.Database db = config.database();
                     MongoRecordStore mongoStore = new MongoRecordStore(
-                            db.uri(), db.name(), db.collection(), new IndexManager());
+                            db.uri(), db.name(), db.collection(), new IndexManager(), retentionPolicy);
                     recordStore = mongoStore;
                     undoStack = new MongoUndoStack(
                             mongoStore.database(), mongoStore.codecRegistry());
@@ -216,7 +220,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                     SpyglassConfig.ClickHouse ch = config.database().clickhouse();
                     ClickHouseRecordStore chStore = new ClickHouseRecordStore(
                             ch.host(), ch.port(), ch.database(), ch.table(),
-                            ch.user(), ch.password(), ch.ssl());
+                            ch.user(), ch.password(), ch.ssl(), retentionPolicy);
                     recordStore = chStore;
                     undoStack = new ClickHouseUndoStack(
                             chStore.client(), ch.database());
@@ -237,7 +241,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                     // expiry on column-stored rows (which don't carry an
                     // expires_at column).
                     SqliteRecordStore sqliteStore = new SqliteRecordStore(
-                            dbPath, false, config.storage().retention().seconds());
+                            dbPath, false, retentionPolicy);
                     recordStore = sqliteStore;
                     undoStack = new SqliteUndoStack(sqliteStore);
                     toolStateStore = new SqliteToolStateStore(sqliteStore);
@@ -252,7 +256,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                     MariaDbRecordStore mariaStore = new MariaDbRecordStore(
                             maria.host(), maria.port(), maria.database(),
                             maria.user(), maria.password(), maria.ssl(),
-                            config.storage().retention().seconds());
+                            retentionPolicy);
                     recordStore = mariaStore;
                     undoStack = new MariaDbUndoStack(mariaStore);
                     toolStateStore = new MariaDbToolStateStore(mariaStore);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -60,7 +60,9 @@ public record SpyglassConfig(
                 String.valueOf(key),
                 new EventSettings(
                         value.node("enabled").getBoolean(true),
-                        value.node("past-tense").getString(String.valueOf(key)))));
+                        value.node("past-tense").getString(String.valueOf(key)),
+                        parseEventRetention(value.node("retention").getString(null),
+                                String.valueOf(key), plugin.getLogger()))));
 
         java.util.List<String> commandRedact = parseCommandRedact(root);
 
@@ -97,7 +99,7 @@ public record SpyglassConfig(
                                 root.node("database", "mariadb", "password").getString(""),
                                 root.node("database", "mariadb", "ssl").getBoolean(false))),
                 new Storage(
-                        Duration.parse(root.node("storage", "retention").getString("4w")),
+                        Duration.parse(root.node("storage", "retention").getString("26w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
                         root.node("storage", "queue-max").getInt(500_000),
                         root.node("storage", "spill-to-disk").getBoolean(true),
@@ -184,7 +186,7 @@ public record SpyglassConfig(
     }
 
     public boolean enabled(String eventName) {
-        return events.getOrDefault(eventName, new EventSettings(false, eventName)).enabled();
+        return events.getOrDefault(eventName, new EventSettings(false, eventName, null)).enabled();
     }
 
     public String pastTense(String eventName) {
@@ -360,6 +362,48 @@ public record SpyglassConfig(
         WAL_BATCHED
     }
 
+    /**
+     * Parse a per-event {@code events.<name>.retention} value (#181) into seconds.
+     * {@code null}/blank -> inherit the global default; {@code "0"}/{@code "never"}/
+     * {@code "forever"}/{@code "off"} -> keep forever; otherwise a duration like
+     * {@code "12w"}. An unparseable value warns and falls back to the global default.
+     */
+    static Long parseEventRetention(String raw, String event, java.util.logging.Logger logger) {
+        if (raw == null) {
+            return null; // inherit storage.retention
+        }
+        String v = raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if (v.isEmpty()) {
+            return null;
+        }
+        if (v.equals("0") || v.equals("never") || v.equals("forever") || v.equals("off")) {
+            return net.medievalrp.spyglass.plugin.storage.RetentionPolicy.NEVER_SECONDS;
+        }
+        try {
+            return Duration.parse(raw).seconds();
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass: invalid retention \"" + raw + "\" for event '"
+                    + event + "'; inheriting the global storage.retention. (" + ex.getMessage() + ")");
+            return null;
+        }
+    }
+
+    /**
+     * Per-event retention policy (#181): the global {@code storage.retention} as
+     * the default, with overrides for every event that set its own
+     * {@code retention}. Consumed by the active {@code RecordStore}.
+     */
+    public net.medievalrp.spyglass.plugin.storage.RetentionPolicy retentionPolicy() {
+        Map<String, Long> overrides = new LinkedHashMap<>();
+        events.forEach((name, settings) -> {
+            if (settings.retentionSeconds() != null) {
+                overrides.put(name, settings.retentionSeconds());
+            }
+        });
+        return new net.medievalrp.spyglass.plugin.storage.RetentionPolicy(
+                storage.retention().seconds(), overrides);
+    }
+
     private static Durability parseDurability(String raw) {
         String key = raw == null ? "" : raw.trim().toLowerCase(java.util.Locale.ROOT).replace('-', '_');
         return switch (key) {
@@ -378,7 +422,14 @@ public record SpyglassConfig(
                          long rollbackTickBudgetMs) {
     }
 
-    public record EventSettings(boolean enabled, String pastTense) {
+    /**
+     * @param retentionSeconds per-event retention override in seconds (#181), or
+     *                         {@code null} to inherit the global
+     *                         {@code storage.retention}. {@link
+     *                         net.medievalrp.spyglass.plugin.storage.RetentionPolicy#NEVER_SECONDS}
+     *                         marks a "keep forever" type.
+     */
+    public record EventSettings(boolean enabled, String pastTense, Long retentionSeconds) {
     }
 
     public record Tool(Material material) {

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -90,10 +90,11 @@ storage {
   durability = "ram"
   # How long recorded events are kept before automatic deletion. Enforced
   # as a store-level TTL (ClickHouse and Mongo both prune rows older than
-  # this), so it bounds disk use and keeps searches fast. "4w" = four
-  # weeks. Shorter = less disk and faster scans but a shorter rollback /
-  # audit window; longer = more history at the cost of disk.
-  retention = "4w"
+  # this), so it bounds disk use and keeps searches fast. "26w" = 26 weeks
+  # (about six months). Shorter = less disk and faster scans but a shorter
+  # rollback / audit window; longer = more history at the cost of disk. Units
+  # are s/m/h/d/w; override per event under events.<name>.retention below.
+  retention = "26w"
   # How the per-block rollback audit trail is stored (#22).
   #   "synthesized" (default) — one rollback-op record per operation;
   #       searches compute the per-block rolled-place/rolled-break
@@ -267,6 +268,18 @@ events {
   # don't audit (decay, ignite, grow, form) noticeably cuts store size and
   # ingest load; block edits (break / place) are the rollback bread and
   # butter, so leave those on.
+  #
+  # retention (optional, per event): override how long THIS event type is kept
+  # before automatic deletion, instead of the global storage.retention above.
+  # Same syntax ("12w", "3d", "1w"); "0" / "never" keeps it effectively forever.
+  # Omit it to inherit the global default. Lets you keep block history long
+  # while pruning high-volume, low-value chat/command spam fast, e.g.
+  #   say     = { enabled = true, past-tense = "said", retention = "3d" }
+  #   command = { enabled = true, past-tense = "ran",  retention = "1w" }
+  # Note: a record's expiry is fixed when it is written, so changing a type's
+  # retention applies to NEW records; existing rows keep the expiry they were
+  # stamped with (on ClickHouse/Mongo - the SQL backends re-evaluate on each
+  # prune sweep).
   break = { enabled = true, past-tense = "broke" }
   place = { enabled = true, past-tense = "placed" }
   deposit = { enabled = true, past-tense = "deposited" }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -10,6 +10,37 @@ import org.spongepowered.configurate.serialize.SerializationException;
 
 class SpyglassConfigTest {
 
+    private static final java.util.logging.Logger LOG =
+            java.util.logging.Logger.getLogger("test");
+
+    @Test
+    void absentPerEventRetentionInheritsTheGlobal() {
+        assertThat(SpyglassConfig.parseEventRetention(null, "break", LOG)).isNull();
+        assertThat(SpyglassConfig.parseEventRetention("", "break", LOG)).isNull();
+    }
+
+    @Test
+    void perEventRetentionParsesDurations() {
+        assertThat(SpyglassConfig.parseEventRetention("3d", "say", LOG))
+                .isEqualTo(3L * 24 * 60 * 60);
+        assertThat(SpyglassConfig.parseEventRetention("12w", "break", LOG))
+                .isEqualTo(12L * 7 * 24 * 60 * 60);
+    }
+
+    @Test
+    void keepForeverKeywordsMapToNever() {
+        Long never = net.medievalrp.spyglass.plugin.storage.RetentionPolicy.NEVER_SECONDS;
+        assertThat(SpyglassConfig.parseEventRetention("0", "command", LOG)).isEqualTo(never);
+        assertThat(SpyglassConfig.parseEventRetention("never", "command", LOG)).isEqualTo(never);
+        assertThat(SpyglassConfig.parseEventRetention("forever", "command", LOG)).isEqualTo(never);
+    }
+
+    @Test
+    void invalidPerEventRetentionFallsBackToTheGlobal() {
+        // Unparseable -> warn + null (inherit), never a crash.
+        assertThat(SpyglassConfig.parseEventRetention("banana", "say", LOG)).isNull();
+    }
+
     @Test
     void absentRedactKeyFallsBackToDefaultAuthSet() throws SerializationException {
         BasicConfigurationNode root = BasicConfigurationNode.root();


### PR DESCRIPTION
Add an optional `retention` per events.<name> block, overriding the global
storage.retention for that event type; omit to inherit, "0"/"never" to keep
forever. Also raise the default storage.retention from 4w to 26w (~6 months) -
per-event retention inherits this default when an event sets none.

A RetentionPolicy (global default + per-event overrides) drives expiry on every
backend:

- ClickHouse / Mongo stamp expires_at per type at write; the TTL index / column
  TTL already expire each row on its own schedule.
- SQLite / MariaDB sweep each overridden type at its own cutoff and the rest at
  the default, using the interned event column - no schema change.

Keep-forever is clamped to RetentionPolicy.MAX_EXPIRY (2105-01-01), which stays
under ClickHouse's TTL ceiling: its TTL is `toDateTime(expires_at)` and
toDateTime() is a 32-bit DateTime capped at 2106-02-07, so an unclamped 100-year
horizon overflowed and the row's insert failed. Expiry is fixed at write time on
ClickHouse/Mongo; the SQL backends re-evaluate per prune sweep.

Verified live on all four backends (Docker): SQLite per-event prune +
reconstruction; MariaDB per-event prune; ClickHouse + Mongo per-type expires_at
stamping (Testcontainers ITs). Plus RetentionPolicy resolution / never-clamp and
config parsing of durations / never / invalid-fallback units. The ITs caught two
real bugs now fixed: the ClickHouse TTL overflow above, and the Mongo per-event
encode missing the UUID representation (every record's UUID fields threw) - fixed
by prepending a STANDARD UuidCodec to the manual-encode registry.

Known: SQLite/MariaDB blob-stored events (chat/command) show the write-time
expiry on read; deletion is still per-type via the prune. ClickHouse/Mongo store
expires_at per type and have no such gap.
