### PR TITLE
fix(autocomplete): complete every entry in a comma-separated value (#189)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -82,15 +82,35 @@ public final class SpyglassSuggestions {
         int colon = token.indexOf(':');
         if (colon > 0) {
             String alias = token.substring(0, colon).toLowerCase(java.util.Locale.ROOT);
-            String partialValue = token.substring(colon + 1);
+            String value = token.substring(colon + 1);
             Optional<QueryParamHandler> handler = api.queryParam(alias);
             if (handler.isEmpty()) {
                 return List.of();
             }
-            List<String> suggestions = handler.get().suggestions(sender, partialValue);
+            // Most value params accept a comma-separated list (a:break,place /
+            // p:Alice,Bob), and `!`-prefixed entries are excludes (#30). Tab
+            // completion must complete the entry currently being typed, not the
+            // whole value: split off everything up to and including the last
+            // comma as an already-committed prefix, peel a leading `!`, and ask
+            // the handler to complete only that final bare entry. Without this
+            // the handler saw the whole `break,pl` span and prefix-matched
+            // nothing past the first entry, so only the first action in a list
+            // was ever completable (#189). Each suggestion is reassembled as the
+            // entire argument value (alias:committed[!]entry) so it survives
+            // Cloud's greedy-span filter (#55) and keeps the earlier entries the
+            // user already typed. Single-value params never see a comma here, and
+            // params where a comma is literal (m:, content) return no
+            // suggestions, so this is a no-op for them.
+            int lastComma = value.lastIndexOf(',');
+            String committed = value.substring(0, lastComma + 1);   // "" when no comma
+            String entry = value.substring(lastComma + 1);
+            boolean negated = entry.startsWith("!");
+            String bare = negated ? entry.substring(1) : entry;
+            String entryPrefix = negated ? "!" : "";
+            List<String> suggestions = handler.get().suggestions(sender, bare);
             List<String> prefixed = new ArrayList<>(suggestions.size());
             for (String suggestion : suggestions) {
-                prefixed.add(alias + ":" + suggestion);
+                prefixed.add(alias + ":" + committed + entryPrefix + suggestion);
             }
             return prefixed;
         }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
@@ -2,15 +2,20 @@ package net.medievalrp.spyglass.plugin.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Stream;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.extension.FlagHandler;
 import net.medievalrp.spyglass.api.param.QueryParamHandler;
 import org.bukkit.command.CommandSender;
+import org.mockito.ArgumentCaptor;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.execution.ExecutionCoordinator;
 import org.incendo.cloud.internal.CommandRegistrationHandler;
@@ -35,18 +40,26 @@ class SpyglassSuggestionsTest {
 
     private CommandManager<CommandSender> manager;
     private CommandSender sender;
+    private QueryParamHandler action;
 
     @BeforeEach
     void setUp() {
-        QueryParamHandler action = mock(QueryParamHandler.class);
+        action = mock(QueryParamHandler.class);
         QueryParamHandler player = mock(QueryParamHandler.class);
         when(action.aliases()).thenReturn(List.of("action", "a"));
         when(player.aliases()).thenReturn(List.of("player", "p"));
-        when(player.suggestions(any(), any())).thenReturn(List.of("Steve", "Alex"));
+        // Input-sensitive stubs (mirroring the real params' prefix match) so the
+        // multi-value tests below prove the handler is asked to complete only the
+        // trailing entry, not the whole comma span.
+        when(action.suggestions(any(), any()))
+                .thenAnswer(inv -> prefixMatch(inv.getArgument(1), "break", "place", "pickup", "drop"));
+        when(player.suggestions(any(), any()))
+                .thenAnswer(inv -> prefixMatch(inv.getArgument(1), "Steve", "Alex"));
 
         SpyglassApi api = mock(SpyglassApi.class);
         when(api.queryParams()).thenReturn(List.of(action, player));
         when(api.flags()).thenReturn(List.<FlagHandler>of());
+        when(api.queryParam("action")).thenReturn(Optional.of(action));
         when(api.queryParam("player")).thenReturn(Optional.of(player));
 
         SpyglassSuggestions suggestions = new SpyglassSuggestions(api);
@@ -54,6 +67,13 @@ class SpyglassSuggestionsTest {
         manager.command(manager.commandBuilder("search")
                 .required("params", suggestions.paramsParser(), suggestions.paramsProvider()));
         sender = mock(CommandSender.class);
+    }
+
+    private static List<String> prefixMatch(String input, String... values) {
+        String lower = input.toLowerCase(Locale.ROOT);
+        return Stream.of(values)
+                .filter(v -> v.toLowerCase(Locale.ROOT).startsWith(lower))
+                .toList();
     }
 
     private List<String> complete(String input) {
@@ -87,6 +107,59 @@ class SpyglassSuggestionsTest {
     void suggestsValuesForALaterParam() {
         assertThat(complete("search action:break player:"))
                 .contains("action:break player:Steve", "action:break player:Alex");
+    }
+
+    // ── #189: comma-separated list values complete every entry ──────────
+
+    @Test
+    void completesSecondActionInACommaList() {
+        // Before the fix the handler saw the whole "break,pl" span and matched
+        // nothing, so only the first action was completable.
+        List<String> out = complete("search action:break,pl");
+        assertThat(out).contains("action:break,place");
+        // The earlier entry is preserved on every suggestion.
+        assertThat(out).allMatch(s -> s.startsWith("action:break,"));
+    }
+
+    @Test
+    void trailingCommaOffersAllNextActions() {
+        assertThat(complete("search action:break,"))
+                .contains("action:break,break", "action:break,place",
+                        "action:break,pickup", "action:break,drop");
+    }
+
+    @Test
+    void completesSecondPlayerKeepingTheFirst() {
+        List<String> out = complete("search player:Steve,Al");
+        assertThat(out).contains("player:Steve,Alex");
+        // Only the entry being typed is completed; the first name is not
+        // re-offered as the second entry.
+        assertThat(out).doesNotContain("player:Steve,Steve");
+    }
+
+    @Test
+    void completesAcrossAnEarlierParamAndAList() {
+        assertThat(complete("search player:Steve action:break,pl"))
+                .contains("player:Steve action:break,place");
+    }
+
+    @Test
+    void completesAnExcludeEntry() {
+        // `!`-prefixed excludes (#30) complete too: the `!` is peeled before the
+        // handler sees the bare entry, then re-attached.
+        assertThat(complete("search action:!pl")).contains("action:!place");
+        assertThat(complete("search action:break,!pl")).contains("action:break,!place");
+    }
+
+    @Test
+    void handlerReceivesOnlyTheBareTrailingEntry() {
+        complete("search action:break,!pla");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(action, atLeastOnce()).suggestions(any(), captor.capture());
+        // Not "break,!pla" and not "!pla" — the comma prefix and the `!` are
+        // stripped so the param only ever completes a single bare entry.
+        assertThat(captor.getValue()).isEqualTo("pla");
     }
 
     /** Headless cloud-core manager — no Bukkit server, just the suggestion engine. */


### PR DESCRIPTION
Closes #189.

## The bug

When building a search query, only the **first** value in a comma-separated list was tab-completable. Typing `a:break,pl<TAB>` offered nothing for the second action.

`SpyglassSuggestions.suggestFor` handed the param handler the entire post-alias span (`break,pl`). Handlers prefix-match their candidates (`name.startsWith(input)`), so `"break,pl"` matched nothing past the first entry. This affected every comma-list param, not just actions: `p:Alice,Bob`, `e:`, `b:`, `i:`, recipient.

## The fix

Complete only the entry currently being typed. In the shared `alias:value` chokepoint:

- Split off everything up to and including the last comma as an already-committed prefix.
- Peel a leading `!` (exclude marker, #30).
- Ask the handler to complete just that bare trailing entry.
- Reassemble each suggestion as the whole argument value (`alias:committed[!]entry`) so it keeps the earlier entries **and** survives Cloud's greedy-span filter (#55).

This is a no-op for single-value params (they never see a comma) and for comma-literal params (`m:`, content) which return no suggestions. As a bonus it also fixes completion of `!`-excludes, which never completed before.

## Tests

6 new tests in `SpyglassSuggestionsTest` (10 total, all green), driving the **real** cloud-core suggestion pipeline (not a mock of it):

- `completesSecondActionInACommaList` - the exact reported case.
- `trailingCommaOffersAllNextActions` - `a:break,` offers the full next list.
- `completesSecondPlayerKeepingTheFirst` - earlier entry preserved, first name not re-offered as the second.
- `completesAcrossAnEarlierParamAndAList` - works after a previous param too.
- `completesAnExcludeEntry` - `!`-excludes complete.
- `handlerReceivesOnlyTheBareTrailingEntry` - asserts the handler is asked to complete only the bare entry (no comma prefix, no `!`).

`./gradlew check` and `./gradlew build` pass; jacoco floors held. Ran `/security-review` (command-input change): no findings - suggestions are display-only and never reach query construction or permission logic.

No `spyglass-api` change.