### PR TITLE
Release 1.0.7

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,5 @@
+Mostly a performance pass on the storage backends and the rollback apply path.
+
+- Storage: cheaper SQLite/MariaDB retention sweeps, leaner Mongo inserts, and a fix for a ClickHouse read-after-flush visibility gap.
+- Rollback: salvage serialization moved off the main thread, paced chunk loads, faster container reads, and partial-drain rollbacks now log their backlog.
+- Fix: cascade dedup key no longer overflows the Y coordinate.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,13 @@ jobs:
           {
             echo "**Spyglass v${v}** - forensic logging & rollback for Paper 1.21.x (Java 21)."
             echo
+            # Brief "what was fixed" summary, maintained per release in this file.
+            if [ -f .github/release-notes.md ]; then
+              echo "### What's fixed"
+              echo
+              cat .github/release-notes.md
+              echo
+            fi
             echo "### Downloads"
             echo "- **\`Spyglass.jar\`** (recommended) - lean build. Paper's library loader"
             echo "  downloads its database driver, command framework, and config libs from"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.6
+version=1.0.7
 group=net.medievalrp
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -1219,4 +1219,27 @@ public final class ClickHouseRecordStore implements RecordStore {
             throw new RuntimeException("OPTIMIZE failed: " + ex.getMessage(), ex);
         }
     }
+
+    /**
+     * Force the server's async-insert buffer to disk so just-saved rows become
+     * SELECT-visible (#205). {@link #save} uses {@code async_insert=1,
+     * wait_for_async_insert=0} (fire-and-forget), so an acked row sits in the
+     * buffer for up to ~1s before a query can see it; the recorder calls this at
+     * the end of a read-your-writes flush so a rollback issued right after a
+     * burst doesn't read a partial picture. Durability is already covered by the
+     * Spyglass WAL; this closes the visibility gap.
+     */
+    @Override
+    public void flushPendingWrites() {
+        try (CommandResponse ignored = client.execute(
+                "SYSTEM FLUSH ASYNC INSERT QUEUE").get(30, TimeUnit.SECONDS)) {
+            // ack: pending async inserts are now flushed and queryable.
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("ClickHouse async-insert flush interrupted", ie);
+        } catch (Exception ex) {
+            throw new RuntimeException(
+                    "ClickHouse async-insert flush failed: " + ex.getMessage(), ex);
+        }
+    }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -121,6 +121,16 @@ public final class MariaDbRecordStore implements RecordStore {
     private static final long DEFAULT_RETENTION_SECONDS = 182L * 24 * 3600; // 26 weeks (~6 months)
     private static final long RETENTION_SWEEP_MINUTES = 60L;
     private static final int POST_FILTER_SCAN_CAP = 20_000;
+    // Rows deleted per retention batch. The sweep loops native DELETE ... LIMIT,
+    // releasing the write lock between batches, so a large expiry never holds
+    // the InnoDB write path or its undo/redo log in one transaction (#203).
+    private static final int PRUNE_BATCH_SIZE = 50_000;
+    // First sweep runs this soon after construction on the retention thread,
+    // never inline on the caller's (main) thread, so a large or long-offline DB
+    // can't stall plugin enable (#203).
+    private static final long INITIAL_SWEEP_DELAY_SECONDS = 5L;
+    // "Watermark unknown" sentinel: the oldest stored occurred is not yet seeded.
+    private static final long WATERMARK_UNKNOWN = Long.MIN_VALUE;
 
     // 14 columns, in bind order. Notably absent (folded / derived / generated,
     // see the class doc): expires_at, source_kind, player_name, world_name,
@@ -181,6 +191,12 @@ public final class MariaDbRecordStore implements RecordStore {
     private final MariaDbPredicateToSql predicateToSql = new MariaDbPredicateToSql(palette);
 
     private final ScheduledExecutorService retention;
+    // Lower bound (epoch seconds) on the oldest stored {@code occurred}, guarded
+    // by writeLock. When it is at or after the most-aggressive retention horizon,
+    // no record can have expired and the hourly sweep skips its scan (#203).
+    // Kept a lower bound (saves lower it, a completed prune raises it) and stays
+    // occurred-authoritative, so backfilled rows still expire by their real time.
+    private volatile long minOccurredSec = WATERMARK_UNKNOWN;
 
     public MariaDbRecordStore(String host, int port, String database, String user,
                               String password, boolean ssl, long retentionSeconds) {
@@ -275,9 +291,13 @@ public final class MariaDbRecordStore implements RecordStore {
                 t.setDaemon(true);
                 return t;
             });
+            // Seed the oldest-occurred watermark and run the first prune on the
+            // retention thread, not inline: the store is constructed in the
+            // plugin's onEnable() on the main thread and must not stall boot (#203).
+            this.retention.schedule(this::seedWatermarkAndPruneQuietly,
+                    INITIAL_SWEEP_DELAY_SECONDS, TimeUnit.SECONDS);
             this.retention.scheduleWithFixedDelay(this::pruneExpiredQuietly,
                     RETENTION_SWEEP_MINUTES, RETENTION_SWEEP_MINUTES, TimeUnit.MINUTES);
-            pruneExpiredQuietly();
         }
     }
 
@@ -430,11 +450,13 @@ public final class MariaDbRecordStore implements RecordStore {
             Map<String, Integer> pendingDict = new HashMap<>();
             Map<UUID, Integer> pendingUuid = new HashMap<>();
             Map<Integer, String> pendingNames = new HashMap<>();
+            long batchMinOccurred = Long.MAX_VALUE;
             try {
                 writeConn.setAutoCommit(false);
                 for (EventRecord record : records) {
                     bindRecord(record, pendingDict, pendingUuid, pendingNames);
                     insertStatement.addBatch();
+                    batchMinOccurred = Math.min(batchMinOccurred, record.occurred().getEpochSecond());
                 }
                 insertStatement.executeBatch();
                 writeConn.commit();
@@ -449,6 +471,8 @@ public final class MariaDbRecordStore implements RecordStore {
                     uuidReverse.put(id, uuid);
                 });
                 uuidName.putAll(pendingNames);
+                // Keep the retention watermark a valid lower bound (#203).
+                lowerWatermark(batchMinOccurred);
             } catch (SQLException ex) {
                 rollbackQuietly();
                 throw new RuntimeException("MariaDB save failed: " + ex.getMessage(), ex);
@@ -1170,54 +1194,148 @@ public final class MariaDbRecordStore implements RecordStore {
         }
     }
 
