### PR TITLE
Fix config loading when event retention is omitted

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.SpyglassLimits;
@@ -193,7 +194,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         try {
             config = SpyglassConfig.load(this);
         } catch (Exception ex) {
-            getLogger().severe("Failed to load config: " + ex.getMessage());
+            getLogger().log(Level.SEVERE, "Failed to load config. Disabling the plugin.", ex);
             setEnabled(false);
             return;
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -61,7 +61,7 @@ public record SpyglassConfig(
                 new EventSettings(
                         value.node("enabled").getBoolean(true),
                         value.node("past-tense").getString(String.valueOf(key)),
-                        parseEventRetention(value.node("retention").getString(null),
+                        parseEventRetention(value.node("retention").getString(),
                                 String.valueOf(key), plugin.getLogger()))));
 
         java.util.List<String> commandRedact = parseCommandRedact(root);


### PR DESCRIPTION
`ConfigurationNode#getString(String)` does not accept `null` values. Using `getString(null)` caused a NPE when loading the config, preventing the plugin from enabling. I changed the call to `getString()`, which correctly returns null for missing retention entries and preserves the intended behavior.

Also improves config load error logging by logging the full exception instead of omitting the stacktrace, making startup exceptions easier to diagnose.
