### PR TITLE
fix(rollback): log partial-drain rollbacks and report the backlog (#204)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -246,6 +246,45 @@ public final class RollbackService {
         }
     }
 
+    /**
+     * The recorder's flush timed out before every queued/spilled record
+     * reached the store, so the rollback below reads an incomplete picture and
+     * can only partially restore. Log it at WARNING with the job id AND tell
+     * the operator how much is still in flight (#204). The old notice went only
+     * to {@code job.sender}, so a partial rollback left no server-log trace and
+     * did not say how much was missing; the drain figures come from
+     * {@link net.medievalrp.spyglass.plugin.pipeline.Recorder#spillSnapshot()}.
+     */
+    private void warnRecorderStillDraining(RollbackJob job) {
+        String detail = drainDetail(recorder.spillSnapshot());
+        logger.warning("Spyglass rollback " + job.shortId()
+                + " starting before the recorder drained: " + detail
+                + ". The newest events may be missing from this rollback; re-run once the"
+                + " backlog clears (see /spyglass stats) to catch them.");
+        support.onMainThread(() -> job.sender.sendMessage(Feedback.bonus(
+                "Recorder still draining: " + detail + ". Rollback may miss the most recent"
+                + " events; re-run after it clears to catch the rest.")));
+    }
+
+    /**
+     * Human-readable "how much is still draining" phrase for
+     * {@link #warnRecorderStillDraining}. With a spill backlog it reports the
+     * record count and, when the drain is rate-capped, an estimated time to
+     * clear; otherwise it reports that the store simply has not caught up.
+     * Package-private + static for unit testing (#204).
+     */
+    static String drainDetail(net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot spill) {
+        long backlog = spill.records();
+        if (backlog <= 0) {
+            return "the store has not caught up to the newest events";
+        }
+        long rate = spill.drainRatePerSec();
+        String eta = rate > 0
+                ? " (~" + Math.max(1L, backlog / rate) + "s to clear at " + rate + " rec/s)"
+                : "";
+        return backlog + " record(s) still draining from the overflow spill" + eta;
+    }
+
     public void runJob(RollbackJob job) {
         JobContext ctx = pendingContexts.remove(job.id);
         if (ctx == null) {
@@ -265,8 +304,7 @@ public final class RollbackService {
             try {
                 boolean drained = recorder.flush(flushTimeout);
                 if (!drained) {
-                    support.onMainThread(() -> job.sender.sendMessage(Feedback.bonus(
-                            "Recorder still draining; rollback may miss the most recent events.")));
+                    warnRecorderStillDraining(job);
                 }
                 streamPagesAndApply(job, ctx.request(), ctx.mode(),
                         ctx.startCursor(), ctx.initialApplied(), ctx.initialSkipped(),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/Recorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/Recorder.java
@@ -42,4 +42,15 @@ public interface Recorder {
      * @return {@code true} if the snapshot drained, {@code false} on timeout
      */
     boolean flush(Duration timeout);
+
+    /**
+     * Snapshot of the on-disk overflow spill backlog, so a caller can tell
+     * the operator how many records are still draining when a {@link #flush}
+     * times out (#204). Default: an empty, disabled snapshot - a recorder
+     * without a spill buffer, and test doubles, report no backlog.
+     * {@link AsyncRecorder} overrides this with the live figures.
+     */
+    default AsyncRecorder.SpillSnapshot spillSnapshot() {
+        return new AsyncRecorder.SpillSnapshot(false, 0L, 0L, 0L, 0L);
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -567,4 +567,71 @@ class RollbackServiceTest {
         verify(fixture.undoStack, org.mockito.Mockito.never()).pushReference(
                 any(UUID.class), any(String.class), any(String.class));
     }
+
+    // #204: when the pre-rollback flush times out, the partial-restore
+    // condition must reach the SERVER LOG (it was sender-only before, leaving
+    // no trace), and the operator message must say how much is still draining.
+    @Test
+    void logsAndTellsOperatorWhenRecorderStillDrainingAtRollback() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        // Flush times out; the recorder reports a spill backlog with a finite
+        // drain rate, so an ETA is included (50000 / 500 = 100s).
+        when(fixture.recorder.flush(any(net.medievalrp.spyglass.api.util.Duration.class)))
+                .thenReturn(false);
+        when(fixture.recorder.spillSnapshot()).thenReturn(
+                new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                        true, 3L, 50_000L, 1_000_000L, 500L));
+
+        java.util.List<java.util.logging.LogRecord> logged = new java.util.ArrayList<>();
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override public void publish(java.util.logging.LogRecord rec) {
+                logged.add(rec);
+            }
+            @Override public void flush() {
+            }
+            @Override public void close() {
+            }
+        };
+        Logger testLogger = Logger.getLogger("test");
+        testLogger.addHandler(handler);
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+        try {
+            fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+        } finally {
+            testLogger.removeHandler(handler);
+        }
+
+        // The core of #204: a WARNING now records that a rollback ran on
+        // incomplete data, with the job context and backlog count.
+        assertThat(logged).anyMatch(rec ->
+                rec.getLevel() == java.util.logging.Level.WARNING
+                        && rec.getMessage().contains("before the recorder drained")
+                        && rec.getMessage().contains("50000"));
+        // The operator is told the count and the ETA, not just "still draining".
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("50000") && line.contains("100s"));
+    }
+
+    // #204: the drain-detail phrase reports the backlog count and a rate-based
+    // ETA, drops the ETA when the drain is unlimited, and degrades cleanly when
+    // nothing is spilled (queue-only / slow-store case).
+    @Test
+    void drainDetailReportsBacklogCountAndEta() {
+        var withRate = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                true, 2L, 10_000L, 500_000L, 500L);
+        assertThat(RollbackService.drainDetail(withRate))
+                .contains("10000").contains("20s").contains("500 rec/s");
+
+        var unlimited = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                true, 2L, 10_000L, 500_000L, 0L);
+        assertThat(RollbackService.drainDetail(unlimited))
+                .contains("10000").doesNotContain("to clear");
+
+        var noBacklog = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                false, 0L, 0L, 0L, 0L);
+        assertThat(RollbackService.drainDetail(noBacklog))
+                .isEqualTo("the store has not caught up to the newest events");
+    }
 }


### PR DESCRIPTION
When the pre-rollback recorder flush timed out (a large spill backlog
draining slower than rollback-flush-timeout), the rollback proceeded on
incomplete data with only a sender-only 'still draining' notice - so a
partial restore left NO server-log trace and did not say how much was
missing.

Add Recorder.spillSnapshot() (default: empty) and, on flush timeout,
logger.warning the condition with the job id and the outstanding backlog,
plus surface the record count and a rate-based ETA to the operator.
drainDetail() is package-private + static and unit-tested for the
backlog+ETA, unlimited-drain, and no-backlog cases; an integration test
asserts the WARNING now fires with the job context and count.

Deliberately does NOT refuse the rollback while draining (the issue's
optional --force gate) - that is a behavior change left for a follow-up.
