### PR TITLE
perf(storage): stream Mongo inserts whose expiry needs no patch (#206)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -253,19 +253,53 @@ public final class MongoRecordStore implements RecordStore {
             polymorphicCollection.insertMany(records);
             return;
         }
-        // #181: per-event-type expiry. The TTL index is on expiresAt, so encode
-        // each record and overwrite that field per type before insert. Same BSON
-        // as the typed path (same codec), just a per-type expiresAt - so the
-        // chunk-bucket fields, _id mapping, and zstd compression are unchanged.
-        List<BsonDocument> docs = new ArrayList<>(records.size());
+        // #181: per-event-type expiry. A record whose stored expiresAt already
+        // equals its per-event target inserts via the streaming typed codec - the
+        // same allocation-free path as the no-policy branch above - and only a
+        // record needing a DIFFERENT expiry (a per-event override) is re-encoded
+        // into a BsonDocument and patched. Previously every record built that
+        // tree, which dominated the drain-thread heap under load (#206), the same
+        // materialized-tree cost #125 removed from the spill/WAL codec. Both paths
+        // store the same per-type expiresAt, so the TTL index, chunk-bucket
+        // fields, _id mapping, and zstd compression are unchanged.
+        List<EventRecord> direct = null;
+        List<BsonDocument> patched = null;
         for (EventRecord record : records) {
-            BsonDocument doc = new BsonDocument();
-            eventCodec.encode(new BsonDocumentWriter(doc), record, EncoderContext.builder().build());
-            doc.put(RecordFields.EXPIRES_AT, new BsonDateTime(
-                    retentionPolicy.expiresAt(record.occurred(), record.event()).toEpochMilli()));
-            docs.add(doc);
+            if (expiryAlreadyCorrect(record, retentionPolicy)) {
+                if (direct == null) {
+                    direct = new ArrayList<>(records.size());
+                }
+                direct.add(record);
+            } else {
+                if (patched == null) {
+                    patched = new ArrayList<>();
+                }
+                BsonDocument doc = new BsonDocument();
+                eventCodec.encode(new BsonDocumentWriter(doc), record, EncoderContext.builder().build());
+                doc.put(RecordFields.EXPIRES_AT, new BsonDateTime(
+                        retentionPolicy.expiresAt(record.occurred(), record.event()).toEpochMilli()));
+                patched.add(doc);
+            }
         }
