### PR TITLE
fix(storage): close the ClickHouse read-your-writes gap on flush (#205)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -1219,4 +1219,27 @@ public final class ClickHouseRecordStore implements RecordStore {
             throw new RuntimeException("OPTIMIZE failed: " + ex.getMessage(), ex);
         }
     }
+
+    /**
+     * Force the server's async-insert buffer to disk so just-saved rows become
+     * SELECT-visible (#205). {@link #save} uses {@code async_insert=1,
+     * wait_for_async_insert=0} (fire-and-forget), so an acked row sits in the
+     * buffer for up to ~1s before a query can see it; the recorder calls this at
+     * the end of a read-your-writes flush so a rollback issued right after a
+     * burst doesn't read a partial picture. Durability is already covered by the
+     * Spyglass WAL; this closes the visibility gap.
+     */
+    @Override
+    public void flushPendingWrites() {
+        try (CommandResponse ignored = client.execute(
+                "SYSTEM FLUSH ASYNC INSERT QUEUE").get(30, TimeUnit.SECONDS)) {
+            // ack: pending async inserts are now flushed and queryable.
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("ClickHouse async-insert flush interrupted", ie);
+        } catch (Exception ex) {
+            throw new RuntimeException(
+                    "ClickHouse async-insert flush failed: " + ex.getMessage(), ex);
+        }
+    }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
@@ -17,6 +17,19 @@ public interface RecordStore extends AutoCloseable {
     void save(List<EventRecord> records);
 
     /**
+     * Force any records that {@link #save} has acknowledged but not yet made
+     * SELECT-visible to become visible, closing a read-your-writes gap before a
+     * rollback reads (#205). The default is a no-op: only a backend with async
+     * server-side insert buffering (ClickHouse's {@code async_insert}, where a
+     * saved row can sit in the server buffer for ~1s before it is queryable) has
+     * such a gap; SQLite, MariaDB, and Mongo are visible as soon as {@code save}
+     * returns. The recorder calls this after its flush drains the queue, so a
+     * rollback issued right after an event burst still reads every event.
+     */
+    default void flushPendingWrites() {
+    }
+
+    /**
      * Full-fat query: hydrates every persisted field of every record.
      * Use for rollback / restore / inspect — any path that has to reason
      * about the pre/post block state or the exact item payload.

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -198,6 +198,38 @@ class ClickHouseRecordStoreIT {
     }
 
     @Test
+    void flushPendingWritesMakesAsyncInsertsQueryable() {
+        // #205: save() is fire-and-forget async_insert, so rows are not SELECT-
+        // visible until the server buffer flushes. flushPendingWrites() - the
+        // method the recorder's read-your-writes flush calls - must force that
+        // buffer so a rollback issued right after a burst reads every event.
+        Instant now = Instant.now().minusSeconds(30);
+        BlockLocation location = new BlockLocation(WORLD, "world", 5, 64, 5);
+        Origin origin = Origin.player();
+        Source source = Source.player(ALICE, "Alice");
+        BlockSnapshot stone = new BlockSnapshot(org.bukkit.Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(org.bukkit.Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        List<EventRecord> records = new java.util.ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            records.add(new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
+                    origin, source, location, "test", "STONE", stone, air));
+        }
+        store.save(records);
+        // The method under test (not the private flushAsyncInserts helper) is
+        // what makes the just-saved async rows queryable.
+        store.flushPendingWrites();
+
+        QueryResult result = store.query(new QueryRequest(
+                List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
+                Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
+        assertThat(result.records())
+                .as("flushPendingWrites() makes every async-inserted row queryable")
+                .hasSize(8);
+    }
+
+    @Test
     void roundTripsBlockSnapshotThroughBsonBlob() {
         Instant now = Instant.now().minusSeconds(60);
         BlockLocation loc = new BlockLocation(WORLD, "world", 5, 64, 5);

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -509,6 +509,19 @@ public final class AsyncRecorder implements Recorder {
                 return false;
             }
         }
+        // The queue has fully drained to the store, but a backend with async
+        // server-side buffering (ClickHouse) may not have made those rows
+        // SELECT-visible yet, which would let a read-your-writes rollback read a
+        // partial picture (#205). Force the buffer out. No-op on the other
+        // backends; if it fails, the newest events may not be queryable, so
+        // report the flush as incomplete rather than falsely durable-and-visible.
+        try {
+            store.flushPendingWrites();
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass store visibility flush failed; the newest events"
+                    + " may not be queryable yet: " + ex.getMessage());
+            return false;
+        }
         return true;
     }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -136,6 +136,44 @@ class AsyncRecorderTest {
     }
 
     @Test
+    void flushForcesStoreVisibilityAfterDraining() {
+        // #205: after the queue drains, flush() forces the store to make the
+        // saved rows SELECT-visible (a no-op on most backends; the async-insert
+        // buffer flush on ClickHouse), so a read-your-writes rollback sees them.
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            for (int index = 0; index < 5; index++) {
+                recorder.record(sampleRecord());
+            }
+            assertThat(recorder.flush(Duration.parse("3s"))).isTrue();
+            assertThat(store.flushPendingCallCount())
+                    .as("flush forces store visibility once, after the queue drains")
+                    .isEqualTo(1);
+            assertThat(store.totalSaved()).isEqualTo(5);
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
+    void flushReturnsFalseWhenVisibilityFlushFails() {
+        // If forcing visibility fails (e.g. ClickHouse unreachable) flush() must
+        // report incomplete rather than claim the newest events are queryable.
+        CapturingStore store = new CapturingStore();
+        store.failVisibilityFlush = true;
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            recorder.record(sampleRecord());
+            assertThat(recorder.flush(Duration.parse("3s")))
+                    .as("a failed visibility flush makes flush() report incomplete")
+                    .isFalse();
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
     void flushAwaitsBarrierThenDrainsQueue() {
         // #98: flush drains the serialization barrier first, then the queue.
         CapturingStore store = new CapturingStore();
@@ -653,14 +691,30 @@ class AsyncRecorderTest {
 
     private static final class CapturingStore implements RecordStore {
         private final CopyOnWriteArrayList<EventRecord> all = new CopyOnWriteArrayList<>();
+        private final AtomicInteger flushPendingCalls = new AtomicInteger();
+        // #205: simulate a backend whose visibility flush (e.g. ClickHouse
+        // unreachable) fails, so flush() must report incomplete.
+        volatile boolean failVisibilityFlush;
 
         int totalSaved() {
             return all.size();
         }
 
+        int flushPendingCallCount() {
+            return flushPendingCalls.get();
+        }
+
         @Override
         public void save(List<EventRecord> records) {
             all.addAll(records);
+        }
+
+        @Override
+        public void flushPendingWrites() {
+            flushPendingCalls.incrementAndGet();
+            if (failVisibilityFlush) {
+                throw new RuntimeException("simulated visibility-flush failure");
+            }
         }
 
         @Override


### PR DESCRIPTION
ClickHouse save() uses async_insert=1, wait_for_async_insert=0
(fire-and-forget), so an acked row sits in the server's async-insert
buffer for up to ~1s before it is SELECT-visible. The recorder's flush
(the read-your-writes barrier a rollback relies on) waited only for the
queue to drain to the store, so a rollback issued within ~1s of a burst
could read a partial picture even though ingest, durability (the WAL), and
the flush barrier all reported success.

Add RecordStore.flushPendingWrites() (default no-op; SQLite/MariaDB/Mongo
are visible on save-return) and implement it on ClickHouse as SYSTEM FLUSH
ASYNC INSERT QUEUE. AsyncRecorder.flush() calls it after the queue drains,
returning false (flush incomplete) if it fails rather than claiming the
newest events are queryable.

AsyncRecorderTest covers both: flush forces visibility exactly once after
draining, and a failing visibility flush makes flush() report incomplete.
ClickHouseRecordStoreIT adds a read-your-writes case (save async, then
flushPendingWrites makes all rows queryable) - runs in CI with Docker.

NOTE: build + unit verified only; not live-verified against a running
ClickHouse (no CH/Docker available in this environment).