+    /** Off-thread boot task: seed the oldest-occurred watermark once, then run
+     *  the first prune - both off the main thread so enable never blocks (#203). */
+    private void seedWatermarkAndPruneQuietly() {
+        try {
+            seedWatermark();
+            pruneExpired();
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.WARNING, "MariaDB retention seed/sweep failed", ex);
+        }
+    }
+
     /**
      * Drop records past their retention horizon; the TTL analogue. Each event
      * type with a per-event {@code retention} override (#181) is swept at its own
-     * cutoff; everything else at the global default. With no overrides this is a
-     * single {@code DELETE ... WHERE occurred < cutoff}, identical to before.
+     * cutoff; everything else at the global default.
+     *
+     * <p>Cheap on a large table (#203): an in-memory lower bound on the oldest
+     * stored {@code occurred} lets a sweep skip in O(1) when nothing can have
+     * expired (so the hourly no-op stops being a full scan of the unindexed time
+     * column), and the delete is {@code LIMIT}-batched with the write lock
+     * released between batches so a real expiry never holds the InnoDB write path
+     * or its undo log in one transaction. The predicate stays {@code occurred <
+     * cutoff}, so retention is unchanged and backfilled rows still expire by their
+     * real timestamp.
      */
     public long pruneExpired() {
         if (readOnly) {
             return 0L;
         }
         long nowSec = System.currentTimeMillis() / 1000L;
-        synchronized (writeLock) {
-            try {
-                long deleted = 0L;
-                List<Integer> overrideIds = new ArrayList<>();
-                for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
-                    Integer dictId = resolveDictId(override.getKey());
-                    if (dictId == null) {
-                        continue; // this event type has never been recorded yet
-                    }
-                    overrideIds.add(dictId);
-                    try (PreparedStatement ps = writeConn.prepareStatement(
-                            "DELETE FROM records WHERE event = ? AND occurred < ?")) {
+        // O(1) skip: nothing can have expired when the oldest stored record is
+        // younger than even the most aggressive horizon. The watermark is a lower
+        // bound, so a stale-high read never skips a genuine expiry.
+        long watermark = minOccurredSec;
+        if (watermark != WATERMARK_UNKNOWN && watermark >= nowSec - retentionPolicy.minSeconds()) {
+            return 0L;
+        }
+        long deleted = 0L;
+        List<Integer> overrideIds = new ArrayList<>();
+        for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
+            Integer dictId = resolveDictId(override.getKey());
+            if (dictId == null) {
+                continue; // this event type has never been recorded yet
+            }
+            overrideIds.add(dictId);
+            long cutoff = nowSec - override.getValue();
+            deleted += pruneBatched(
+                    "DELETE FROM records WHERE event = ? AND occurred < ? LIMIT ?",
+                    ps -> {
                         ps.setInt(1, dictId);
-                        ps.setLong(2, nowSec - override.getValue());
-                        deleted += ps.executeUpdate();
-                    }
+                        ps.setLong(2, cutoff);
+                        ps.setInt(3, PRUNE_BATCH_SIZE);
+                    });
+        }
+        long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
+        StringBuilder sql = new StringBuilder("DELETE FROM records WHERE occurred < ?");
+        if (!overrideIds.isEmpty()) {
+            sql.append(" AND event NOT IN (").append(placeholders(overrideIds.size())).append(')');
+        }
+        sql.append(" LIMIT ?");
+        String defaultSql = sql.toString();
+        deleted += pruneBatched(defaultSql, ps -> {
+            int idx = 1;
+            ps.setLong(idx++, defaultCutoff);
+            for (Integer id : overrideIds) {
+                ps.setInt(idx++, id);
+            }
+            ps.setInt(idx, PRUNE_BATCH_SIZE);
+        });
+        // A sweep ran: every survivor is at least as recent as the least-
+        // aggressive cutoff, so raise the watermark to it (still a lower bound).
+        raiseWatermark(nowSec - retentionPolicy.maxSeconds());
+        return deleted;
+    }
+
+    /**
+     * Run a {@code LIMIT}-batched delete until a batch removes fewer than the
+     * batch size, taking and releasing the write lock per batch so the ingest
+     * drain can slip in between batches (#203).
+     */
+    private long pruneBatched(String sql, SqlBinder binder) {
+        long total = 0L;
+        while (true) {
+            int removed;
+            synchronized (writeLock) {
+                try (PreparedStatement ps = writeConn.prepareStatement(sql)) {
+                    binder.bind(ps);
+                    removed = ps.executeUpdate();
+                } catch (SQLException ex) {
+                    throw new RuntimeException("MariaDB retention prune failed: " + ex.getMessage(), ex);
                 }
-                long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
-                StringBuilder sql = new StringBuilder("DELETE FROM records WHERE occurred < ?");
-                if (!overrideIds.isEmpty()) {
-                    sql.append(" AND event NOT IN (");
-                    sql.append("?,".repeat(overrideIds.size()));
-                    sql.setLength(sql.length() - 1);
-                    sql.append(')');
-                }
-                try (PreparedStatement ps = writeConn.prepareStatement(sql.toString())) {
-                    ps.setLong(1, defaultCutoff);
-                    for (int i = 0; i < overrideIds.size(); i++) {
-                        ps.setInt(2 + i, overrideIds.get(i));
-                    }
-                    deleted += ps.executeUpdate();
-                }
-                return deleted;
+            }
+            total += removed;
+            if (removed < PRUNE_BATCH_SIZE) {
+                return total;
+            }
+            Thread.yield();
+        }
+    }
+
+    /** Seed the oldest-occurred watermark from the table (one min() scan at
+     *  boot, off-thread). Empty table seeds to "far future" so sweeps skip. */
+    private void seedWatermark() {
+        synchronized (writeLock) {
+            try (Statement st = writeConn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT min(occurred) FROM records")) {
+                long value = rs.next() ? rs.getLong(1) : 0L;
+                minOccurredSec = rs.wasNull() ? Long.MAX_VALUE : value;
             } catch (SQLException ex) {
-                throw new RuntimeException("MariaDB retention prune failed: " + ex.getMessage(), ex);
+                throw new RuntimeException("MariaDB watermark seed failed: " + ex.getMessage(), ex);
             }
         }
+    }
+
+    /** Lower the watermark toward a just-inserted batch's oldest occurred so it
+     *  stays a valid lower bound. No-op until seeded. */
+    private void lowerWatermark(long occurredSec) {
+        synchronized (writeLock) {
+            if (minOccurredSec != WATERMARK_UNKNOWN && occurredSec < minOccurredSec) {
+                minOccurredSec = occurredSec;
+            }
+        }
+    }
+
+    /** Raise the watermark after a completed prune (every survivor is at least
+     *  this recent). No-op until seeded. */
+    private void raiseWatermark(long floorSec) {
+        synchronized (writeLock) {
+            if (minOccurredSec != WATERMARK_UNKNOWN && floorSec > minOccurredSec) {
+                minOccurredSec = floorSec;
+            }
+        }
+    }
+
+    private static String placeholders(int count) {
+        return count <= 0 ? "" : "?,".repeat(count).substring(0, count * 2 - 1);
+    }
+
+    /** Binds the parameters of one prune batch. */
+    @FunctionalInterface
+    private interface SqlBinder {
+        void bind(PreparedStatement ps) throws SQLException;
     }
 
     /** Total record rows - test / benchmark helper. */

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -253,19 +253,53 @@ public final class MongoRecordStore implements RecordStore {
             polymorphicCollection.insertMany(records);
             return;
         }
-        // #181: per-event-type expiry. The TTL index is on expiresAt, so encode
-        // each record and overwrite that field per type before insert. Same BSON
-        // as the typed path (same codec), just a per-type expiresAt - so the
-        // chunk-bucket fields, _id mapping, and zstd compression are unchanged.
-        List<BsonDocument> docs = new ArrayList<>(records.size());
+        // #181: per-event-type expiry. A record whose stored expiresAt already
+        // equals its per-event target inserts via the streaming typed codec - the
+        // same allocation-free path as the no-policy branch above - and only a
+        // record needing a DIFFERENT expiry (a per-event override) is re-encoded
+        // into a BsonDocument and patched. Previously every record built that
+        // tree, which dominated the drain-thread heap under load (#206), the same
+        // materialized-tree cost #125 removed from the spill/WAL codec. Both paths
+        // store the same per-type expiresAt, so the TTL index, chunk-bucket
+        // fields, _id mapping, and zstd compression are unchanged.
+        List<EventRecord> direct = null;
+        List<BsonDocument> patched = null;
         for (EventRecord record : records) {
-            BsonDocument doc = new BsonDocument();
-            eventCodec.encode(new BsonDocumentWriter(doc), record, EncoderContext.builder().build());
-            doc.put(RecordFields.EXPIRES_AT, new BsonDateTime(
-                    retentionPolicy.expiresAt(record.occurred(), record.event()).toEpochMilli()));
-            docs.add(doc);
+            if (expiryAlreadyCorrect(record, retentionPolicy)) {
+                if (direct == null) {
+                    direct = new ArrayList<>(records.size());
+                }
+                direct.add(record);
+            } else {
+                if (patched == null) {
+                    patched = new ArrayList<>();
+                }
+                BsonDocument doc = new BsonDocument();
+                eventCodec.encode(new BsonDocumentWriter(doc), record, EncoderContext.builder().build());
+                doc.put(RecordFields.EXPIRES_AT, new BsonDateTime(
+                        retentionPolicy.expiresAt(record.occurred(), record.event()).toEpochMilli()));
+                patched.add(doc);
+            }
         }
-        rawCollection.insertMany(docs);
+        if (direct != null) {
+            polymorphicCollection.insertMany(direct);
+        }
+        if (patched != null) {
+            rawCollection.insertMany(patched);
+        }
+    }
+
+    /**
+     * True when a record's stored {@code expiresAt} already equals its per-event
+     * retention target, so it inserts via the streaming typed codec with no
+     * expiry patch (#206). A record stamped with the global default retention
+     * matches for every non-overridden event type - the common case - so only
+     * override-type (or oddly-stamped, or null-expiry) records pay the re-encode.
+     */
+    static boolean expiryAlreadyCorrect(EventRecord record, RetentionPolicy policy) {
+        Instant expiresAt = record.expiresAt();
+        return expiresAt != null
+                && policy.expiresAt(record.occurred(), record.event()).equals(expiresAt);
     }
 
     @Override

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
@@ -17,6 +17,19 @@ public interface RecordStore extends AutoCloseable {
     void save(List<EventRecord> records);
 
     /**
+     * Force any records that {@link #save} has acknowledged but not yet made
+     * SELECT-visible to become visible, closing a read-your-writes gap before a
+     * rollback reads (#205). The default is a no-op: only a backend with async
+     * server-side insert buffering (ClickHouse's {@code async_insert}, where a
+     * saved row can sit in the server buffer for ~1s before it is queryable) has
+     * such a gap; SQLite, MariaDB, and Mongo are visible as soon as {@code save}
+     * returns. The recorder calls this after its flush drains the queue, so a
+     * rollback issued right after an event burst still reads every event.
+     */
+    default void flushPendingWrites() {
+    }
+
+    /**
      * Full-fat query: hydrates every persisted field of every record.
      * Use for rollback / restore / inspect — any path that has to reason
      * about the pre/post block state or the exact item payload.

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicy.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RetentionPolicy.java
@@ -75,6 +75,33 @@ public final class RetentionPolicy {
         return defaultSeconds;
     }
 
+    /**
+     * The most aggressive (smallest) retention across the default and every
+     * override - the horizon before which no record of any type can have
+     * expired. A prune-sweep can skip entirely when the oldest stored record is
+     * younger than this (#203).
+     */
+    public long minSeconds() {
+        long min = defaultSeconds;
+        for (long seconds : perEventSeconds.values()) {
+            min = Math.min(min, seconds);
+        }
+        return min;
+    }
+
+    /**
+     * The least aggressive (largest) retention across the default and every
+     * override - a lower bound on how old a surviving record can be right after
+     * a sweep (used to advance the oldest-record watermark, #203).
+     */
+    public long maxSeconds() {
+        long max = defaultSeconds;
+        for (long seconds : perEventSeconds.values()) {
+            max = Math.max(max, seconds);
+        }
+        return max;
+    }
+
     /** The per-event overrides (event-name -> seconds); never null, may be empty. */
     public Map<String, Long> overrides() {
         return perEventSeconds;

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -118,6 +118,19 @@ public final class SqliteRecordStore implements RecordStore {
     private static final long DEFAULT_RETENTION_SECONDS = 182L * 24 * 3600; // 26 weeks (~6 months)
     private static final long RETENTION_SWEEP_MINUTES = 60L;
     private static final int POST_FILTER_SCAN_CAP = 20_000;
+    // Rows deleted per retention batch. The sweep loops this in autocommit
+    // transactions, releasing the write lock between batches, so a large
+    // expiry never freezes the ingest drain or balloons the WAL in one shot
+    // (#203). The occurred filter clusters expired rows at the low-rowid front
+    // for live-ingested data, so each batch scans ~this many rows, not the table.
+    private static final int PRUNE_BATCH_SIZE = 50_000;
+    // First sweep runs this soon after construction on the retention thread,
+    // never inline on the caller's (main) thread, so a large or long-offline
+    // DB can't stall plugin enable (#203).
+    private static final long INITIAL_SWEEP_DELAY_SECONDS = 5L;
+    // "Watermark unknown" sentinel: the store has not yet seeded the oldest
+    // stored occurred, so a sweep cannot take the O(1) skip fast path.
+    private static final long WATERMARK_UNKNOWN = Long.MIN_VALUE;
 
     // 14 columns, in bind order. Notably absent (folded/derived, see the
     // class doc): expires_at, source_kind, player_name, world_name,
@@ -174,6 +187,16 @@ public final class SqliteRecordStore implements RecordStore {
     private final SqlitePredicateToSql predicateToSql = new SqlitePredicateToSql(palette);
 
     private final ScheduledExecutorService retention;
+    // Lower bound (epoch seconds) on the oldest {@code occurred} still stored,
+    // guarded by writeLock. When it is at or after the most-aggressive retention
+    // horizon, no record can have expired and the hourly sweep skips its scan
+    // entirely - turning the common no-op sweep from a full-table scan into an
+    // O(1) comparison (#203). Kept a lower bound so the skip is always safe:
+    // saves lower it toward newly inserted rows, a completed prune raises it to
+    // the least-aggressive cutoff (every survivor is at least that recent), and
+    // it stays occurred-authoritative so backfilled rows (id minted now, occurred
+    // backdated) still expire by their real timestamp.
+    private volatile long minOccurredSec = WATERMARK_UNKNOWN;
 
     public SqliteRecordStore(Path dbFile) {
         this(dbFile, false, DEFAULT_READ_POOL, DEFAULT_RETENTION_SECONDS);
@@ -243,9 +266,14 @@ public final class SqliteRecordStore implements RecordStore {
                 t.setDaemon(true);
                 return t;
             });
+            // Seed the oldest-occurred watermark and run the first prune on the
+            // retention thread, not inline: the store is constructed in the
+            // plugin's onEnable() on the main thread, and the seed's one-time
+            // min(occurred) scan (plus any real prune) must not stall boot (#203).
+            this.retention.schedule(this::seedWatermarkAndPruneQuietly,
+                    INITIAL_SWEEP_DELAY_SECONDS, TimeUnit.SECONDS);
             this.retention.scheduleWithFixedDelay(this::pruneExpiredQuietly,
                     RETENTION_SWEEP_MINUTES, RETENTION_SWEEP_MINUTES, TimeUnit.MINUTES);
-            pruneExpiredQuietly();
         }
     }
 
@@ -349,11 +377,13 @@ public final class SqliteRecordStore implements RecordStore {
             Map<String, Integer> pendingDict = new HashMap<>();
             Map<UUID, Integer> pendingUuid = new HashMap<>();
             Map<Integer, String> pendingNames = new HashMap<>();
+            long batchMinOccurred = Long.MAX_VALUE;
             try {
                 writeConn.setAutoCommit(false);
                 for (EventRecord record : records) {
                     bindRecord(record, pendingDict, pendingUuid, pendingNames);
                     insertStatement.addBatch();
+                    batchMinOccurred = Math.min(batchMinOccurred, record.occurred().getEpochSecond());
                 }
                 insertStatement.executeBatch();
                 writeConn.commit();
@@ -368,6 +398,9 @@ public final class SqliteRecordStore implements RecordStore {
                     uuidReverse.put(id, uuid);
                 });
                 uuidName.putAll(pendingNames);
+                // Keep the retention watermark a valid lower bound: a batch may
+                // carry an older occurred than anything seen so far (#203).
+                lowerWatermark(batchMinOccurred);
             } catch (SQLException ex) {
                 rollbackQuietly();
                 throw new RuntimeException("SQLite save failed: " + ex.getMessage(), ex);
@@ -1053,57 +1086,182 @@ public final class SqliteRecordStore implements RecordStore {
         }
     }
 
+    /** Off-thread boot task: seed the oldest-occurred watermark once, then run
+     *  the first prune - both off the main thread so enable never blocks (#203). */
+    private void seedWatermarkAndPruneQuietly() {
+        try {
+            seedWatermark();
+            pruneExpired();
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.WARNING, "SQLite retention seed/sweep failed", ex);
+        }
+    }
+
     /**
      * Drop records past their retention horizon; the SQLite TTL analogue. Each
      * event type with a per-event {@code retention} override (#181) is swept at
-     * its own cutoff; everything else at the global default. With no overrides
-     * this is a single {@code DELETE ... WHERE occurred < cutoff}, identical to
-     * before. The {@code event} dict id is reused, so the sweep filters on the
-     * interned event column directly - no extra schema.
+     * its own cutoff; everything else at the global default.
+     *
+     * <p>Two changes make this cheap on a large table (#203). First, an O(1)
+     * skip: an in-memory lower bound on the oldest stored {@code occurred} lets
+     * a sweep return immediately when nothing can have expired, so the common
+     * hourly no-op stops being a full-table scan of the unindexed time column.
+     * Second, the delete is LIMIT-batched and releases the write lock between
+     * batches, so a real expiry (or a retention reduction that trims millions of
+     * rows) never holds the lock in one transaction or balloons the WAL. The
+     * predicate stays {@code occurred < cutoff}, so retention is unchanged and
+     * backfilled rows (id minted now, occurred backdated) still expire by their
+     * real timestamp.
      */
     public long pruneExpired() {
         if (readOnly) {
             return 0L;
         }
         long nowSec = System.currentTimeMillis() / 1000L;
-        synchronized (writeLock) {
-            try {
-                long deleted = 0L;
-                List<Integer> overrideIds = new ArrayList<>();
-                for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
-                    Integer dictId = resolveDictId(override.getKey());
-                    if (dictId == null) {
-                        continue; // this event type has never been recorded yet
-                    }
-                    overrideIds.add(dictId);
-                    try (PreparedStatement ps = writeConn.prepareStatement(
-                            "DELETE FROM records WHERE event = ? AND occurred < ?")) {
+        // O(1) skip: if the oldest stored record is younger than even the most
+        // aggressive horizon, nothing has expired. The watermark is a lower
+        // bound, so a stale-high read can never skip a genuine expiry - at worst
+        // a row inserted concurrently is swept on the next pass.
+        long watermark = minOccurredSec;
+        if (watermark != WATERMARK_UNKNOWN && watermark >= nowSec - retentionPolicy.minSeconds()) {
+            return 0L;
+        }
+        long deleted = 0L;
+        List<Integer> overrideIds = new ArrayList<>();
+        for (Map.Entry<String, Long> override : retentionPolicy.overrides().entrySet()) {
+            Integer dictId = resolveDictId(override.getKey());
+            if (dictId == null) {
+                continue; // this event type has never been recorded yet
+            }
+            overrideIds.add(dictId);
+            long cutoff = nowSec - override.getValue();
+            deleted += pruneBatched(
+                    "DELETE FROM records WHERE rowid IN ("
+                            + "SELECT rowid FROM records WHERE event = ? AND occurred < ? LIMIT ?)",
+                    ps -> {
                         ps.setInt(1, dictId);
-                        ps.setLong(2, nowSec - override.getValue());
-                        deleted += ps.executeUpdate();
-                    }
+                        ps.setLong(2, cutoff);
+                        ps.setInt(3, pruneBatchSize);
+                    });
+        }
+        // Everything without an override: the global default cutoff.
+        long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
+        StringBuilder inner = new StringBuilder("SELECT rowid FROM records WHERE occurred < ?");
+        if (!overrideIds.isEmpty()) {
+            inner.append(" AND event NOT IN (").append(placeholders(overrideIds.size())).append(')');
+        }
+        inner.append(" LIMIT ?");
+        String defaultSql = "DELETE FROM records WHERE rowid IN (" + inner + ")";
+        deleted += pruneBatched(defaultSql, ps -> {
+            int idx = 1;
+            ps.setLong(idx++, defaultCutoff);
+            for (Integer id : overrideIds) {
+                ps.setInt(idx++, id);
+            }
+            ps.setInt(idx, pruneBatchSize);
+        });
+        // A sweep ran: every survivor is now at least as recent as the
+        // least-aggressive cutoff, so raise the watermark to it (still a lower
+        // bound - a never-expiring type keeps it low, which is correct).
+        raiseWatermark(nowSec - retentionPolicy.maxSeconds());
+        return deleted;
+    }
+
+    /**
+     * Run a LIMIT-batched delete until a batch removes fewer than the batch
+     * size, taking (and releasing) the write lock per batch so the ingest drain
+     * can slip in between batches and the WAL auto-checkpoints (#203). For
+     * live-ingested data the expired rows cluster at the low-rowid front, so
+     * each batch's inner {@code SELECT ... LIMIT} scans about one batch of rows,
+     * not the whole table.
+     */
+    private long pruneBatched(String sql, SqlBinder binder) {
+        long total = 0L;
+        while (true) {
+            int removed;
+            synchronized (writeLock) {
+                try (PreparedStatement ps = writeConn.prepareStatement(sql)) {
+                    binder.bind(ps);
+                    removed = ps.executeUpdate();
+                } catch (SQLException ex) {
+                    throw new RuntimeException("SQLite retention prune failed: " + ex.getMessage(), ex);
                 }
-                // Everything without an override: the global default cutoff.
-                long defaultCutoff = nowSec - retentionPolicy.defaultSeconds();
-                StringBuilder sql = new StringBuilder("DELETE FROM records WHERE occurred < ?");
-                if (!overrideIds.isEmpty()) {
-                    sql.append(" AND event NOT IN (");
-                    sql.append("?,".repeat(overrideIds.size()));
-                    sql.setLength(sql.length() - 1);
-                    sql.append(')');
-                }
-                try (PreparedStatement ps = writeConn.prepareStatement(sql.toString())) {
-                    ps.setLong(1, defaultCutoff);
-                    for (int i = 0; i < overrideIds.size(); i++) {
-                        ps.setInt(2 + i, overrideIds.get(i));
-                    }
-                    deleted += ps.executeUpdate();
-                }
-                return deleted;
+            }
+            total += removed;
+            if (removed < pruneBatchSize) {
+                return total;
+            }
+            // Lock released above between batches; yield so a waiting save() runs.
+            Thread.yield();
+        }
+    }
+
+    /** Seed the oldest-occurred watermark from the table (one min() scan, run
+     *  off-thread at boot). An empty table seeds to "far future" so sweeps skip
+     *  until a save lowers it. */
+    private void seedWatermark() {
+        synchronized (writeLock) {
+            try (Statement st = writeConn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT min(occurred) FROM records")) {
+                // min() over an empty table is one row whose value is SQL NULL;
+                // getLong returns 0 for NULL, so wasNull() (read AFTER getLong)
+                // distinguishes an empty table from a genuine epoch-0 row.
+                long value = rs.next() ? rs.getLong(1) : 0L;
+                minOccurredSec = rs.wasNull() ? Long.MAX_VALUE : value;
             } catch (SQLException ex) {
-                throw new RuntimeException("SQLite retention prune failed: " + ex.getMessage(), ex);
+                throw new RuntimeException("SQLite watermark seed failed: " + ex.getMessage(), ex);
             }
         }
+    }
+
+    /** Lower the watermark toward a just-inserted batch's oldest occurred, so it
+     *  stays a valid lower bound. No-op until the watermark has been seeded. */
+    private void lowerWatermark(long occurredSec) {
+        synchronized (writeLock) {
+            if (minOccurredSec != WATERMARK_UNKNOWN && occurredSec < minOccurredSec) {
+                minOccurredSec = occurredSec;
+            }
+        }
+    }
+
+    /** Raise the watermark after a completed prune (every survivor is at least
+     *  this recent). No-op until seeded. */
+    private void raiseWatermark(long floorSec) {
+        synchronized (writeLock) {
+            if (minOccurredSec != WATERMARK_UNKNOWN && floorSec > minOccurredSec) {
+                minOccurredSec = floorSec;
+            }
+        }
+    }
+
+    private static String placeholders(int count) {
+        return count <= 0 ? "" : "?,".repeat(count).substring(0, count * 2 - 1);
+    }
+
+    /** Binds the parameters of one prune batch. */
+    @FunctionalInterface
+    private interface SqlBinder {
+        void bind(PreparedStatement ps) throws SQLException;
+    }
+
+    // Test seam (#203): shrink the delete batch so a batching test needn't insert
+    // PRUNE_BATCH_SIZE rows. Production always uses PRUNE_BATCH_SIZE.
+    private volatile int pruneBatchSize = PRUNE_BATCH_SIZE;
+
+    void pruneBatchSizeForTest(int size) {
+        this.pruneBatchSize = Math.max(1, size);
+    }
+
+    /** Visible for tests: the current oldest-occurred watermark (epoch seconds),
+     *  or {@link #WATERMARK_UNKNOWN} before it is seeded. */
+    long oldestOccurredWatermarkForTest() {
+        return minOccurredSec;
+    }
+
+    /** Visible for tests: seed the watermark synchronously (production seeds it
+     *  off-thread a few seconds after construction). */
+    void seedWatermarkForTest() {
+        seedWatermark();
     }
 
     /** Fold the WAL back into the main db file (bounds the -wal sidecar). */

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -198,6 +198,38 @@ class ClickHouseRecordStoreIT {
     }
 
     @Test
+    void flushPendingWritesMakesAsyncInsertsQueryable() {
+        // #205: save() is fire-and-forget async_insert, so rows are not SELECT-
+        // visible until the server buffer flushes. flushPendingWrites() - the
+        // method the recorder's read-your-writes flush calls - must force that
+        // buffer so a rollback issued right after a burst reads every event.
+        Instant now = Instant.now().minusSeconds(30);
+        BlockLocation location = new BlockLocation(WORLD, "world", 5, 64, 5);
+        Origin origin = Origin.player();
+        Source source = Source.player(ALICE, "Alice");
+        BlockSnapshot stone = new BlockSnapshot(org.bukkit.Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(org.bukkit.Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        List<EventRecord> records = new java.util.ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            records.add(new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
+                    origin, source, location, "test", "STONE", stone, air));
+        }
+        store.save(records);
+        // The method under test (not the private flushAsyncInserts helper) is
+        // what makes the just-saved async rows queryable.
+        store.flushPendingWrites();
+
+        QueryResult result = store.query(new QueryRequest(
+                List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
+                Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
+        assertThat(result.records())
+                .as("flushPendingWrites() makes every async-inserted row queryable")
+                .hasSize(8);
+    }
+
+    @Test
     void roundTripsBlockSnapshotThroughBsonBlob() {
         Instant now = Instant.now().minusSeconds(60);
         BlockLocation loc = new BlockLocation(WORLD, "world", 5, 64, 5);

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreExpiryTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreExpiryTest.java
@@ -1,0 +1,85 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import java.util.Map;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Headless coverage of the Mongo save routing (#206): a record whose stored
+ * expiresAt already equals its per-event target takes the streaming typed insert
+ * (no BsonDocument tree); only a record needing a different expiry is re-encoded
+ * and patched. This pins {@link MongoRecordStore#expiryAlreadyCorrect} without a
+ * Mongo connection - the full round-trip is covered by the Testcontainers IT.
+ */
+class MongoRecordStoreExpiryTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000cd");
+    private static final Instant OCCURRED = Instant.parse("2026-04-23T12:00:00Z");
+
+    private static BlockBreakRecord record(String event, Instant expiresAt) {
+        BlockSnapshot stone = new BlockSnapshot(Material.STONE, "minecraft:stone",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockBreakRecord(UUID.randomUUID(), event, OCCURRED, expiresAt,
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD, "world", 1, 64, 1), "srv", "STONE", stone, air);
+    }
+
+    @Test
+    void defaultRetentionTypeStampedWithDefaultTakesTheStreamedPath() {
+        // "place" has no override, and the record carries occurred + default, so
+        // its stored expiresAt already equals the target -> no patch needed.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord place = record("place", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(place, policy)).isTrue();
+    }
+
+    @Test
+    void overriddenTypeStampedWithDefaultNeedsThePatch() {
+        // "break" is overridden to 100s but the record was stamped with the 3600s
+        // global default, so the target differs -> must be re-encoded and patched.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord brk = record("break", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(brk, policy)).isFalse();
+    }
+
+    @Test
+    void overriddenTypeAlreadyStampedWithItsOverrideTakesTheStreamedPath() {
+        // If a record already carries its override expiry, no patch is needed.
+        RetentionPolicy policy = new RetentionPolicy(3600L, Map.of("break", 100L));
+        EventRecord brk = record("break", OCCURRED.plusSeconds(100L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(brk, policy)).isTrue();
+    }
+
+    @Test
+    void nullExpiresAtNeedsThePatch() {
+        RetentionPolicy policy = RetentionPolicy.uniform(3600L);
+        EventRecord noExpiry = record("place", null);
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(noExpiry, policy)).isFalse();
+    }
+
+    @Test
+    void neverRetentionClampsToTheCeilingSoAStampedDefaultNeedsThePatch() {
+        // "say" kept forever: target is the clamped MAX_EXPIRY, not occurred +
+        // default, so a default-stamped record is patched up to the ceiling.
+        RetentionPolicy policy = new RetentionPolicy(3600L,
+                Map.of("say", RetentionPolicy.NEVER_SECONDS));
+        EventRecord say = record("say", OCCURRED.plusSeconds(3600L));
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(say, policy)).isFalse();
+
+        EventRecord alreadyNever = record("say", RetentionPolicy.MAX_EXPIRY);
+        assertThat(MongoRecordStore.expiryAlreadyCorrect(alreadyNever, policy)).isTrue();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStoreIT.java
@@ -100,13 +100,20 @@ class MongoRecordStoreIT {
             policyStore.database().getCollection("EventRecords", org.bson.BsonDocument.class)
                     .deleteMany(new org.bson.BsonDocument());
             policyStore.save(List.of(
+                    // break + say are overridden -> the encode-and-patch write path.
                     new BlockBreakRecord(UUID.randomUUID(), "break", now, now.plusSeconds(3600),
                             origin, source, loc, "t", "STONE", stone, air),
                     new ChatRecord(UUID.randomUUID(), "say", now, now.plusSeconds(3600),
-                            origin, source, loc, "t", "Alice", "hi", List.of(), Map.of())));
+                            origin, source, loc, "t", "Alice", "hi", List.of(), Map.of()),
+                    // place is NOT overridden and is stamped with the default
+                    // retention, so it takes the streaming typed insert (#206); it
+                    // must still round-trip the default expiresAt.
+                    new BlockPlaceRecord(UUID.randomUUID(), "place", now, now.plusSeconds(3600),
+                            origin, source, loc, "t", "STONE", air, stone)));
 
             // Read back through the store's typed query; expiresAt is the stored
-            // per-type value the encode-and-patch write produced.
+            // per-type value (the patched write for overrides, the record's own
+            // default for the streamed non-override).
             QueryResult res = policyStore.query(new QueryRequest(
                     List.of(new QueryPredicate.Eq("source.playerId", ALICE)),
                     Sort.NEWEST_FIRST, 50, EnumSet.noneOf(Flag.class), false));
@@ -114,12 +121,17 @@ class MongoRecordStoreIT {
                     .filter(r -> r.event().equals("break")).findFirst().orElseThrow();
             EventRecord say = res.records().stream()
                     .filter(r -> r.event().equals("say")).findFirst().orElseThrow();
+            EventRecord place = res.records().stream()
+                    .filter(r -> r.event().equals("place")).findFirst().orElseThrow();
             assertThat(brk.expiresAt())
-                    .as("break stored expiresAt = occurred + its 100s retention")
+                    .as("break stored expiresAt = occurred + its 100s retention (patched)")
                     .isEqualTo(now.plusSeconds(100L));
             assertThat(say.expiresAt())
-                    .as("say stored expiresAt = the clamped never ceiling")
+                    .as("say stored expiresAt = the clamped never ceiling (patched)")
                     .isEqualTo(RetentionPolicy.MAX_EXPIRY);
+            assertThat(place.expiresAt())
+                    .as("place stored expiresAt = occurred + the 3600s default (streamed, #206)")
+                    .isEqualTo(now.plusSeconds(3600L));
         } finally {
             policyStore.close();
         }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStoreTest.java
@@ -534,6 +534,85 @@ class SqliteRecordStoreTest {
                 .isEqualTo(old.plusSeconds(3600));
     }
 
+    @Test
+    void noOpSweepIsSkippedOnceTheWatermarkIsSeeded() throws SQLException {
+        // Only fresh rows: after seeding, the oldest occurred is recent, so the
+        // hourly sweep takes the O(1) skip path instead of scanning (#203).
+        store.save(List.of(simpleBreak(1), simpleBreak(2)));
+        store.seedWatermarkForTest();
+        assertThat(store.oldestOccurredWatermarkForTest())
+                .as("watermark seeded to the oldest stored occurred")
+                .isGreaterThan(BASE.minusSeconds(RETENTION).getEpochSecond());
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned).isZero();
+        assertThat(rawCount("records")).isEqualTo(2L);
+    }
+
+    @Test
+    void prunesBackdatedRowByOccurredNotBySequence() throws SQLException {
+        // The row's id is minted NOW (a recent sequence) but its occurred is far
+        // in the past - the shape a bulk import produces. Retention keys on
+        // occurred, so it is pruned; a sequence-range sweep would wrongly keep it
+        // (its recent seq sits above any old-time bound). Pins #203's choice to
+        // stay occurred-authoritative rather than swap to a seq predicate.
+        Instant old = BASE.minusSeconds(5 * RETENTION);
+        UUID recentId = EventIds.newId();
+        BlockBreakRecord backdated = new BlockBreakRecord(recentId, "break",
+                old, old.plusSeconds(RETENTION),
+                Origin.player(), Source.player(UUID.randomUUID(), "Import"),
+                new BlockLocation(WORLD, "world", 3, 64, 3), "srv", "STONE",
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"));
+        store.save(List.of(backdated, simpleBreak(1)));
+
+        // Watermark unseeded here, so the sweep runs its full occurred filter.
+        long pruned = store.pruneExpired();
+        assertThat(pruned).isEqualTo(1L);
+        assertThat(store.query(request(List.of())).records())
+                .extracting(EventRecord::id)
+                .doesNotContain(recentId);
+    }
+
+    @Test
+    void batchedSweepDeletesEveryExpiredRowAcrossBatches() throws SQLException {
+        store.pruneBatchSizeForTest(50);
+        List<EventRecord> old = new ArrayList<>();
+        for (int i = 0; i < 130; i++) {
+            Instant when = BASE.minusSeconds(2L * RETENTION + i);
+            old.add(new BlockBreakRecord(EventIds.newId(), "break", when, when.plusSeconds(RETENTION),
+                    Origin.player(), Source.player(UUID.randomUUID(), "Old"),
+                    new BlockLocation(WORLD, "world", i, 64, i), "srv", "STONE",
+                    simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air")));
+        }
+        store.save(old);
+        store.save(List.of(simpleBreak(1))); // one fresh survivor
+
+        long pruned = store.pruneExpired();
+        assertThat(pruned)
+                .as("the batch loop must cross the 50-row boundary and delete all 130 expired")
+                .isEqualTo(130L);
+        assertThat(rawCount("records")).isEqualTo(1L);
+    }
+
+    @Test
+    void saveLowersWatermarkSoALaterOldInsertStillPrunes() throws SQLException {
+        // Seed with only fresh data (watermark recent). A subsequent OLD insert
+        // must lower the watermark, or the next sweep would wrongly skip it.
+        store.save(List.of(simpleBreak(1)));
+        store.seedWatermarkForTest();
+        Instant old = BASE.minusSeconds(3 * RETENTION);
+        store.save(List.of(new BlockBreakRecord(EventIds.newId(), "break", old, old.plusSeconds(RETENTION),
+                Origin.player(), Source.player(UUID.randomUUID(), "Old"),
+                new BlockLocation(WORLD, "world", 9, 64, 9), "srv", "STONE",
+                simple(Material.STONE, "minecraft:stone"), simple(Material.AIR, "minecraft:air"))));
+
+        assertThat(store.oldestOccurredWatermarkForTest())
+                .as("save lowered the watermark to the backdated occurred")
+                .isEqualTo(old.getEpochSecond());
+        long pruned = store.pruneExpired();
+        assertThat(pruned).isEqualTo(1L);
+    }
+
     private static final class CapturingSink implements RecordStore.RollbackEffectSink {
         record Block(UUID world, int x, int y, int z, String data) {
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -246,6 +246,45 @@ public final class RollbackService {
         }
     }
 
+    /**
+     * The recorder's flush timed out before every queued/spilled record
+     * reached the store, so the rollback below reads an incomplete picture and
+     * can only partially restore. Log it at WARNING with the job id AND tell
+     * the operator how much is still in flight (#204). The old notice went only
+     * to {@code job.sender}, so a partial rollback left no server-log trace and
+     * did not say how much was missing; the drain figures come from
+     * {@link net.medievalrp.spyglass.plugin.pipeline.Recorder#spillSnapshot()}.
+     */
+    private void warnRecorderStillDraining(RollbackJob job) {
+        String detail = drainDetail(recorder.spillSnapshot());
+        logger.warning("Spyglass rollback " + job.shortId()
+                + " starting before the recorder drained: " + detail
+                + ". The newest events may be missing from this rollback; re-run once the"
+                + " backlog clears (see /spyglass stats) to catch them.");
+        support.onMainThread(() -> job.sender.sendMessage(Feedback.bonus(
+                "Recorder still draining: " + detail + ". Rollback may miss the most recent"
+                + " events; re-run after it clears to catch the rest.")));
+    }
+
+    /**
+     * Human-readable "how much is still draining" phrase for
+     * {@link #warnRecorderStillDraining}. With a spill backlog it reports the
+     * record count and, when the drain is rate-capped, an estimated time to
+     * clear; otherwise it reports that the store simply has not caught up.
+     * Package-private + static for unit testing (#204).
+     */
+    static String drainDetail(net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot spill) {
+        long backlog = spill.records();
+        if (backlog <= 0) {
+            return "the store has not caught up to the newest events";
+        }
+        long rate = spill.drainRatePerSec();
+        String eta = rate > 0
+                ? " (~" + Math.max(1L, backlog / rate) + "s to clear at " + rate + " rec/s)"
+                : "";
+        return backlog + " record(s) still draining from the overflow spill" + eta;
+    }
+
     public void runJob(RollbackJob job) {
         JobContext ctx = pendingContexts.remove(job.id);
         if (ctx == null) {
@@ -265,8 +304,7 @@ public final class RollbackService {
             try {
                 boolean drained = recorder.flush(flushTimeout);
                 if (!drained) {
-                    support.onMainThread(() -> job.sender.sendMessage(Feedback.bonus(
-                            "Recorder still draining; rollback may miss the most recent events.")));
+                    warnRecorderStillDraining(job);
                 }
                 streamPagesAndApply(job, ctx.request(), ctx.mode(),
                         ctx.startCursor(), ctx.initialApplied(), ctx.initialSkipped(),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
@@ -88,7 +88,10 @@ public final class ContainerTransactionListener implements RecordingListener {
             return;
         }
 
-        InventoryHolder holder = clicked.getHolder();
+        // getHolder(false): the listener only reads the holder's block location
+        // and type, so skip the tile-entity snapshot copy getHolder() builds on
+        // every container click (#210).
+        InventoryHolder holder = clicked.getHolder(false);
         if (holder instanceof ShulkerBox) {
             return;
         }
@@ -177,7 +180,7 @@ public final class ContainerTransactionListener implements RecordingListener {
         Inventory bottom = event.getView().getBottomInventory();
         boolean clickedIsTop = clicked.equals(top);
 
-        InventoryHolder topHolder = top.getHolder();
+        InventoryHolder topHolder = top.getHolder(false); // no snapshot copy (#210)
         if (topHolder instanceof ShulkerBox) {
             return;
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorder.java
@@ -509,6 +509,19 @@ public final class AsyncRecorder implements Recorder {
                 return false;
             }
         }
+        // The queue has fully drained to the store, but a backend with async
+        // server-side buffering (ClickHouse) may not have made those rows
+        // SELECT-visible yet, which would let a read-your-writes rollback read a
+        // partial picture (#205). Force the buffer out. No-op on the other
+        // backends; if it fails, the newest events may not be queryable, so
+        // report the flush as incomplete rather than falsely durable-and-visible.
+        try {
+            store.flushPendingWrites();
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass store visibility flush failed; the newest events"
+                    + " may not be queryable yet: " + ex.getMessage());
+            return false;
+        }
         return true;
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/Recorder.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/Recorder.java
@@ -42,4 +42,15 @@ public interface Recorder {
      * @return {@code true} if the snapshot drained, {@code false} on timeout
      */
     boolean flush(Duration timeout);
+
+    /**
+     * Snapshot of the on-disk overflow spill backlog, so a caller can tell
+     * the operator how many records are still draining when a {@link #flush}
+     * times out (#204). Default: an empty, disabled snapshot - a recorder
+     * without a spill buffer, and test doubles, report no backlog.
+     * {@link AsyncRecorder} overrides this with the live figures.
+     */
+    default AsyncRecorder.SpillSnapshot spillSnapshot() {
+        return new AsyncRecorder.SpillSnapshot(false, 0L, 0L, 0L, 0L);
+    }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/pipeline/SpillBuffer.java
@@ -65,6 +65,13 @@ public final class SpillBuffer {
     private final AtomicLong pendingRecords = new AtomicLong();
     private final AtomicLong pendingFiles = new AtomicLong();
     private final AtomicLong pendingBytes = new AtomicLong();
+    // Drain-thread-only ordered cache of segment paths still to replay, so
+    // draining N segments costs one directory listing per empty-cache refill
+    // instead of one listing per poll (the old oldestSegment() re-listed every
+    // call -> O(N^2) to drain a large backlog) (#210). poll()/ack() are the
+    // single drain thread per this class's contract, so it needs no locking; new
+    // spills (higher seq, sorted later) are picked up on the next refill.
+    private final java.util.ArrayDeque<Path> segmentCache = new java.util.ArrayDeque<>();
 
     public SpillBuffer(@Nullable Path dataFolder, boolean enabled, Logger logger) {
         this.logger = logger;
@@ -142,13 +149,14 @@ public final class SpillBuffer {
             return null;
         }
         // Skip past any unreadable segments (drop them) until a good one or none.
-        for (Path oldest = oldestSegment(); oldest != null; oldest = oldestSegment()) {
+        for (Path oldest = nextSegment(); oldest != null; oldest = nextSegment()) {
             try {
                 byte[] bytes = Files.readAllBytes(oldest);
                 return new Spilled(oldest, bytes.length, EventBatchCodec.decode(bytes));
             } catch (IOException | RuntimeException ex) {
                 // A segment that won't decode would wedge the drain forever;
                 // its records are unrecoverable, so drop it and move to the next.
+                // nextSegment() already removed it from the cache; delete the file.
                 logger.log(Level.WARNING, "Spyglass spill: dropping unreadable segment "
                         + oldest.getFileName() + " (" + ex.getMessage() + ")");
                 pendingRecords.addAndGet(-recordCountOf(oldest));
@@ -160,7 +168,8 @@ public final class SpillBuffer {
         return null;
     }
 
-    /** Delete a segment after its records were saved, and update counters. */
+    /** Delete a segment after its records were saved, and update counters. The
+     *  {@link #poll} that produced it already removed it from the cache. */
     void ack(Spilled spilled) {
         pendingRecords.addAndGet(-spilled.records().size());
         pendingFiles.decrementAndGet();
@@ -168,17 +177,22 @@ public final class SpillBuffer {
         deleteQuietly(spilled.file());
     }
 
+    /** Oldest not-yet-replayed segment, removed from the cache. Refills the
+     *  cache from disk (sorted, chronological) when it empties, so a run of
+     *  {@link #poll}s costs one listing per refill, not one per call. */
     @Nullable
-    private Path oldestSegment() {
-        try (Stream<Path> stream = Files.list(dir)) {
-            return stream
-                    .filter(p -> p.getFileName().toString().endsWith(EXTENSION))
-                    .min(Comparator.comparing(p -> p.getFileName().toString()))
-                    .orElse(null);
-        } catch (IOException ex) {
-            logger.log(Level.WARNING, "Spyglass spill: failed to list " + dir, ex);
-            return null;
+    private Path nextSegment() {
+        if (segmentCache.isEmpty()) {
+            try (Stream<Path> stream = Files.list(dir)) {
+                stream.filter(p -> p.getFileName().toString().endsWith(EXTENSION))
+                        .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                        .forEach(segmentCache::addLast);
+            } catch (IOException ex) {
+                logger.log(Level.WARNING, "Spyglass spill: failed to list " + dir, ex);
+                return null;
+            }
         }
+        return segmentCache.pollFirst();
     }
 
     private void seedFromExisting() {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -123,6 +123,13 @@ public final class RollbackEngine {
     // per-block audit-record build, which now runs off-main.
     private volatile int worldWriteBatchChunks = 16;
 
+    // #208: max chunks that may be BLOCK-loaded (a getChunk on a not-yet-loaded
+    // chunk) per resolve hop. A rollback over an unloaded region paces its loads
+    // across ticks instead of bursting up to worldWriteBatchChunks blocking loads
+    // into one tick. Already-loaded chunks don't count against it, so the common
+    // in-view rollback is unaffected.
+    private static final int MAX_CHUNK_LOADS_PER_HOP = 4;
+
     // Apply-phase breakdown (reset per applyAllChunked, logged on
     // completion). writeNanos = wall-time the pool spends on palette
     // writes (sum of per-batch barrier waits); postNanos = main-thread
@@ -438,6 +445,17 @@ public final class RollbackEngine {
         return span <= 0L ? 0 : 64 - Long.numberOfLeadingZeros(span);
     }
 
+    /**
+     * Whether the resolve loop should stop this hop before a not-yet-loaded
+     * chunk, to pace synchronous chunk loads across ticks (#208). Never defers an
+     * already-loaded chunk, and always resolves at least one chunk per hop (an
+     * empty batch never defers) so progress is guaranteed even in a fully cold
+     * region. Package-private for unit testing.
+     */
+    static boolean deferForChunkLoadPacing(boolean chunkLoaded, int loadsThisHop, boolean batchEmpty) {
+        return !chunkLoaded && !batchEmpty && loadsThisHop >= MAX_CHUNK_LOADS_PER_HOP;
+    }
+
     private static void sortByComparator(List<Integer> indices,
                                          List<RollbackEffect.BlockReplace> effects) {
         int n = indices.size();
@@ -649,6 +667,7 @@ public final class RollbackEngine {
         long tResolve = System.nanoTime();
         List<ChunkWork> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
+        int loadsThisHop = 0;
         try {
             while (cursor < total && batch.size() < maxBatchChunks) {
             BlockLocation startLoc = blockReplaceEffects.get(cursor).location();
@@ -678,6 +697,18 @@ public final class RollbackEngine {
                 continue;
             }
 
+            // #208: pace synchronous chunk loads across ticks. prepareChunk's
+            // getChunk blocks to load an unloaded chunk; without this a rollback
+            // over an unloaded region would trigger up to maxBatchChunks blocking
+            // loads in a single tick and stall it. Already-loaded chunks (rolling
+            // back where a player stands - the common case) never hit the cap and
+            // resolve at full speed; a cold region just spreads its loads over
+            // more ticks, trading wall-time for TPS like the apply budget does.
+            boolean chunkLoaded = world.isChunkLoaded(cx, cz);
+            if (deferForChunkLoadPacing(chunkLoaded, loadsThisHop, batch.isEmpty())) {
+                break;
+            }
+
             // Pin the chunk loaded, then resolve its section context —
             // both on main, so the worker never calls into the chunk
             // system. addPluginChunkTicket is thread-safe per Paper.
@@ -700,6 +731,9 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
+                if (!chunkLoaded) {
+                    loadsThisHop++;
+                }
             } catch (Throwable t) {
                 // prepareChunk / onChunkResolved threw after this chunk was
                 // pinned: release its ticket here (it never reaches the post
@@ -1046,6 +1080,7 @@ public final class RollbackEngine {
         // runs of the sorted order share a chunk, so one walk groups them.
         List<ColChunk> batch = new ArrayList<>(Math.min(maxBatchChunks, 64));
         int cursor = from;
+        int loadsThisHop = 0;
         try {
             while (cursor < total && batch.size() < maxBatchChunks) {
             int startIdx = order[cursor];
@@ -1058,6 +1093,13 @@ public final class RollbackEngine {
                     break;
                 }
                 rangeEnd++;
+            }
+            // #208: pace synchronous chunk loads across ticks (see the mirror in
+            // applyChunkBatchParallel). Already-loaded chunks resolve at full
+            // speed; a cold region spreads its blocking getChunk loads over hops.
+            boolean chunkLoaded = world.isChunkLoaded(cx, cz);
+            if (deferForChunkLoadPacing(chunkLoaded, loadsThisHop, batch.isEmpty())) {
+                break;
             }
             boolean ticketAdded = false;
             if (ticketHolder != null) {
@@ -1077,6 +1119,9 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
+                if (!chunkLoaded) {
+                    loadsThisHop++;
+                }
             } catch (Throwable t) {
                 // Release this chunk's just-added ticket before failing the
                 // batch; the rest are freed below (#127).

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturer.java
@@ -58,7 +58,11 @@ public final class SalvageCapturer implements SalvageHook {
         this.logger = logger;
     }
 
-    private record Captured(int x, int y, int z, String type, List<StoredItem> items) {
+    // Contents are CLONED (detached), not yet serialized: the heavy
+    // serializeAsBytes + base64 is deferred to the off-main persist step so a
+    // rollback over a container-dense area doesn't serialize every surviving
+    // container on the tick (#207).
+    private record Captured(int x, int y, int z, String type, ItemStack[] contents) {
     }
 
     @Override
@@ -87,13 +91,16 @@ public final class SalvageCapturer implements SalvageHook {
         // thread, before any write to this chunk). Most chunks have none.
         for (BlockState state : chunk.getTileEntities(false)) {
             if (state instanceof Container container) {
-                List<StoredItem> items = capture(inventoryOf(container));
-                if (!items.isEmpty()) {
+                // Clone the live contents on the main thread (cheap); the
+                // serialize is deferred to the persist step (#207). null means
+                // the container is empty - nothing to salvage.
+                ItemStack[] contents = cloneIfNonEmpty(inventoryOf(container));
+                if (contents != null) {
                     if (captured == null) {
                         captured = new ArrayList<>();
                     }
                     captured.add(new Captured(state.getX(), state.getY(), state.getZ(),
-                            state.getType().name(), items));
+                            state.getType().name(), contents));
                 }
             }
         }
@@ -111,37 +118,46 @@ public final class SalvageCapturer implements SalvageHook {
             return;
         }
         final String op = operator;
-        List<SalvageSnapshot> toSave = new ArrayList<>();
+        final UUID worldId = world.getUID();
+        final String worldName = world.getName();
+        // Main thread: decide which containers the rollback destroyed by
+        // comparing CLONED stacks (no serialization), then hand the captured
+        // clones - with their coordinates - to the off-main persist step, which
+        // serializes only the genuinely-destroyed set (#207).
+        List<Captured> destroyed = new ArrayList<>();
         for (Captured cap : captured) {
             Block block = world.getBlockAt(cap.x(), cap.y(), cap.z());
-            boolean destroyed;
+            boolean gone;
             // Check the block TYPE first — read from the chunk section the
             // rollback overwrote. A direct NMS section write leaves the old block
             // entity lingering in the chunk map, so getState() can still return a
             // stale Container even though the block is now (e.g.) stone; the
             // material is authoritative.
             if (!block.getType().name().equals(cap.type())) {
-                destroyed = true;
+                gone = true;
             } else if (block.getState() instanceof Container container) {
                 // Same container type still here — destroyed only if its contents
-                // changed (e.g. the rollback restored a different recorded inv).
-                destroyed = !sameItems(capture(inventoryOf(container)), cap.items());
+                // changed. Compares live stacks against the captured clones via
+                // ItemStack equality, no serialize.
+                gone = !sameContents(inventoryOf(container).getContents(), cap.contents());
             } else {
-                destroyed = true;
+                gone = true;
             }
-            if (destroyed && salvagedCells.add(
-                    world.getUID() + ":" + cap.x() + ":" + cap.y() + ":" + cap.z())) {
-                toSave.add(new SalvageSnapshot(UUID.randomUUID(), rollbackId,
-                        world.getUID(), world.getName(),
-                        cap.x(), cap.y(), cap.z(), cap.type(), op,
-                        Instant.now(), cap.items()));
+            if (gone && salvagedCells.add(
+                    worldId + ":" + cap.x() + ":" + cap.y() + ":" + cap.z())) {
+                destroyed.add(cap);
             }
         }
-        if (!toSave.isEmpty()) {
-            logger.fine("salvage: persisting " + toSave.size()
+        if (!destroyed.isEmpty()) {
+            logger.fine("salvage: persisting " + destroyed.size()
                     + " destroyed container(s) from chunk " + chunkX + "," + chunkZ);
+            final UUID batchRollbackId = rollbackId;
             persistExecutor.execute(() -> {
-                for (SalvageSnapshot snapshot : toSave) {
+                for (Captured cap : destroyed) {
+                    // Serialize off the main thread, then persist.
+                    SalvageSnapshot snapshot = new SalvageSnapshot(UUID.randomUUID(), batchRollbackId,
+                            worldId, worldName, cap.x(), cap.y(), cap.z(), cap.type(), op,
+                            Instant.now(), serializeContents(cap.contents()));
                     try {
                         store.save(snapshot);
                     } catch (RuntimeException ex) {
@@ -161,34 +177,51 @@ public final class SalvageCapturer implements SalvageHook {
                 ? chest.getBlockInventory() : container.getInventory();
     }
 
-    private static List<StoredItem> capture(Inventory inventory) {
-        List<StoredItem> items = new ArrayList<>();
-        int size = inventory.getSize();
-        for (int slot = 0; slot < size; slot++) {
-            ItemStack stack = inventory.getItem(slot);
+    /** Clone the live contents (main thread) if any slot holds a real item;
+     *  returns null for an empty container. Empty slots normalize to null so the
+     *  written-time comparison lines up regardless of AIR-vs-null. */
+    private static ItemStack[] cloneIfNonEmpty(Inventory inventory) {
+        ItemStack[] live = inventory.getContents();
+        ItemStack[] out = new ItemStack[live.length];
+        boolean anyItem = false;
+        for (int slot = 0; slot < live.length; slot++) {
+            ItemStack stack = live[slot];
             if (stack != null && stack.getType() != Material.AIR) {
-                items.add(ItemSerialization.storedItem(slot, stack));
+                out[slot] = stack.clone();
+                anyItem = true;
+            }
+        }
+        return anyItem ? out : null;
+    }
+
+    /** Off-main: serialize the cloned, destroyed container's contents. */
+    private static List<StoredItem> serializeContents(ItemStack[] contents) {
+        List<StoredItem> items = new ArrayList<>();
+        for (int slot = 0; slot < contents.length; slot++) {
+            if (contents[slot] != null) {
+                items.add(ItemSerialization.storedItem(slot, contents[slot]));
             }
         }
         return items;
     }
 
-    // Equal iff the same slot->blob set. Order-independent; cheap for the
-    // handful of captured containers.
-    private static boolean sameItems(List<StoredItem> a, List<StoredItem> b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        Set<String> keys = new HashSet<>();
-        for (StoredItem item : a) {
-            keys.add(item.slot() + ":" + item.data());
-        }
-        for (StoredItem item : b) {
-            if (!keys.contains(item.slot() + ":" + item.data())) {
+    // Equal iff every slot's live stack matches the captured clone, treating a
+    // null and an AIR stack as the same empty slot. ItemStack.equals is a
+    // read-only deep compare - no serialization (#207).
+    private static boolean sameContents(ItemStack[] live, ItemStack[] captured) {
+        int size = Math.max(live.length, captured.length);
+        for (int slot = 0; slot < size; slot++) {
+            ItemStack liveStack = slot < live.length ? normalizeEmpty(live[slot]) : null;
+            ItemStack capturedStack = slot < captured.length ? captured[slot] : null;
+            if (!java.util.Objects.equals(liveStack, capturedStack)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static ItemStack normalizeEmpty(ItemStack stack) {
+        return (stack == null || stack.getType() == Material.AIR) ? null : stack;
     }
 
     private static String key(World world, int chunkX, int chunkZ) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockCascade.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FallingBlockCascade.java
@@ -77,7 +77,7 @@ public final class FallingBlockCascade {
             // this exact cell, skip but keep walking — there might be
             // un-logged gravity blocks further up.
             if (alreadyCascaded != null) {
-                long packed = ((long) y << 56) | ((long) (x & 0xFFFFFFF) << 28) | (z & 0xFFFFFFF);
+                long packed = packCell(x, y, z);
                 if (!alreadyCascaded.add(packed)) {
                     continue;
                 }
@@ -97,6 +97,26 @@ public final class FallingBlockCascade {
             FallingBlockTracker.track(world.getUID(), x, y, z,
                     player.getUniqueId(), player.getName());
         }
+    }
+
+    /**
+     * Pack {@code (x, y, z)} into a collision-free long key for the
+     * per-session dedup set: 26 bits each for x/z (covers the world
+     * border's +/-33.5M range) and 12 bits for y. The low-12-bit y mask
+     * is collision-free because a single world spans well under 4096
+     * blocks vertically, so no two real y values differ by a multiple of
+     * 4096. Same layout as {@link
+     * net.medievalrp.spyglass.plugin.worldedit.FaweEditDedupe}'s key.
+     *
+     * <p>The previous {@code y << 56} packing left y only 8 bits and did
+     * not mask it, so cells 256 apart at the same (x, z) collided and a
+     * negative y sign-extended into the x field - both of which silently
+     * dropped cascade break records for tall / low gravity columns.
+     */
+    static long packCell(int x, int y, int z) {
+        return ((long) x & 0x3FF_FFFFL) << 38
+                | ((long) z & 0x3FF_FFFFL) << 12
+                | ((long) y & 0xFFFL);
     }
 
     /** Convenience overload for callers that don't need session-level

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -567,4 +567,71 @@ class RollbackServiceTest {
         verify(fixture.undoStack, org.mockito.Mockito.never()).pushReference(
                 any(UUID.class), any(String.class), any(String.class));
     }
+
+    // #204: when the pre-rollback flush times out, the partial-restore
+    // condition must reach the SERVER LOG (it was sender-only before, leaving
+    // no trace), and the operator message must say how much is still draining.
+    @Test
+    void logsAndTellsOperatorWhenRecorderStillDrainingAtRollback() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        // Flush times out; the recorder reports a spill backlog with a finite
+        // drain rate, so an ETA is included (50000 / 500 = 100s).
+        when(fixture.recorder.flush(any(net.medievalrp.spyglass.api.util.Duration.class)))
+                .thenReturn(false);
+        when(fixture.recorder.spillSnapshot()).thenReturn(
+                new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                        true, 3L, 50_000L, 1_000_000L, 500L));
+
+        java.util.List<java.util.logging.LogRecord> logged = new java.util.ArrayList<>();
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override public void publish(java.util.logging.LogRecord rec) {
+                logged.add(rec);
+            }
+            @Override public void flush() {
+            }
+            @Override public void close() {
+            }
+        };
+        Logger testLogger = Logger.getLogger("test");
+        testLogger.addHandler(handler);
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+        try {
+            fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+        } finally {
+            testLogger.removeHandler(handler);
+        }
+
+        // The core of #204: a WARNING now records that a rollback ran on
+        // incomplete data, with the job context and backlog count.
+        assertThat(logged).anyMatch(rec ->
+                rec.getLevel() == java.util.logging.Level.WARNING
+                        && rec.getMessage().contains("before the recorder drained")
+                        && rec.getMessage().contains("50000"));
+        // The operator is told the count and the ETA, not just "still draining".
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("50000") && line.contains("100s"));
+    }
+
+    // #204: the drain-detail phrase reports the backlog count and a rate-based
+    // ETA, drops the ETA when the drain is unlimited, and degrades cleanly when
+    // nothing is spilled (queue-only / slow-store case).
+    @Test
+    void drainDetailReportsBacklogCountAndEta() {
+        var withRate = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                true, 2L, 10_000L, 500_000L, 500L);
+        assertThat(RollbackService.drainDetail(withRate))
+                .contains("10000").contains("20s").contains("500 rec/s");
+
+        var unlimited = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                true, 2L, 10_000L, 500_000L, 0L);
+        assertThat(RollbackService.drainDetail(unlimited))
+                .contains("10000").doesNotContain("to clear");
+
+        var noBacklog = new net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.SpillSnapshot(
+                false, 0L, 0L, 0L, 0L);
+        assertThat(RollbackService.drainDetail(noBacklog))
+                .isEqualTo("the store has not caught up to the newest events");
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
@@ -198,7 +198,7 @@ class ContainerTransactionListenerTest {
         when(holder.getBlock()).thenReturn(block);
 
         Inventory inventory = mock(Inventory.class);
-        when(inventory.getHolder()).thenReturn(holder);
+        when(inventory.getHolder(false)).thenReturn(holder); // #210: listener reads getHolder(false)
         when(inventory.getItem(slot)).thenReturn(slotItem);
 
         InventoryClickEvent event = mock(InventoryClickEvent.class);
@@ -232,7 +232,7 @@ class ContainerTransactionListenerTest {
         when(doubleChest.getRightSide()).thenReturn(right);
 
         Inventory inventory = mock(Inventory.class);
-        when(inventory.getHolder()).thenReturn(doubleChest);
+        when(inventory.getHolder(false)).thenReturn(doubleChest); // #210: getHolder(false)
         when(inventory.getItem(rawSlot)).thenReturn(slotItem);
 
         InventoryClickEvent event = mock(InventoryClickEvent.class);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/AsyncRecorderTest.java
@@ -136,6 +136,44 @@ class AsyncRecorderTest {
     }
 
     @Test
+    void flushForcesStoreVisibilityAfterDraining() {
+        // #205: after the queue drains, flush() forces the store to make the
+        // saved rows SELECT-visible (a no-op on most backends; the async-insert
+        // buffer flush on ClickHouse), so a read-your-writes rollback sees them.
+        CapturingStore store = new CapturingStore();
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            for (int index = 0; index < 5; index++) {
+                recorder.record(sampleRecord());
+            }
+            assertThat(recorder.flush(Duration.parse("3s"))).isTrue();
+            assertThat(store.flushPendingCallCount())
+                    .as("flush forces store visibility once, after the queue drains")
+                    .isEqualTo(1);
+            assertThat(store.totalSaved()).isEqualTo(5);
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
+    void flushReturnsFalseWhenVisibilityFlushFails() {
+        // If forcing visibility fails (e.g. ClickHouse unreachable) flush() must
+        // report incomplete rather than claim the newest events are queryable.
+        CapturingStore store = new CapturingStore();
+        store.failVisibilityFlush = true;
+        AsyncRecorder recorder = new AsyncRecorder(1000, store, Logger.getLogger("test"));
+        try {
+            recorder.record(sampleRecord());
+            assertThat(recorder.flush(Duration.parse("3s")))
+                    .as("a failed visibility flush makes flush() report incomplete")
+                    .isFalse();
+        } finally {
+            recorder.shutdown(Duration.parse("2s"));
+        }
+    }
+
+    @Test
     void flushAwaitsBarrierThenDrainsQueue() {
         // #98: flush drains the serialization barrier first, then the queue.
         CapturingStore store = new CapturingStore();
@@ -653,14 +691,30 @@ class AsyncRecorderTest {
 
     private static final class CapturingStore implements RecordStore {
         private final CopyOnWriteArrayList<EventRecord> all = new CopyOnWriteArrayList<>();
+        private final AtomicInteger flushPendingCalls = new AtomicInteger();
+        // #205: simulate a backend whose visibility flush (e.g. ClickHouse
+        // unreachable) fails, so flush() must report incomplete.
+        volatile boolean failVisibilityFlush;
 
         int totalSaved() {
             return all.size();
         }
 
+        int flushPendingCallCount() {
+            return flushPendingCalls.get();
+        }
+
         @Override
         public void save(List<EventRecord> records) {
             all.addAll(records);
+        }
+
+        @Override
+        public void flushPendingWrites() {
+            flushPendingCalls.incrementAndGet();
+            if (failVisibilityFlush) {
+                throw new RuntimeException("simulated visibility-flush failure");
+            }
         }
 
         @Override

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/pipeline/SpillBufferTest.java
@@ -75,6 +75,44 @@ class SpillBufferTest {
     }
 
     @Test
+    void drainsManySegmentsInOrderIncludingOnesSpilledMidDrain(@TempDir Path dir) throws Exception {
+        // #210: the drain-thread segment cache must replay every segment
+        // oldest-first across an empty-cache refill, and pick up spills that
+        // land mid-drain (higher seq -> sorted after the cached ones).
+        SpillBuffer spill = new SpillBuffer(dir, true, LOG);
+        List<UUID> expected = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            UUID id = UUID.randomUUID();
+            expected.add(id);
+            spill.spill(batch(id));
+        }
+
+        List<UUID> drained = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            SpillBuffer.Spilled s = spill.poll();
+            drained.add(s.records().getFirst().id());
+            spill.ack(s);
+        }
+        // Two more spills after the cache was already populated + partly drained.
+        for (int i = 0; i < 2; i++) {
+            UUID id = UUID.randomUUID();
+            expected.add(id);
+            spill.spill(batch(id));
+        }
+        SpillBuffer.Spilled s;
+        while ((s = spill.poll()) != null) {
+            drained.add(s.records().getFirst().id());
+            spill.ack(s);
+        }
+
+        assertThat(drained)
+                .as("every segment replayed once, oldest-first, including mid-drain spills")
+                .containsExactlyElementsOf(expected);
+        assertThat(spill.hasPending()).isFalse();
+        assertThat(spill.pendingRecordCount()).isZero();
+    }
+
+    @Test
     void recoversSegmentsLeftByAPriorRun(@TempDir Path dir) throws Exception {
         UUID id = UUID.randomUUID();
         new SpillBuffer(dir, true, LOG).spill(batch(id, UUID.randomUUID()));

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackSortTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackSortTest.java
@@ -130,4 +130,35 @@ class RollbackSortTest {
         return new BlockSnapshot(Material.STONE, "minecraft:stone",
                 List.of(), List.of(), List.of(), List.of(), null);
     }
+
+    // ===== #208: chunk-load pacing decision ====================
+
+    @Test
+    void loadedChunksNeverDeferSoAnInViewRollbackRunsAtFullSpeed() {
+        // The common case: rolling back where a player stands, every chunk
+        // already loaded. Pacing must never kick in, whatever the hop count.
+        for (int loads = 0; loads < 100; loads++) {
+            assertThat(RollbackEngine.deferForChunkLoadPacing(true, loads, false))
+                    .as("a loaded chunk is never deferred (loadsThisHop=%d)", loads)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void firstUnloadedChunkOfAHopIsAlwaysResolved() {
+        // An empty batch never defers, so a fully cold region still makes
+        // progress at >= one chunk per hop (no starvation).
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 0, true)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 999, true)).isFalse();
+    }
+
+    @Test
+    void unloadedChunksAreDeferredOnceThePerHopCapIsReached() {
+        // Below the cap (4) an unloaded chunk still resolves; at/after it, with a
+        // non-empty batch, the loop defers the rest of this hop to the next tick.
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 0, false)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 3, false)).isFalse();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 4, false)).isTrue();
+        assertThat(RollbackEngine.deferForChunkLoadPacing(false, 5, false)).isTrue();
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/salvage/SalvageCapturerTest.java
@@ -1,0 +1,132 @@
+package net.medievalrp.spyglass.plugin.salvage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.Chunk;
+import org.bukkit.block.Barrel;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Pins the deferred-serialization contract for container salvage (#207): the
+ * heavy {@code serializeAsBytes} + base64 must run on the persist executor for
+ * only the genuinely-destroyed containers, never on the main-thread
+ * onChunkResolved / onChunkWritten hooks (which now only clone and compare).
+ */
+class SalvageCapturerTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+    private static final int CX = 4;
+    private static final int CZ = -2;
+    private static final int BX = 70;
+    private static final int BY = 64;
+    private static final int BZ = -20;
+
+    private final SalvageStore store = mock(SalvageStore.class);
+    private final List<Runnable> deferred = new ArrayList<>();
+    private final Executor collecting = deferred::add;
+    private final SalvageCapturer capturer =
+            new SalvageCapturer(store, collecting, Logger.getLogger("test"));
+
+    private ItemStack diamond() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.DIAMOND);
+        when(stack.getAmount()).thenReturn(1);
+        when(stack.hasItemMeta()).thenReturn(false);
+        when(stack.serializeAsBytes()).thenReturn(new byte[] {1, 2, 3});
+        when(stack.clone()).thenReturn(stack); // captured clone == the same reference
+        return stack;
+    }
+
+    /** A barrel holding one diamond, wired as the only tile entity in the chunk. */
+    private ItemStack wireBarrelWithDiamond(World world, Chunk chunk) {
+        ItemStack diamond = diamond();
+        Inventory inv = mock(Inventory.class);
+        when(inv.getContents()).thenReturn(new ItemStack[] {diamond, null, null});
+        Barrel barrel = mock(Barrel.class);
+        when(barrel.getX()).thenReturn(BX);
+        when(barrel.getY()).thenReturn(BY);
+        when(barrel.getZ()).thenReturn(BZ);
+        when(barrel.getType()).thenReturn(Material.BARREL);
+        when(barrel.getInventory()).thenReturn(inv);
+        when(chunk.getTileEntities(false))
+                .thenReturn(new org.bukkit.block.BlockState[] {barrel});
+        return diamond;
+    }
+
+    @Test
+    void destroyedContainerSerializesAndSavesOnlyViaTheExecutor() {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD);
+        when(world.getName()).thenReturn("world");
+        when(world.isChunkLoaded(CX, CZ)).thenReturn(true);
+        Chunk chunk = mock(Chunk.class);
+        when(world.getChunkAt(CX, CZ)).thenReturn(chunk);
+        wireBarrelWithDiamond(world, chunk);
+        // After the rollback, the barrel cell is now stone -> destroyed.
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.STONE);
+        when(world.getBlockAt(BX, BY, BZ)).thenReturn(block);
+
+        capturer.begin("Alice", UUID.randomUUID());
+        capturer.onChunkResolved(world, CX, CZ);
+        capturer.onChunkWritten(world, CX, CZ);
+
+        // #207: nothing serialized or saved on the main-thread hooks - the work
+        // is queued to the persist executor.
+        verifyNoInteractions(store);
+        assertThat(deferred).hasSize(1);
+
+        deferred.get(0).run();
+
+        ArgumentCaptor<SalvageSnapshot> saved = ArgumentCaptor.forClass(SalvageSnapshot.class);
+        verify(store).save(saved.capture());
+        assertThat(saved.getValue().items())
+                .as("the destroyed barrel's one diamond is serialized off-main and saved")
+                .hasSize(1);
+        assertThat(saved.getValue().x()).isEqualTo(BX);
+        assertThat(saved.getValue().containerType()).isEqualTo("BARREL");
+    }
+
+    @Test
+    void survivingContainerIsNeverSaved() {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD);
+        when(world.getName()).thenReturn("world");
+        when(world.isChunkLoaded(CX, CZ)).thenReturn(true);
+        Chunk chunk = mock(Chunk.class);
+        when(world.getChunkAt(CX, CZ)).thenReturn(chunk);
+        ItemStack diamond = wireBarrelWithDiamond(world, chunk);
+        // After the rollback the barrel is still a barrel with the same diamond.
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.BARREL);
+        Barrel liveState = mock(Barrel.class);
+        Inventory liveInv = mock(Inventory.class);
+        when(liveInv.getContents()).thenReturn(new ItemStack[] {diamond, null, null});
+        when(liveState.getInventory()).thenReturn(liveInv);
+        when(block.getState()).thenReturn(liveState);
+        when(world.getBlockAt(BX, BY, BZ)).thenReturn(block);
+
+        capturer.begin("Alice", UUID.randomUUID());
+        capturer.onChunkResolved(world, CX, CZ);
+        capturer.onChunkWritten(world, CX, CZ);
+
+        assertThat(deferred).as("an unchanged container queues no persist work").isEmpty();
+        verify(store, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockCascadeTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FallingBlockCascadeTest.java
@@ -1,0 +1,72 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the per-session cascade dedup key (#209).
+ *
+ * <p>The old packing {@code (y << 56) | ((x & 0xFFFFFFF) << 28) | (z & 0xFFFFFFF)}
+ * left y only 8 bits (unmasked), so two cells 256 apart at the same (x, z)
+ * collided and a negative y sign-extended into the x field - both silently
+ * dropping cascade break records. These tests assert the new {@link
+ * FallingBlockCascade#packCell} is collision-free across a full world column,
+ * including negative y, and that the exact failure the old formula exhibited no
+ * longer reproduces.
+ */
+class FallingBlockCascadeTest {
+
+    @Test
+    void distinctCellsInAWorldColumnNeverCollide() {
+        // A single (x, z) column across the full modern overworld height
+        // (-64..319) plus a couple of extreme customs. Every y must map to a
+        // distinct key, or a cascade above a broken support would be deduped
+        // away and never recorded.
+        Set<Long> keys = new HashSet<>();
+        int x = 12_345;
+        int z = -6_789;
+        for (int y = -64; y <= 2032; y++) {
+            assertThat(keys.add(FallingBlockCascade.packCell(x, y, z)))
+                    .as("y=%d collided with an earlier y in the same column", y)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void cellsExactly256ApartDoNotCollide() {
+        // The reported failure: y<<56 kept only 8 bits, so y and y+256 shared a
+        // key. Both directions, including a negative lower cell.
+        assertThat(FallingBlockCascade.packCell(10, 64, 20))
+                .isNotEqualTo(FallingBlockCascade.packCell(10, 320, 20));
+        assertThat(FallingBlockCascade.packCell(-3, -64, 7))
+                .isNotEqualTo(FallingBlockCascade.packCell(-3, 192, 7));
+    }
+
+    @Test
+    void negativeYDoesNotCorruptTheXOrZField() {
+        // A negative y must not bleed into the x/z bits: two different columns
+        // at the same negative y stay distinct, and a negative-y cell differs
+        // from the same column at a positive y.
+        assertThat(FallingBlockCascade.packCell(100, -64, 200))
+                .isNotEqualTo(FallingBlockCascade.packCell(101, -64, 200));
+        assertThat(FallingBlockCascade.packCell(100, -64, 200))
+                .isNotEqualTo(FallingBlockCascade.packCell(100, -64, 201));
+        assertThat(FallingBlockCascade.packCell(100, -64, 200))
+                .isNotEqualTo(FallingBlockCascade.packCell(100, 64, 200));
+    }
+
+    @Test
+    void oldFormulaCollidedWhereTheNewOneDoesNot() {
+        // Documents the bug: the old key formula collapses (10,64,20) and
+        // (10,320,20) to one value; the fix separates them.
+        long oldLower = ((long) 64 << 56) | ((long) (10 & 0xFFFFFFF) << 28) | (20 & 0xFFFFFFF);
+        long oldUpper = ((long) 320 << 56) | ((long) (10 & 0xFFFFFFF) << 28) | (20 & 0xFFFFFFF);
+        assertThat(oldLower).as("old formula collided (regression guard)").isEqualTo(oldUpper);
+
+        assertThat(FallingBlockCascade.packCell(10, 64, 20))
+                .isNotEqualTo(FallingBlockCascade.packCell(10, 320, 20));
+    }
+}


### PR DESCRIPTION
Cuts Spyglass 1.0.7 from dev.

## What's fixed
Mostly a performance pass on the storage backends and the rollback apply path.
- Storage: cheaper SQLite/MariaDB retention sweeps, leaner Mongo inserts, and a fix for a ClickHouse read-after-flush visibility gap.
- Rollback: salvage serialization moved off the main thread, paced chunk loads, faster container reads, and partial-drain rollbacks now log their backlog.
- Fix: cascade dedup key no longer overflows the Y coordinate.

## Also
- Release notes now include a brief 'What's fixed' section, sourced from .github/release-notes.md (maintained per release).

Merging to main triggers the release workflow: builds the three jars and publishes v1.0.7.