-        rawCollection.insertMany(docs);
+        if (direct != null) {
+            polymorphicCollection.insertMany(direct);
+        }
+        if (patched != null) {
+            rawCollection.insertMany(patched);
+        }
+    }
+
+    /**
+     * True when a record's stored {@code expiresAt} already equals its per-event
+     * retention target, so it inserts via the streaming typed codec with no
+     * expiry patch (#206). A record stamped with the global default retention
+     * matches for every non-overridden event type - the common case - so only
+     * override-type (or oddly-stamped, or null-expiry) records pay the re-encode.
+     */
+    static boolean expiryAlreadyCorrect(EventRecord record, RetentionPolicy policy) {
+        Instant expiresAt = record.expiresAt();
+        return expiresAt != null
+                && policy.expiresAt(record.occurred(), record.event()).equals(expiresAt);
     }
 
     @Override

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreExpiryTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreExpiryTest.java
@@ -1,0 +1,85 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import java.util.Map;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Headless coverage of the Mongo save routing (#206): a record whose stored
+ * expiresAt already equals its per-event target takes the streaming typed insert
+ * (no BsonDocument tree); only a record needing a different expiry is re-encoded
+ * and patched. This pins {@link MongoRecordStore#expiryAlreadyCorrect} without a
+ * Mongo connection - the full round-trip is covered by the Testcontainers IT.
+ */
+class MongoRecordStoreExpiryTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000cd");
+    private static final Instant OCCURRED = Instant.parse("2026-04-23T12:00:00Z");
+
+    private static BlockBreakRecord record(String event, Instant expiresAt) {
+        BlockSnapshot stone = new BlockSnapshot(Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockBreakRecord(UUID.randomUUID(), event, OCCURRED, expiresAt,
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD, "world", 1, 64, 1), "srv", "STONE", stone, air);
+    }
+
+    @Test
+    void defaultRetentionTypeStampedWithDefaultTakesTheStreamedPath() {
+        // "place" has no override, and the record carries occurred + default, so
+        // its stored expiresAt already equals the target -> no patch needed.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord place = record("place", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(place, policy)).isTrue();
+    }
+
+    @Test
+    void overriddenTypeStampedWithDefaultNeedsThePatch() {
+        // "break" is overridden to 100s but the record was stamped with the 3600s
+        // global default, so the target differs -> must be re-encoded and patched.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord brk = record("break", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(brk, policy)).isFalse();
+    }
+
+    @Test
+    void overriddenTypeAlreadyStampedWithItsOverrideTakesTheStreamedPath() {
+        // If a record already carries its override expiry, no patch is needed.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord brk = record("break", OCCURRED.plusSeconds(100L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(brk, policy)).isTrue();
+    }
+
+    @Test
+    void nullExpiresAtNeedsThePatch() {
+        RetentionPolicy policy = RetentionPolicy.uniform(3600L);
+        EventRecord noExpiry = record("place", null);
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(noExpiry, policy)).isFalse();
+    }
+
+    @Test
+    void neverRetentionClampsToTheCeilingSoAStampedDefaultNeedsThePatch() {
+        // "say" kept forever: target is the clamped MAX_EXPIRY, not occurred +
+        // default, so a default-stamped record is patched up to the ceiling.
+        RetentionPolicy policy = new RetentionPolicy(3600L,
+                Map.of("say", RetentionPolicy.NEVER_SECONDS));
+        EventRecord say = record("say", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(say, policy)).isFalse();
+
+        EventRecord alreadyNever = record("say", RetentionPolicy.MAX_EXPIRY);
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(alreadyNever, policy)).isTrue();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -100,13 +100,20 @@ class MongoRecordStoreIT {
             policyStore.database().getCollection("EventRecords", org.bson.BsonDocument.class)
                     .deleteMany(new org.bson.BsonDocument());
             policyStore.save(List.of(
+                    // break + say are overridden -> the encode-and-patch write path.
                     new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
                             origin, source, loc, "t", "STONE", stone, air),
                     new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
-                            origin, source, loc, "t", "Alice", "hi", List.of(), Map.of())));
+                            origin, source, loc, "t", "Alice", "hi", List.of(), Map.of()),
+                    // place is NOT overridden and is stamped with the default
+                    // retention, so it takes the streaming typed insert (#206); it
+                    // must still round-trip the default expiresAt.
+                    new BlockPlaceRecord(UUID.randomUUID(), "place", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "STONE", air, stone)));
 
             // Read back through the store's typed query; expiresAt is the stored
-            // per-type value the encode-and-patch write produced.
+            // per-type value (the patched write for overrides, the record's own
+            // default for the streamed non-override).
             QueryResult res = policyStore.query(new QueryRequest(
                     List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
                     Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
@@ -114,12 +121,17 @@ class MongoRecordStoreIT {
                     .filter(r -> r.event().equals("break")).findFirst().orElseThrow();
             EventRecord say = res.records().stream()
                     .filter(r -> r.event().equals("say")).findFirst().orElseThrow();
+            EventRecord place = res.records().stream()
+                    .filter(r -> r.event().equals("place")).findFirst().orElseThrow();
             assertThat(brk.expiresAt())
-                    .as("break stored expiresAt = occurred + its 100s retention")
+                    .as("break stored expiresAt = occurred + its 100s retention (patched)")
                     .isEqualTo(now.plusSeconds(100L));
             assertThat(say.expiresAt())
-                    .as("say stored expiresAt = the clamped never ceiling")
+                    .as("say stored expiresAt = the clamped never ceiling (patched)")
                     .isEqualTo(RetentionPolicy.MAX_EXPIRY);
+            assertThat(place.expiresAt())
+                    .as("place stored expiresAt = occurred + the 3600s default (streamed, #206)")
+                    .isEqualTo(now.plusSeconds(3600L));
         } finally {
             policyStore.close();
         }


### PR DESCRIPTION
The per-event-expiry save path (#181) re-materialized every record into a
BsonDocument tree before insertMany, purely to overwrite expiresAt per
type - the same ~3x-batch heap churn #125 removed from the spill/WAL codec,
now on the ingest drain thread under load.

A record's stored expiresAt already equals its per-event target for every
non-overridden event type (the common case), so route those through the
streaming typed insertMany (no tree) and only re-encode + patch the records
whose event has an override. Both paths store the same per-type expiresAt,
so TTL, chunk buckets, _id mapping, and zstd are unchanged.

expiryAlreadyCorrect is package-private + headless-unit-tested (default type
streamed, override type patched, already-correct override streamed, null
expiry patched, never-ceiling patched). The Testcontainers IT now also
round-trips a non-override (streamed) record's expiresAt alongside the
patched break/say. Verified live against a local mongod round-trip too.
