### PR TITLE
perf(rollback): pace synchronous chunk loads during apply resolve (#208)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -123,6 +123,13 @@ public final class RollbackEngine {
     // per-block audit-record build, which now runs off-main.
     private volatile int worldWriteBatchChunks = 16;
 
+    // #208: max chunks that may be BLOCK-loaded (a getChunk on a not-yet-loaded
+    // chunk) per resolve hop. A rollback over an unloaded region paces its loads
+    // across ticks instead of bursting up to worldWriteBatchChunks blocking loads
+    // into one tick. Already-loaded chunks don't count against it, so the common
+    // in-view rollback is unaffected.
+    private static final int MAX_CHUNK_LOADS_PER_HOP = 4;
+
     // Apply-phase breakdown (reset per applyAllChunked, logged on
     // completion). writeNanos = wall-time the pool spends on palette
     // writes (sum of per-batch barrier waits); postNanos = main-thread
@@ -438,6 +445,17 @@ public final class RollbackEngine {
         return span <= 0L ? 0 : 64 - Long.numberOfLeadingZeros(span);
     }
 
+    /**
+     * Whether the resolve loop should stop this hop before a not-yet-loaded
+     * chunk, to pace synchronous chunk loads across ticks (#208). Never defers an
+     * already-loaded chunk, and always resolves at least one chunk per hop (an
+     * empty batch never defers) so progress is guaranteed even in a fully cold
+     * region. Package-private for unit testing.
+     */
+    static boolean deferForChunkLoadPacing(boolean chunkLoaded, int loadsThisHop, boolean batchEmpty) {
+        return !chunkLoaded && !batchEmpty && loadsThisHop >= MAX_CHUNK_LOADS_PER_HOP;
+    }
+
     private static void sortByComparator(List<Integer> indices,
                                          List<RollbackEffect.BlockReplace> effects) {
         int n = indices.size();
@@ -649,6 +667,7 @@ public final class RollbackEngine {
         long tResolve = System.nanoTime();
         List<ChunkWork> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
+        int loadsThisHop = 0;
         try {
             while (cursor < total && batch.size() < maxBatchChunks) {
             BlockLocation startLoc = blockReplaceEffects.get(cursor).location();
@@ -678,6 +697,18 @@ public final class RollbackEngine {
                 continue;
             }
 
+            // #208: pace synchronous chunk loads across ticks. prepareChunk's
+            // getChunk blocks to load an unloaded chunk; without this a rollback
+            // over an unloaded region would trigger up to maxBatchChunks blocking
+            // loads in a single tick and stall it. Already-loaded chunks (rolling
+            // back where a player stands - the common case) never hit the cap and
+            // resolve at full speed; a cold region just spreads its loads over
+            // more ticks, trading wall-time for TPS like the apply budget does.
+            boolean chunkLoaded = world.isChunkLoaded(cx, cz);
+            if (deferForChunkLoadPacing(chunkLoaded, loadsThisHop, batch.isEmpty())) {
+                break;
+            }
+
             // Pin the chunk loaded, then resolve its section context —
             // both on main, so the worker never calls into the chunk
             // system. addPluginChunkTicket is thread-safe per Paper.
@@ -700,6 +731,9 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
+                if (!chunkLoaded) {
+                    loadsThisHop++;
+                }
             } catch (Throwable t) {
                 // prepareChunk / onChunkResolved threw after this chunk was
                 // pinned: release its ticket here (it never reaches the post
@@ -1046,6 +1080,7 @@ public final class RollbackEngine {
         // runs of the sorted order share a chunk, so one walk groups them.
         List<ColChunk> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
+        int loadsThisHop = 0;
         try {
             while (cursor < total && batch.size() < maxBatchChunks) {
             int startIdx = order[cursor];
@@ -1058,6 +1093,13 @@ public final class RollbackEngine {
                     break;
                 }
                 rangeEnd++;
+            }
+            // #208: pace synchronous chunk loads across ticks (see the mirror in
+            // applyChunkBatchParallel). Already-loaded chunks resolve at full
+            // speed; a cold region spreads its blocking getChunk loads over hops.
+            boolean chunkLoaded = world.isChunkLoaded(cx, cz);
+            if (deferForChunkLoadPacing(chunkLoaded, loadsThisHop, batch.isEmpty())) {
+                break;
             }
             boolean ticketAdded = false;
             if (ticketHolder != null) {
@@ -1077,6 +1119,9 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
+                if (!chunkLoaded) {
+                    loadsThisHop++;
+                }
             } catch (Throwable t) {
                 // Release this chunk's just-added ticket before failing the
                 // batch; the rest are freed below (#127).

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackSortTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackSortTest.java
@@ -130,4 +130,35 @@ class RollbackSortTest {
         return new BlockSnapshot(Material.STONE, "minecraft:stone",
                 List.of(), List.of(), List.of(), List.of(), null);
     }
+
+    // ===== #208: chunk-load pacing decision ====================
+
+    @Test
+    void loadedChunksNeverDeferSoAnInViewRollbackRunsAtFullSpeed() {
+        // The common case: rolling back where a player stands, every chunk
+        // already loaded. Pacing must never kick in, whatever the hop count.
+        for (int loads = 0; loads < 100; loads++) {
+            assertThat(RollbackEngine.deferForChunkLoadPacing(true, loads, false))
+                    .as("a loaded chunk is never deferred (loadsThisHop=%d)", loads)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void firstUnloadedChunkOfAHopIsAlwaysResolved() {
+        // An empty batch never defers, so a fully cold region still makes
+        // progress at >= one chunk per hop (no starvation).
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 0, true)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 999, true)).isFalse();
+    }
+
+    @Test
+    void unloadedChunksAreDeferredOnceThePerHopCapIsReached() {
+        // Below the cap (4) an unloaded chunk still resolves; at/after it, with a
+        // non-empty batch, the loop defers the rest of this hop to the next tick.
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 0, false)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 3, false)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 4, false)).isTrue();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 5, false)).isTrue();
+    }
 }


### PR DESCRIPTION
The apply resolve phase pins + prepares up to worldWriteBatchChunks (16)
chunks per main-thread hop, and ChunkDirectWriter.prepareChunk's getChunk
blocks to load an unloaded chunk. Rolling back an unloaded region (offline
cleanup, a far box) could therefore trigger up to 16 blocking chunk loads
in a single tick and stall it; only the apply write phase had a tick budget,
not resolve.

Cap the number of chunks BLOCK-loaded per resolve hop (already-loaded chunks
don't count, so the common in-view rollback is unaffected) in both the
object and columnar resolve loops. A cold region now spreads its loads over
more hops, trading wall-time for TPS the same way the apply budget does. The
existing partial-batch resume (cursor / batchEnd) carries the deferred
chunks to the next tick, so every cell is still applied.

deferForChunkLoadPacing is package-private and unit-tested (loaded never
defers, an empty batch never defers so a cold region still progresses,
unloaded defers once the per-hop cap is reached); the existing chaos and
failsafe engine tests still pass.
