### PR TITLE
perf(rollback): defer salvage item serialization off the main thread (#207)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
@@ -58,7 +58,11 @@ public final class SalvageCapturer implements SalvageHook {
         this.logger = logger;
     }
 
-    private record Captured(int x, int y, int z, String type, List<StoredItem> items) {
+    // Contents are CLONED (detached), not yet serialized: the heavy
+    // serializeAsBytes + base64 is deferred to the off-main persist step so a
+    // rollback over a container-dense area doesn't serialize every surviving
+    // container on the tick (#207).
+    private record Captured(int x, int y, int z, String type, ItemStack[] contents) {
     }
 
     @Override
@@ -87,13 +91,16 @@ public final class SalvageCapturer implements SalvageHook {
         // thread, before any write to this chunk). Most chunks have none.
         for (BlockState state : chunk.getTileEntities(false)) {
             if (state instanceof Container container) {
-                List<StoredItem> items = capture(inventoryOf(container));
-                if (!items.isEmpty()) {
+                // Clone the live contents on the main thread (cheap); the
+                // serialize is deferred to the persist step (#207). null means
+                // the container is empty - nothing to salvage.
+                ItemStack[] contents = cloneIfNonEmpty(inventoryOf(container));
+                if (contents != null) {
                     if (captured == null) {
                         captured = new ArrayList<>();
                     }
                     captured.add(new Captured(state.getX(), state.getY(), state.getZ(),
-                            state.getType().name(), items));
+                            state.getType().name(), contents));
                 }
             }
         }
@@ -111,37 +118,46 @@ public final class SalvageCapturer implements SalvageHook {
             return;
         }
         final String op = operator;
-        List<SalvageSnapshot> toSave = new ArrayList<>();
+        final UUID worldId = world.getUID();
+        final String worldName = world.getName();
+        // Main thread: decide which containers the rollback destroyed by
+        // comparing CLONED stacks (no serialization), then hand the captured
+        // clones - with their coordinates - to the off-main persist step, which
+        // serializes only the genuinely-destroyed set (#207).
+        List<Captured> destroyed = new ArrayList<>();
         for (Captured cap : captured) {
             Block block = world.getBlockAt(cap.x(), cap.y(), cap.z());
-            boolean destroyed;
+            boolean gone;
             // Check the block TYPE first — read from the chunk section the
             // rollback overwrote. A direct NMS section write leaves the old block
             // entity lingering in the chunk map, so getState() can still return a
             // stale Container even though the block is now (e.g.) stone; the
             // material is authoritative.
             if (!block.getType().name().equals(cap.type())) {
-                destroyed = true;
+                gone = true;
             } else if (block.getState() instanceof Container container) {
                 // Same container type still here — destroyed only if its contents
-                // changed (e.g. the rollback restored a different recorded inv).
-                destroyed = !sameItems(capture(inventoryOf(container)), cap.items());
+                // changed. Compares live stacks against the captured clones via
+                // ItemStack equality, no serialize.
+                gone = !sameContents(inventoryOf(container).getContents(), cap.contents());
             } else {
-                destroyed = true;
+                gone = true;
             }
-            if (destroyed && salvagedCells.add(
-                    world.getUID() + ":" + cap.x() + ":" + cap.y() + ":" + cap.z())) {
-                toSave.add(new SalvageSnapshot(UUID.randomUUID(), rollbackId,
-                        world.getUID(), world.getName(),
-                        cap.x(), cap.y(), cap.z(), cap.type(), op,
-                        Instant.now(), cap.items()));
+            if (gone && salvagedCells.add(
+                    worldId + ":" + cap.x() + ":" + cap.y() + ":" + cap.z())) {
+                destroyed.add(cap);
             }
         }
-        if (!toSave.isEmpty()) {
-            logger.fine("salvage: persisting " + toSave.size()
+        if (!destroyed.isEmpty()) {
+            logger.fine("salvage: persisting " + destroyed.size()
                     + " destroyed container(s) from chunk " + chunkX + "," + chunkZ);
+            final UUID batchRollbackId = rollbackId;
             persistExecutor.execute(() -> {
-                for (SalvageSnapshot snapshot : toSave) {
+                for (Captured cap : destroyed) {
+                    // Serialize off the main thread, then persist.
+                    SalvageSnapshot snapshot = new SalvageSnapshot(UUID.randomUUID(), batchRollbackId,
+                            worldId, worldName, cap.x(), cap.y(), cap.z(), cap.type(), op,
+                            Instant.now(), serializeContents(cap.contents()));
                     try {
                         store.save(snapshot);
                     } catch (RuntimeException ex) {
@@ -161,34 +177,51 @@ public final class SalvageCapturer implements SalvageHook {
                 ? chest.getBlockInventory() : container.getInventory();
     }
 
-    private static List<StoredItem> capture(Inventory inventory) {
-        List<StoredItem> items = new ArrayList<>();
-        int size = inventory.getSize();
-        for (int slot = 0; slot < size; slot++) {
-            ItemStack stack = inventory.getItem(slot);
+    /** Clone the live contents (main thread) if any slot holds a real item;
+     *  returns null for an empty container. Empty slots normalize to null so the
+     *  written-time comparison lines up regardless of AIR-vs-null. */
+    private static ItemStack[] cloneIfNonEmpty(Inventory inventory) {
+        ItemStack[] live = inventory.getContents();
+        ItemStack[] out = new ItemStack[live.length];
+        boolean anyItem = false;
+        for (int slot = 0; slot < live.length; slot++) {
+            ItemStack stack = live[slot];
             if (stack != null && stack.getType() != Material.AIR) {
-                items.add(ItemSerialization.storedItem(slot, stack));
+                out[slot] = stack.clone();
+                anyItem = true;
+            }
+        }
+        return anyItem ? out : null;
+    }
+
+    /** Off-main: serialize the cloned, destroyed container's contents. */
+    private static List<StoredItem> serializeContents(ItemStack[] contents) {
+        List<StoredItem> items = new ArrayList<>();
+        for (int slot = 0; slot < contents.length; slot++) {
+            if (contents[slot] != null) {
+                items.add(ItemSerialization.storedItem(slot, contents[slot]));
             }
         }
         return items;
     }
 
-    // Equal iff the same slot->blob set. Order-independent; cheap for the
-    // handful of captured containers.
-    private static boolean sameItems(List<StoredItem> a, List<StoredItem> b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        Set<String> keys = new HashSet<>();
-        for (StoredItem item : a) {
-            keys.add(item.slot() + ":" + item.data());
-        }
-        for (StoredItem item : b) {
-            if (!keys.contains(item.slot() + ":" + item.data())) {
+    // Equal iff every slot's live stack matches the captured clone, treating a
+    // null and an AIR stack as the same empty slot. ItemStack.equals is a
+    // read-only deep compare - no serialization (#207).
+    private static boolean sameContents(ItemStack[] live, ItemStack[] captured) {
+        int size = Math.max(live.length, captured.length);
+        for (int slot = 0; slot < size; slot++) {
+            ItemStack liveStack = slot < live.length ? normalizeEmpty(live[slot]) : null;
+            ItemStack capturedStack = slot < captured.length ? captured[slot] : null;
+            if (!java.util.Objects.equals(liveStack, capturedStack)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static ItemStack normalizeEmpty(ItemStack stack) {
+        return (stack == null || stack.getType() == Material.AIR) ? null : stack;
     }
 
     private static String key(World world, int chunkX, int chunkZ) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturerTest.java
@@ -1,0 +1,132 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.Chunk;
+import org.bukkit.block.Barrel;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Pins the deferred-serialization contract for container salvage (#207): the
+ * heavy {@code serializeAsBytes} + base64 must run on the persist executor for
+ * only the genuinely-destroyed containers, never on the main-thread
+ * onChunkResolved / onChunkWritten hooks (which now only clone and compare).
+ */
+class SalvageCapturerTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+    private static final int CX = 4;
+    private static final int CZ = -2;
+    private static final int BX = 70;
+    private static final int BY = 64;
+    private static final int BZ = -20;
+
+    private final SalvageStore store = mock(SalvageStore.class);
+    private final List<Runnable> deferred = new ArrayList<>();
+    private final Executor collecting = deferred::add;
+    private final SalvageCapturer capturer =
+            new SalvageCapturer(store, collecting, Logger.getLogger("test"));
+
+    private ItemStack diamond() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.DIAMOND);
+        when(stack.getAmount()).thenReturn(1);
+        when(stack.hasItemMeta()).thenReturn(false);
+        when(stack.serializeAsBytes()).thenReturn(new byte[] {1, 2, 3});
+        when(stack.clone()).thenReturn(stack); // captured clone == the same reference
+        return stack;
+    }
+
+    /** A barrel holding one diamond, wired as the only tile entity in the chunk. */
+    private ItemStack wireBarrelWithDiamond(World world, Chunk chunk) {
+        ItemStack diamond = diamond();
+        Inventory inv = mock(Inventory.class);
+        when(inv.getContents()).thenReturn(new ItemStack[] {diamond, null, null});
+        Barrel barrel = mock(Barrel.class);
+        when(barrel.getX()).thenReturn(BX);
+        when(barrel.getY()).thenReturn(BY);
+        when(barrel.getZ()).thenReturn(BZ);
+        when(barrel.getType()).thenReturn(Material.BARREL);
+        when(barrel.getInventory()).thenReturn(inv);
+        when(chunk.getTileEntities(false))
+                .thenReturn(new org.bukkit.block.BlockState[] {barrel});
+        return diamond;
+    }
+
+    @Test
+    void destroyedContainerSerializesAndSavesOnlyViaTheExecutor() {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD);
+        when(world.getName()).thenReturn("world");
+        when(world.isChunkLoaded(CX, CZ)).thenReturn(true);
+        Chunk chunk = mock(Chunk.class);
+        when(world.getChunkAt(CX, CZ)).thenReturn(chunk);
+        wireBarrelWithDiamond(world, chunk);
+        // After the rollback, the barrel cell is now stone -> destroyed.
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.STONE);
+        when(world.getBlockAt(BX, BY, BZ)).thenReturn(block);
+
+        capturer.begin("Alice", UUID.randomUUID());
+        capturer.onChunkResolved(world, CX, CZ);
+        capturer.onChunkWritten(world, CX, CZ);
+
+        // #207: nothing serialized or saved on the main-thread hooks - the work
+        // is queued to the persist executor.
+        verifyNoInteractions(store);
+        assertThat(deferred).hasSize(1);
+
+        deferred.get(0).run();
+
+        ArgumentCaptor<SalvageSnapshot> saved = ArgumentCaptor.forClass(SalvageSnapshot.class);
+        verify(store).save(saved.capture());
+        assertThat(saved.getValue().items())
+                .as("the destroyed barrel's one diamond is serialized off-main and saved")
+                .hasSize(1);
+        assertThat(saved.getValue().x()).isEqualTo(BX);
+        assertThat(saved.getValue().containerType()).isEqualTo("BARREL");
+    }
+
+    @Test
+    void survivingContainerIsNeverSaved() {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD);
+        when(world.getName()).thenReturn("world");
+        when(world.isChunkLoaded(CX, CZ)).thenReturn(true);
+        Chunk chunk = mock(Chunk.class);
+        when(world.getChunkAt(CX, CZ)).thenReturn(chunk);
+        ItemStack diamond = wireBarrelWithDiamond(world, chunk);
+        // After the rollback the barrel is still a barrel with the same diamond.
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.BARREL);
+        Barrel liveState = mock(Barrel.class);
+        Inventory liveInv = mock(Inventory.class);
+        when(liveInv.getContents()).thenReturn(new ItemStack[] {diamond, null, null});
+        when(liveState.getInventory()).thenReturn(liveInv);
+        when(block.getState()).thenReturn(liveState);
+        when(world.getBlockAt(BX, BY, BZ)).thenReturn(block);
+
+        capturer.begin("Alice", UUID.randomUUID());
+        capturer.onChunkResolved(world, CX, CZ);
+        capturer.onChunkWritten(world, CX, CZ);
+
+        assertThat(deferred).as("an unchanged container queues no persist work").isEmpty();
+        verify(store, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
SalvageCapturer serialized every non-empty container's inventory (NBT ->
serializeAsBytes -> base64) on the main thread at onChunkResolved, and did
it AGAIN at onChunkWritten to compare against the post-rollback state - up
to 16 chunks per main-thread hop, so a rollback over a container-dense area
(a shop/warehouse district) chewed ticks.

Now the main-thread hooks only clone the stacks and compare them via
ItemStack equality (no serialization); the heavy serialize runs on the
existing off-main persist executor for ONLY the genuinely-destroyed
containers, right before the save. worldId/worldName/operator/rollbackId
are captured on-main and passed into the persist task.

New SalvageCapturerTest pins the contract: a destroyed container is
serialized and saved ONLY when the persist executor runs (nothing on the
onChunkResolved/onChunkWritten hooks), and a surviving container queues no
work. Behaviour is unchanged (same destroyed-detection, same saved items).
