### PR TITLE
perf: getHolder(false) on container clicks + O(1)-amortized spill poll (#210)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
@@ -88,7 +88,10 @@ public final class ContainerTransactionListener implements RecordingListener {
             return;
         }
 
-        InventoryHolder holder = clicked.getHolder();
+        // getHolder(false): the listener only reads the holder's block location
+        // and type, so skip the tile-entity snapshot copy getHolder() builds on
+        // every container click (#210).
+        InventoryHolder holder = clicked.getHolder(false);
         if (holder instanceof ShulkerBox) {
             return;
         }
@@ -177,7 +180,7 @@ public final class ContainerTransactionListener implements RecordingListener {
         Inventory bottom = event.getView().getBottomInventory();
         boolean clickedIsTop = clicked.equals(top);
 
-        InventoryHolder topHolder = top.getHolder();
+        InventoryHolder topHolder = top.getHolder(false); // no snapshot copy (#210)
         if (topHolder instanceof ShulkerBox) {
             return;
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
@@ -65,6 +65,13 @@ public final class SpillBuffer {
     private final AtomicLong pendingRecords = new AtomicLong();
     private final AtomicLong pendingFiles = new AtomicLong();
     private final AtomicLong pendingBytes = new AtomicLong();
+    // Drain-thread-only ordered cache of segment paths still to replay, so
+    // draining N segments costs one directory listing per empty-cache refill
+    // instead of one listing per poll (the old oldestSegment() re-listed every
+    // call -> O(N^2) to drain a large backlog) (#210). poll()/ack() are the
+    // single drain thread per this class's contract, so it needs no locking; new
+    // spills (higher seq, sorted later) are picked up on the next refill.
+    private final java.util.ArrayDeque<Path> segmentCache = new java.util.ArrayDeque<>();
 
     public SpillBuffer(@Nullable Path dataFolder, boolean enabled, Logger logger) {
         this.logger = logger;
@@ -142,13 +149,14 @@ public final class SpillBuffer {
             return null;
         }
         // Skip past any unreadable segments (drop them) until a good one or none.
-        for (Path oldest = oldestSegment(); oldest != null; oldest = oldestSegment()) {
+        for (Path oldest = nextSegment(); oldest != null; oldest = nextSegment()) {
             try {
                 byte[] bytes = Files.readAllBytes(oldest);
                 return new Spilled(oldest, bytes.length, EventBatchCodec.decode(bytes));
             } catch (IOException | RuntimeException ex) {
                 // A segment that won't decode would wedge the drain forever;
                 // its records are unrecoverable, so drop it and move to the next.
+                // nextSegment() already removed it from the cache; delete the file.
                 logger.log(Level.WARNING, "Spyglass spill: dropping unreadable segment "
                         + oldest.getFileName() + " (" + ex.getMessage() + ")");
                 pendingRecords.addAndGet(-recordCountOf(oldest));
@@ -160,7 +168,8 @@ public final class SpillBuffer {
         return null;
     }
 
-    /** Delete a segment after its records were saved, and update counters. */
+    /** Delete a segment after its records were saved, and update counters. The
+     *  {@link #poll} that produced it already removed it from the cache. */
     void ack(Spilled spilled) {
         pendingRecords.addAndGet(-spilled.records().size());
         pendingFiles.decrementAndGet();
@@ -168,17 +177,22 @@ public final class SpillBuffer {
         deleteQuietly(spilled.file());
     }
 
+    /** Oldest not-yet-replayed segment, removed from the cache. Refills the
+     *  cache from disk (sorted, chronological) when it empties, so a run of
+     *  {@link #poll}s costs one listing per refill, not one per call. */
     @Nullable
-    private Path oldestSegment() {
-        try (Stream<Path> stream = Files.list(dir)) {
-            return stream
-                    .filter(p -> p.getFileName().toString().endsWith(EXTENSION))
-                    .min(Comparator.comparing(p -> p.getFileName().toString()))
-                    .orElse(null);
-        } catch (IOException ex) {
-            logger.log(Level.WARNING, "Spyglass spill: failed to list " + dir, ex);
-            return null;
+    private Path nextSegment() {
+        if (segmentCache.isEmpty()) {
+            try (Stream<Path> stream = Files.list(dir)) {
+                stream.filter(p -> p.getFileName().toString().endsWith(EXTENSION))
+                        .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                        .forEach(segmentCache::addLast);
+            } catch (IOException ex) {
+                logger.log(Level.WARNING, "Spyglass spill: failed to list " + dir, ex);
+                return null;
+            }
         }
+        return segmentCache.pollFirst();
     }
 
     private void seedFromExisting() {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
@@ -198,7 +198,7 @@ class ContainerTransactionListenerTest {
         when(holder.getBlock()).thenReturn(block);
 
         Inventory inventory = mock(Inventory.class);
-        when(inventory.getHolder()).thenReturn(holder);
+        when(inventory.getHolder(false)).thenReturn(holder); // #210: listener reads getHolder(false)
         when(inventory.getItem(slot)).thenReturn(slotItem);
 
         InventoryClickEvent event = mock(InventoryClickEvent.class);
@@ -232,7 +232,7 @@ class ContainerTransactionListenerTest {
         when(doubleChest.getRightSide()).thenReturn(right);
 
         Inventory inventory = mock(Inventory.class);
-        when(inventory.getHolder()).thenReturn(doubleChest);
+        when(inventory.getHolder(false)).thenReturn(doubleChest); // #210: getHolder(false)
         when(inventory.getItem(rawSlot)).thenReturn(slotItem);
 
         InventoryClickEvent event = mock(InventoryClickEvent.class);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
@@ -75,6 +75,44 @@ class SpillBufferTest {
     }
 
     @Test
+    void drainsManySegmentsInOrderIncludingOnesSpilledMidDrain(@TempDir Path dir) throws Exception {
+        // #210: the drain-thread segment cache must replay every segment
+        // oldest-first across an empty-cache refill, and pick up spills that
+        // land mid-drain (higher seq -> sorted after the cached ones).
+        SpillBuffer spill = new SpillBuffer(dir, true, LOG);
+        List<UUID> expected = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            UUID id = UUID.randomUUID();
+            expected.add(id);
+            spill.spill(batch(id));
+        }
+
+        List<UUID> drained = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            SpillBuffer.Spilled s = spill.poll();
+            drained.add(s.records().getFirst().id());
+            spill.ack(s);
+        }
+        // Two more spills after the cache was already populated + partly drained.
+        for (int i = 0; i < 2; i++) {
+            UUID id = UUID.randomUUID();
+            expected.add(id);
+            spill.spill(batch(id));
+        }
+        SpillBuffer.Spilled s;
+        while ((s = spill.poll()) != null) {
+            drained.add(s.records().getFirst().id());
+            spill.ack(s);
+        }
+
+        assertThat(drained)
+                .as("every segment replayed once, oldest-first, including mid-drain spills")
+                .containsExactlyElementsOf(expected);
+        assertThat(spill.hasPending()).isFalse();
+        assertThat(spill.pendingRecordCount()).isZero();
+    }
+
+    @Test
     void recoversSegmentsLeftByAPriorRun(@TempDir Path dir) throws Exception {
         UUID id = UUID.randomUUID();
         new SpillBuffer(dir, true, LOG).spill(batch(id, UUID.randomUUID()));


### PR DESCRIPTION
Two low-risk cleanups from the audit:

- ContainerTransactionListener fetched the clicked/top inventory holder via
  getHolder(), which builds a fresh tile-entity snapshot copy on every
  container click. The listener only reads the holder's block location and
  type, so getHolder(false) returns the live holder without the copy.

- SpillBuffer.poll() re-listed the whole spill directory every call
  (oldestSegment() did a Files.list + min per poll), so draining an N-segment
  backlog was O(N^2) directory scans. Replace it with a drain-thread-only
  ordered segment cache refilled once per empty-cache cycle; poll()/ack() are
  the single drain thread per the class contract, and mid-drain spills (higher
  seq, sorted later) are picked up on the next refill. New test drains many
  segments in order including ones spilled mid-drain; the existing round-trip,
  oldest-first, recovery, and corrupt-drop tests still pass.

The ChunkResender full-chunk broadcast (the third audit note) is left as is -
it is a deliberate, documented correctness tradeoff (over-send beats the
false-negatives smarter filters produced), only worth revisiting if it ever
bites. ContainerTransactionListenerTest fixtures updated to stub getHolder(false).
