### PR TITLE
chore(release): 1.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.5
+version=1.0.6
 group=net.medievalrp
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -61,8 +61,7 @@ public record SpyglassConfig(
                 new EventSettings(
                         value.node("enabled").getBoolean(true),
                         value.node("past-tense").getString(String.valueOf(key)),
-                        parseEventRetention(value.node("retention").getString(),
-                                String.valueOf(key), plugin.getLogger()))));
+                        readEventRetention(value, String.valueOf(key), plugin.getLogger()))));
 
         java.util.List<String> commandRedact = parseCommandRedact(root);
 
@@ -360,6 +359,24 @@ public record SpyglassConfig(
          * audit logs.
          */
         WAL_BATCHED
+    }
+
+    /**
+     * Read an event node's {@code retention} value and parse it (#181, #185).
+     *
+     * <p>The value is fetched with the no-arg {@link ConfigurationNode#getString()}.
+     * Configurate's {@code getString(String)} overload runs {@code requireNonNull}
+     * on the supplied default, so {@code getString(null)} threw a
+     * {@code NullPointerException} ("Failed to load config: def") on every config
+     * whose events omit {@code retention} - which is the bundled default for all of
+     * them, so 1.0.5 failed to enable everywhere. The nullable read returns
+     * {@code null} for a missing key, which {@link #parseEventRetention} treats as
+     * inherit-the-global. Kept package-visible so the absent-key path is unit-tested
+     * without standing up a full plugin.
+     */
+    static Long readEventRetention(ConfigurationNode eventNode, String event,
+            java.util.logging.Logger logger) {
+        return parseEventRetention(eventNode.node("retention").getString(), event, logger);
     }
 
     /**

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -41,6 +41,26 @@ class SpyglassConfigTest {
         assertThat(SpyglassConfig.parseEventRetention("banana", "say", LOG)).isNull();
     }
 
+    // #185: 1.0.5 read events.<name>.retention with getString(null), which NPEs in
+    // Configurate ("Failed to load config: def") because no bundled event sets the
+    // key. parseEventRetention(null, ...) above can't catch that - it's the read,
+    // not the parse, that threw. These drive the real read path over a live node, so
+    // a revert to the throwing overload fails here instead of only on a live server.
+    @Test
+    void eventNodeWithoutRetentionReadsAsInheritNotACrash() {
+        BasicConfigurationNode event = BasicConfigurationNode.root();
+        // 'retention' deliberately absent - the default for every bundled event.
+        assertThat(SpyglassConfig.readEventRetention(event, "break", LOG)).isNull();
+    }
+
+    @Test
+    void eventNodeWithRetentionReadsTheOverride() throws SerializationException {
+        BasicConfigurationNode event = BasicConfigurationNode.root();
+        event.node("retention").set("3d");
+        assertThat(SpyglassConfig.readEventRetention(event, "say", LOG))
+                .isEqualTo(3L * 24 * 60 * 60);
+    }
+
     @Test
     void absentRedactKeyFallsBackToDefaultAuthSet() throws SerializationException {
         BasicConfigurationNode root = BasicConfigurationNode.root();


### PR DESCRIPTION
Cuts **1.0.6** to ship the #184 config-load fix (already on main as 4c17b69) with a regression guard around it.

- `test(config)`: route the per-event retention read through a package-visible `readEventRetention()` and cover the absent-key node path. The prior `absentPerEventRetention` test fed `null` straight into `parseEventRetention`, mocking out the exact `getString(null)` line that NPE'd ("Failed to load config: def") - so 1.0.5 shipped the crash with green tests. Verified the new test fails if the throwing overload is reintroduced.
- `chore(release)`: 1.0.5 -> 1.0.6. Push to main triggers the release workflow (builds + publishes the three jars).

Closes #185 (already auto-closed by #184; this is the released fix).