### PR TITLE
feat(command): dedicated spyglass.salvage permission for /sg inventory (#199)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -16,7 +16,7 @@ Root command is `/spyglass`, aliased to `/sg`. Subcommands take short aliases to
 | `/sg restore <query>` | `rs`, `rst` | `spyglass.rollback` | Re-apply previously-rolled-back events |
 | `/sg undo` | `u` | `spyglass.rollback` | Undo your most recent rollback or restore |
 | `/sg rbqueue [...]` | `queue`, `rbq` | `spyglass.rollback` | List, cancel, or resume rollback jobs |
-| `/sg inventory` | `inv`, `salvage` | `spyglass.rollback` | Recover items a rollback destroyed |
+| `/sg inventory` | `inv`, `salvage` | `spyglass.salvage` | Recover items a rollback destroyed |
 | `/sg tool` | `t`, `inspect` | `spyglass.tool` | Toggle the inspection wand |
 | `/sg tele <world> <x> <y> <z>` | - | `spyglass.tele` | Teleport (used by clickable search results) |
 
@@ -29,7 +29,8 @@ All default to `op`.
 | `spyglass.use` | help, events, page |
 | `spyglass.search` | search |
 | `spyglass.search.ip` | reveals join IPs in results and unlocks the `ip:` key. Without it, IPs render as `(ip hidden)` and `ip:` errors. Applies on Paper and the proxy |
-| `spyglass.rollback` | rollback, restore, undo, rbqueue, inventory |
+| `spyglass.rollback` | rollback, restore, undo, rbqueue |
+| `spyglass.salvage` | `/sg inventory` container salvage (recover items a rollback destroyed). Independent of `spyglass.rollback` |
 | `spyglass.tool` | inspection wand |
 | `spyglass.tele` | teleport (used by clickable result rows) |
 | `spyglass.worldedit` | allows the `-we` flag to use your WorldEdit selection as the search region |
@@ -139,7 +140,7 @@ If the server crashes mid-rollback, the job comes back as resumable on the next 
 
 ## Container salvage
 
-When a force-overwrite rollback destroys a container that had items in it - a chest someone filled after the grief, restored back to stone - those items are **not lost**. The rollback captures the destroyed inventory first and files it under `/sg inventory`.
+When a force-overwrite rollback destroys a container that had items in it - a chest someone filled after the grief, restored back to stone - those items are **not lost**. The rollback captures the destroyed inventory first and files it under `/sg inventory`, gated behind its own `spyglass.salvage` node (granted independently of `spyglass.rollback`).
 
 `/sg inventory` (alias `inv`) opens a paginated GUI, grouped by rollback. The first screen lists each **rollback** that destroyed containers (operator, time, and how many containers); click one to see that rollback's **containers** (icons showing type and coordinates); click a container to open its **items**. The bottom row has Back / Previous / Next buttons - every level paginates (45 per page), so a rollback that wiped a 124-chest base browses cleanly. It is **extract-only**: take items out, but you cannot put any in. Each withdrawal is logged as a `salvage-withdraw` event (find them with `/sg search a:salvage-withdraw`); a container disappears from the GUI once emptied. From the console or RCON the command prints a flat text listing instead.
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -175,8 +175,12 @@ public final class SpyglassCommands {
             }
 
             for (String name : INVENTORY_ALIASES) {
+                // Gated on its own node, not spyglass.rollback: pulling items out
+                // of a rollback-destroyed container is a distinct capability from
+                // running a rollback, so an operator can grant recovery without
+                // granting rollback (and vice versa). See plugin.yml (#199).
                 manager.command(manager.commandBuilder(root).literal(name)
-                        .permission("spyglass.rollback")
+                        .permission("spyglass.salvage")
                         .handler(ctx -> salvage.execute(ctx.sender())));
             }
 

--- a/spyglass/src/main/resources/plugin.yml
+++ b/spyglass/src/main/resources/plugin.yml
@@ -20,6 +20,11 @@ permissions:
     default: op
   spyglass.rollback:
     default: op
+  # Opens /sg inventory to recover items a rollback destroyed. A standalone
+  # node, NOT implied by spyglass.rollback: taking items out of recovered
+  # containers is a distinct capability, so it is granted independently (#199).
+  spyglass.salvage:
+    default: op
   spyglass.tool:
     default: op
   spyglass.worldedit:


### PR DESCRIPTION
Part of #199 (the permission half). The InvUI GUI rewrite is a separate follow-up PR; **this does not close #199.**

## What changes
`/sg inventory` (aliases `inv`, `salvage`) is now gated behind a dedicated **`spyglass.salvage`** node instead of `spyglass.rollback`. Taking items out of a rollback-destroyed container is a distinct capability from running a rollback, so it is granted independently.

- `SpyglassCommands`: the `INVENTORY_ALIASES` loop now requires `spyglass.salvage`.
- `plugin.yml`: new `spyglass.salvage` node (`default: op`), declared above the `libraries:` block so it survives the shaded-jar truncation (verified in the shaded jar).
- `COMMANDS.md`: command table + permissions table + the Container-salvage prose updated.

## BREAKING
Operators who previously granted only `spyglass.rollback` must now **also** grant `spyglass.salvage` to use `/sg inventory`. Both default to `op`, so default installs are unaffected; only setups with explicit non-op grants of `spyglass.rollback` need the extra node. Chosen deliberately (independent node, not a child of rollback) per the issue discussion.

## Testing
- `./gradlew :spyglass:build` green (includes `check`).
- Verified the shaded-jar `plugin.yml` retains `spyglass.salvage` above the stripped `libraries:` block.
- Permission-denial in-game verification is bundled with the InvUI follow-up (needs a live server); no headless command-registration harness exists to unit-test Cloud permission wiring.

## Follow-up (still open on #199)
Migrate `SalvageGui` (408 lines, raw Bukkit inventory) to InvUI, preserving the `InFlightTracker` dupe window, extract-only semantics, off-thread reads, and withdraw logging. Needs the relocated InvUI dependency (shadow 9.4.2 satisfies the relocation requirement) and isolated-server verification.