### PR TITLE
perf(listener): serialize entity-death drops off the main thread (#188)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -404,7 +404,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new ItemPickupListener(recorder, support, deferredSerializer),
                 new CreativeCloneListener(recorder, support),
                 new TeleportListener(recorder, support),
-                new EntityDeathListener(recorder, support, enabledEvents),
+                new EntityDeathListener(recorder, support, enabledEvents, deferredSerializer),
                 new EntityDamageListener(recorder, support),
                 new EntityMountListener(recorder, support),
                 new EntityDismountListener(recorder, support),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/entity/EntityDeathListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/entity/EntityDeathListener.java
@@ -2,6 +2,7 @@ package net.medievalrp.spyglass.plugin.listener.entity;
 
 import java.util.Base64;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EntityHitRecord;
 import net.medievalrp.spyglass.api.event.ItemDropRecord;
@@ -16,6 +17,7 @@ import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.ItemSerialization;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -51,11 +53,16 @@ public final class EntityDeathListener implements RecordingListener {
     // granularity, so the independent death / kill / mob-kill toggles must be
     // honoured here. Live, thread-safe view of the enabled set.
     private final Set<String> enabledEvents;
+    // Off-main serialization for the per-drop item projection (#188); the
+    // shared DeferredSerializer, same stage as ItemPickupListener (#97).
+    private final Executor serializer;
 
-    public EntityDeathListener(Recorder recorder, RecordingSupport support, Set<String> enabledEvents) {
+    public EntityDeathListener(Recorder recorder, RecordingSupport support,
+                               Set<String> enabledEvents, Executor serializer) {
         this.recorder = recorder;
         this.support = support;
         this.enabledEvents = enabledEvents;
+        this.serializer = serializer;
     }
 
     @Override
@@ -159,12 +166,30 @@ public final class EntityDeathListener implements RecordingListener {
             return;
         }
         for (ItemStack drop : event.getDrops()) {
-            StoredItem stored = ItemSerialization.storedItemProjection(0, drop);
-            if (stored == null) {
+            if (drop == null || drop.getType() == Material.AIR) {
                 continue;
             }
+            // A single death can spill a whole inventory, so the item
+            // projection (getItemMeta + Adventure text + custom-data render)
+            // scales with drop count per tick. Mirror the pickup path (#97):
+            // the only main-thread work is a cheap clone + type/amount capture
+            // plus the RecordContext, which stamps occurred + the time-ordered
+            // v7 id at event time; the heavy build runs off-thread (#188). The
+            // drop is about to be spawned as an item entity, so this
+            // independent clone is safe to serialize off the main thread, and
+            // ItemDropRecord is forensic-only (not Rollbackable), so deferring
+            // it has no interaction with the rollback flush contract.
+            ItemStack snapshot = drop.clone();
+            String target = drop.getType().name();
+            int amount = drop.getAmount();
             RecordContext dropCtx = support.context(deathOrigin, victimSource, location);
-            recorder.record(ItemDropRecord.of(dropCtx, drop.getType().name(), drop.getAmount(), stored));
+            serializer.execute(() -> {
+                StoredItem stored = ItemSerialization.storedItemProjection(0, snapshot);
+                if (stored == null) {
+                    return;
+                }
+                recorder.record(ItemDropRecord.of(dropCtx, target, amount, stored));
+            });
         }
     }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/entity/EntityDeathListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/entity/EntityDeathListenerTest.java
@@ -2,11 +2,16 @@ package net.medievalrp.spyglass.plugin.listener.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EntityHitRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
@@ -37,6 +42,10 @@ class EntityDeathListenerTest {
     private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
 
     private static final Set<String> ALL = Set.of("death", "drop", "kill", "mob-kill");
+    // Same-thread serializer: the inline tests below assert on records
+    // synchronously, so the deferred drop projection (#188) runs immediately.
+    // The deferral-specific tests use a capturing executor instead.
+    private static final Executor DIRECT = Runnable::run;
 
     private CapturingRecorder recorder;
     private RecordingSupport support;
@@ -49,7 +58,7 @@ class EntityDeathListenerTest {
 
     @Test
     void declaresAllDeathFamilyEvents() {
-        EntityDeathListener listener = new EntityDeathListener(recorder, support, ALL);
+        EntityDeathListener listener = new EntityDeathListener(recorder, support, ALL, DIRECT);
         assertThat(listener.events()).isEqualTo(Set.of("death", "drop", "kill", "mob-kill"));
     }
 
@@ -61,7 +70,7 @@ class EntityDeathListenerTest {
         stubDamageByEntity(zombie, alice, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 6.0);
         EntityDeathEvent event = mockDeath(zombie);
 
-        new EntityDeathListener(recorder, support, ALL).onEntityDeath(event);
+        new EntityDeathListener(recorder, support, ALL, DIRECT).onEntityDeath(event);
 
         EntityDeathRecord death = (EntityDeathRecord) findEvent("death");
         assertThat(death.source().entityType()).isEqualTo("zombie");
@@ -82,7 +91,7 @@ class EntityDeathListenerTest {
         stubDamageByEntity(bob, zombie, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 4.0);
         EntityDeathEvent event = mockDeath(bob);
 
-        new EntityDeathListener(recorder, support, ALL).onEntityDeath(event);
+        new EntityDeathListener(recorder, support, ALL, DIRECT).onEntityDeath(event);
 
         EntityDeathRecord death = (EntityDeathRecord) findEvent("death");
         assertThat(death.source().playerName()).isEqualTo("Bob");
@@ -104,7 +113,7 @@ class EntityDeathListenerTest {
         when(bob.getLastDamageCause()).thenReturn(fall);
         EntityDeathEvent event = mockDeath(bob);
 
-        new EntityDeathListener(recorder, support, ALL).onEntityDeath(event);
+        new EntityDeathListener(recorder, support, ALL, DIRECT).onEntityDeath(event);
 
         assertThat(recorder.records).hasSize(1);
         EntityDeathRecord death = (EntityDeathRecord) recorder.records.get(0);
@@ -122,7 +131,7 @@ class EntityDeathListenerTest {
         stubDamageByEntity(zombie, alice, EntityDamageEvent.DamageCause.ENTITY_ATTACK, 6.0);
         EntityDeathEvent event = mockDeath(zombie);
 
-        new EntityDeathListener(recorder, support, Set.of("death", "drop"))
+        new EntityDeathListener(recorder, support, Set.of("death", "drop"), DIRECT)
                 .onEntityDeath(event);
 
         assertThat(recorder.records).hasSize(1);
@@ -145,7 +154,7 @@ class EntityDeathListenerTest {
         EntityDeathEvent event = mockDeath(bob);
         when(event.getDrops()).thenReturn(List.of(diamond, iron));
 
-        new EntityDeathListener(recorder, support, ALL).onEntityDeath(event);
+        new EntityDeathListener(recorder, support, ALL, DIRECT).onEntityDeath(event);
 
         List<EventRecord> drops = recorder.records.stream()
                 .filter(r -> r.event().equals("drop")).toList();
@@ -154,6 +163,100 @@ class EntityDeathListenerTest {
                 assertThat(r.source().playerName()).isEqualTo("Bob"));
         assertThat(((ItemDropRecord) drops.get(0)).target()).isEqualTo("DIAMOND");
         assertThat(((ItemDropRecord) drops.get(1)).target()).isEqualTo("IRON_INGOT");
+    }
+
+    @Test
+    void dropProjectionIsDeferredWhileDeathRecordsInlineAtEventTime() {
+        // #188: the only main-thread work per drop is clone + type/amount +
+        // context; the storedItemProjection build is handed to the serializer.
+        // The death record (main-thread-only entity NBT) still records inline.
+        Player bob = mockPlayer(BOB, "Bob");
+        stubFallDeath(bob);
+        ItemStack diamond = mockStack(Material.DIAMOND, 2);
+        ItemStack iron = mockStack(Material.IRON_INGOT, 5);
+        EntityDeathEvent event = mockDeath(bob);
+        when(event.getDrops()).thenReturn(List.of(diamond, iron));
+
+        List<Runnable> deferred = new ArrayList<>();
+        new EntityDeathListener(recorder, support, ALL, deferred::add).onEntityDeath(event);
+
+        assertThat(recorder.records).singleElement()
+                .satisfies(r -> assertThat(r.event()).isEqualTo("death"));
+        assertThat(deferred).hasSize(2);
+
+        deferred.forEach(Runnable::run);
+
+        List<EventRecord> drops = recorder.records.stream()
+                .filter(r -> r.event().equals("drop")).toList();
+        assertThat(drops).hasSize(2);
+        assertThat(drops).allSatisfy(r ->
+                assertThat(r.source().playerName()).isEqualTo("Bob"));
+        assertThat(((ItemDropRecord) drops.get(0)).target()).isEqualTo("DIAMOND");
+        assertThat(((ItemDropRecord) drops.get(0)).amount()).isEqualTo(2);
+        assertThat(((ItemDropRecord) drops.get(0)).item().material()).isEqualTo("DIAMOND");
+        assertThat(((ItemDropRecord) drops.get(1)).target()).isEqualTo("IRON_INGOT");
+        assertThat(((ItemDropRecord) drops.get(1)).amount()).isEqualTo(5);
+    }
+
+    @Test
+    void dropStampsOccurredAndIdAtEventTimeNotSerializationTime() {
+        Player bob = mockPlayer(BOB, "Bob");
+        stubFallDeath(bob);
+        ItemStack diamond = mockStack(Material.DIAMOND, 1);
+        EntityDeathEvent event = mockDeath(bob);
+        when(event.getDrops()).thenReturn(List.of(diamond));
+
+        List<Runnable> deferred = new ArrayList<>();
+        Instant before = Instant.now();
+        new EntityDeathListener(recorder, support, ALL, deferred::add).onEntityDeath(event);
+        Instant after = Instant.now();
+
+        // Built only when the deferred task runs, strictly after the handling
+        // window, yet occurred + id (stamped via RecordContext on the main
+        // thread) must reflect event time, not serialization time.
+        deferred.forEach(Runnable::run);
+
+        ItemDropRecord drop = (ItemDropRecord) recorder.records.stream()
+                .filter(r -> r.event().equals("drop")).findFirst().orElseThrow();
+        assertThat(drop.occurred()).isBetween(before, after);
+        assertThat(drop.id()).isNotNull();
+    }
+
+    @Test
+    void dropClonesStackOnHandlingThreadBeforeDeferring() {
+        Player bob = mockPlayer(BOB, "Bob");
+        stubFallDeath(bob);
+        ItemStack diamond = mockStack(Material.DIAMOND, 2);
+        EntityDeathEvent event = mockDeath(bob);
+        when(event.getDrops()).thenReturn(List.of(diamond));
+
+        List<Runnable> deferred = new ArrayList<>();
+        new EntityDeathListener(recorder, support, ALL, deferred::add).onEntityDeath(event);
+
+        // The snapshot is taken synchronously, before the deferred task could
+        // observe a consumed/mutated live stack.
+        verify(diamond).clone();
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).noneSatisfy(r ->
+                assertThat(r.event()).isEqualTo("drop"));
+    }
+
+    @Test
+    void airDropIsSkippedWithoutCloningOrDeferring() {
+        Player bob = mockPlayer(BOB, "Bob");
+        stubFallDeath(bob);
+        ItemStack air = mock(ItemStack.class);
+        when(air.getType()).thenReturn(Material.AIR);
+        EntityDeathEvent event = mockDeath(bob);
+        when(event.getDrops()).thenReturn(List.of(air));
+
+        List<Runnable> deferred = new ArrayList<>();
+        new EntityDeathListener(recorder, support, ALL, deferred::add).onEntityDeath(event);
+
+        assertThat(deferred).isEmpty();
+        verify(air, never()).clone();
+        assertThat(recorder.records).noneSatisfy(r ->
+                assertThat(r.event()).isEqualTo("drop"));
     }
 
     private EventRecord findEvent(String name) {
@@ -207,7 +310,22 @@ class EntityDeathListenerTest {
         when(stack.getType()).thenReturn(material);
         when(stack.getAmount()).thenReturn(amount);
         when(stack.getItemMeta()).thenReturn(null);
+        // The drop is cloned on the main thread and the projection is built
+        // off-thread from that clone (#188), so the clone needs its type too.
+        ItemStack clone = mock(ItemStack.class);
+        when(clone.getType()).thenReturn(material);
+        when(clone.getAmount()).thenReturn(amount);
+        when(clone.getItemMeta()).thenReturn(null);
+        when(stack.clone()).thenReturn(clone);
         return stack;
+    }
+
+    private static void stubFallDeath(Player victim) {
+        when(victim.getKiller()).thenReturn(null);
+        EntityDamageEvent fall = mock(EntityDamageEvent.class);
+        when(fall.getCause()).thenReturn(EntityDamageEvent.DamageCause.FALL);
+        when(fall.getFinalDamage()).thenReturn(8.0);
+        when(victim.getLastDamageCause()).thenReturn(fall);
     }
 
     private static EntityDeathEvent mockDeath(LivingEntity victim) {


### PR DESCRIPTION
Closes #188.

## What

`EntityDeathListener.onEntityDeath` built the per-drop item projection (`ItemSerialization.storedItemProjection` -> `getItemMeta` full meta copy, Adventure `PlainTextComponentSerializer` over display name + each lore line, `getAsComponentString()` custom-data render, enchant rendering) inline on the server thread, once per item in `EntityDeathEvent.getDrops()`. A single player PvP death spills a whole inventory, so this scaled with drop count per tick (caught in a JFR profile).

This applies the already-established #97 pattern: capture a cheap snapshot on the main thread, hand the heavy build to the shared `DeferredSerializer`.

Per drop, the only main-thread work is now: AIR pre-check, `ItemStack.clone()`, capture type/amount, and build the `RecordContext` (which stamps `occurred` + the v7 `id` at event time). The `storedItemProjection` build runs off the main thread.

## Why it is safe

- `ItemDropRecord` is **not** `Rollbackable` (only `EventRecord`), so deferring it has zero interaction with the rollback `flush()` / read-your-writes contract.
- The drops are about to be spawned as item entities, so an independent `clone()` taken on the main thread is safe to serialize off-thread.
- The victim's entity NBT and the `death` / `kill` / `mob-kill` records stay inline at event time (NMS reads aren't thread-safe and the victim is gone once the event returns, #129).

## Tests

Added 4 tests to `EntityDeathListenerTest` (10 total, all green):
- `dropProjectionIsDeferredWhileDeathRecordsInlineAtEventTime` - death recorded inline, both drops deferred until the serializer runs; projection/amount/attribution equivalent to the old inline path.
- `dropStampsOccurredAndIdAtEventTimeNotSerializationTime` - `occurred` falls in the handling window even though the build runs later.
- `dropClonesStackOnHandlingThreadBeforeDeferring` - the clone is taken synchronously.
- `airDropIsSkippedWithoutCloningOrDeferring` - air drops skipped, no clone, no defer.

`./gradlew check` and `./gradlew build` both pass; jacoco floors held. No `spyglass-api` change.

## Notes

No event-type parity change - this only moves *when* the existing `drop` projection is built, not its shape, so all backends are unaffected.