### PR TITLE
feat(storage): T64 codec for dense ClickHouse coordinate columns (#155)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
@@ -96,7 +96,15 @@ final class ClickHouseSchema {
         // worse than plain ZSTD. T64 bit-packs the narrow Minecraft
         // coordinate range order-independently and is ~32% smaller on
         // real scattered/organic coordinate data, with no read-path
-        // regression (measured on CH 24.8). The sparse Nullable coord
+        // regression (measured on CH 24.8). ZSTD(3) rather than (1)
+        // behind it: identical bytes and read speed on scattered data,
+        // but 14-19% smaller on WorldEdit scan-shaped runs, the one
+        // regime where T64 loses ground to Delta; the extra compress
+        // cost lands on ClickHouse merge threads and is negligible at
+        // coordinate-column volumes. Chaining Delta before T64 is not
+        // an option: 24.8 rejects it at INSERT (T64 needs element-
+        // aligned input), and on 26.5, where it runs, it gave the
+        // whole scattered-data win back. The sparse Nullable coord
         // columns (teleport_*, source_command_block_*) are ~95% NULL, so
         // the null-map dominates and plain ZSTD beats any transform.
         // MODIFY COLUMN with an unchanged codec is a cheap metadata
@@ -105,7 +113,7 @@ final class ClickHouseSchema {
         for (String coordinate : COORDINATE_CODEC_COLUMNS) {
             boolean dense = coordinate.startsWith("location_");
             String type = dense ? "Int32" : "Nullable(Int32)";
-            String codec = dense ? "CODEC(T64, ZSTD(1))" : "CODEC(ZSTD(1))";
+            String codec = dense ? "CODEC(T64, ZSTD(3))" : "CODEC(ZSTD(1))";
             execute(client, "ALTER TABLE " + qualifiedTable(database, eventsTable)
                     + " MODIFY COLUMN " + coordinate + " " + type + " " + codec);
         }
@@ -252,9 +260,9 @@ final class ClickHouseSchema {
                 + "    source_description Nullable(String),\n"
                 + "    location_world_id UUID,\n"
                 + "    location_world_name LowCardinality(String),\n"
-                + "    location_x Int32 CODEC(T64, ZSTD(1)),\n"
-                + "    location_y Int32 CODEC(T64, ZSTD(1)),\n"
-                + "    location_z Int32 CODEC(T64, ZSTD(1)),\n"
+                + "    location_x Int32 CODEC(T64, ZSTD(3)),\n"
+                + "    location_y Int32 CODEC(T64, ZSTD(3)),\n"
+                + "    location_z Int32 CODEC(T64, ZSTD(3)),\n"
                 + "    server LowCardinality(String) DEFAULT '',\n"
                 + "    target Nullable(String),\n"
                 // --- Block events (Break / Place / Use) ---

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
@@ -88,17 +88,26 @@ final class ClickHouseSchema {
         // Storage codecs (#21), idempotent for tables created before
         // them: ids are time-ordered v7 now, so a shared-prefix-aware
         // codec halves the column that used to be incompressible v4
-        // noise — measured the single largest consumer of store disk,
-        // twice over (the by_player projection duplicates every
-        // column). Coordinates are spatially clustered, so storing
-        // row-to-row differences compresses ~4x. MODIFY COLUMN with an
-        // unchanged codec is a cheap metadata no-op; with a new codec
-        // it applies to new parts immediately and old parts converge
-        // as merges churn them.
+        // noise - measured the single largest consumer of store disk,
+        // twice over (the by_player projection duplicates every column).
+        // Coordinate codecs (#155): the table sorts by (event, occurred,
+        // id), NOT by position, so consecutive rows jump around the map
+        // and Delta on the dense location_* columns underperforms - often
+        // worse than plain ZSTD. T64 bit-packs the narrow Minecraft
+        // coordinate range order-independently and is ~32% smaller on
+        // real scattered/organic coordinate data, with no read-path
+        // regression (measured on CH 24.8). The sparse Nullable coord
+        // columns (teleport_*, source_command_block_*) are ~95% NULL, so
+        // the null-map dominates and plain ZSTD beats any transform.
+        // MODIFY COLUMN with an unchanged codec is a cheap metadata
+        // no-op; with a new codec it applies to new parts immediately
+        // and old parts converge as merges churn them.
         for (String coordinate : COORDINATE_CODEC_COLUMNS) {
-            String type = coordinate.startsWith("location_") ? "Int32" : "Nullable(Int32)";
+            boolean dense = coordinate.startsWith("location_");
+            String type = dense ? "Int32" : "Nullable(Int32)";
+            String codec = dense ? "CODEC(T64, ZSTD(1))" : "CODEC(ZSTD(1))";
             execute(client, "ALTER TABLE " + qualifiedTable(database, eventsTable)
-                    + " MODIFY COLUMN " + coordinate + " " + type + " CODEC(Delta, ZSTD(1))");
+                    + " MODIFY COLUMN " + coordinate + " " + type + " " + codec);
         }
 
         // Storage v2 (#44) cannot be reached by ALTER from the v1
@@ -237,15 +246,15 @@ final class ClickHouseSchema {
                 + "    source_plugin_name Nullable(String),\n"
                 + "    source_command_block_world_id Nullable(UUID),\n"
                 + "    source_command_block_world_name Nullable(String),\n"
-                + "    source_command_block_x Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    source_command_block_y Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    source_command_block_z Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
+                + "    source_command_block_x Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    source_command_block_y Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    source_command_block_z Nullable(Int32) CODEC(ZSTD(1)),\n"
                 + "    source_description Nullable(String),\n"
                 + "    location_world_id UUID,\n"
                 + "    location_world_name LowCardinality(String),\n"
-                + "    location_x Int32 CODEC(Delta, ZSTD(1)),\n"
-                + "    location_y Int32 CODEC(Delta, ZSTD(1)),\n"
-                + "    location_z Int32 CODEC(Delta, ZSTD(1)),\n"
+                + "    location_x Int32 CODEC(T64, ZSTD(1)),\n"
+                + "    location_y Int32 CODEC(T64, ZSTD(1)),\n"
+                + "    location_z Int32 CODEC(T64, ZSTD(1)),\n"
                 + "    server LowCardinality(String) DEFAULT '',\n"
                 + "    target Nullable(String),\n"
                 // --- Block events (Break / Place / Use) ---
@@ -286,14 +295,14 @@ final class ClickHouseSchema {
                 // --- Teleport ---
                 + "    teleport_from_world_id Nullable(UUID),\n"
                 + "    teleport_from_world_name Nullable(String),\n"
-                + "    teleport_from_x Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    teleport_from_y Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    teleport_from_z Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
+                + "    teleport_from_x Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    teleport_from_y Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    teleport_from_z Nullable(Int32) CODEC(ZSTD(1)),\n"
                 + "    teleport_to_world_id Nullable(UUID),\n"
                 + "    teleport_to_world_name Nullable(String),\n"
-                + "    teleport_to_x Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    teleport_to_y Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
-                + "    teleport_to_z Nullable(Int32) CODEC(Delta, ZSTD(1)),\n"
+                + "    teleport_to_x Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    teleport_to_y Nullable(Int32) CODEC(ZSTD(1)),\n"
+                + "    teleport_to_z Nullable(Int32) CODEC(ZSTD(1)),\n"
                 + "    teleport_cause LowCardinality(Nullable(String)),\n"
                 // --- Entity events (Death / Hit / Mount / Name) ---
                 + "    entity_type LowCardinality(Nullable(String)),\n"


### PR DESCRIPTION
Resolves the #155 spike **and** implements it. Measured against ClickHouse 24.8 (the pinned version) with a multi-dataset A/B experiment + adversarial methodology review, then a second round targeting the WorldEdit regression specifically (round-4 comment on #155).

## Change
- **Dense `location_x/y/z`** (Int32): `CODEC(Delta, ZSTD(1))` -> **`CODEC(T64, ZSTD(3))`**
- **Sparse Nullable `teleport_*` / `source_command_block_*`**: `CODEC(Delta, ZSTD(1))` -> **`CODEC(ZSTD(1))`**
- Applies to both the CREATE TABLE DDL and the idempotent `MODIFY COLUMN` migration (per-column-group codec).

## Why T64 (measured, CH 24.8)
The table sorts by `(event, occurred, id)`, not by position, so consecutive rows are spatially uncorrelated and Delta on the dense coords underperforms - often *worse than plain ZSTD*. T64 bit-packs the narrow Minecraft coordinate range order-independently.

- **Reference 21.6M-row log** (true physical order): Delta 76.74 MiB -> T64 47.2 MiB coord bytes, **-38.5%**
- Synthetic organic scatter / session-clustered / mixed logs: **-28% to -31%** coord-only
- **Read path:** no regression - T64 full-scans ~2x *faster* than Delta on the reference log (less I/O), range scans equal (max_threads=1, 3 reps, decode-verified sums)

## Why ZSTD(3) behind it (the WorldEdit mitigation)
Contiguous WorldEdit scans are the one regime where T64 loses to Delta. WE scan shapes are low-entropy structured runs, so a stronger entropy stage recovers part of what the transform gives up; scattered coords have no such slack, so level 3 costs nothing there:

| dataset | T64,ZSTD(1) | **T64,ZSTD(3)** | Delta,ZSTD(1) |
|---|---|---|---|
| reference 21.6M log | 47.22 MiB | **47.18 MiB** | 76.74 MiB |
| organic scatter 2M | 9.32 MB | 9.31 MB | 13.4 MB |
| organic sessions 2M | 6.74 MB | 6.67 MB | 9.64 MB |
| mixed log (~24% WE rows) 2M | 5.61 MB | **5.53 MB** | 7.74 MB |
| WE `//set` 2M | 209 KB | **180 KB (-14%)** | 49 KB |
| WE `//walls` 2M | 700 KB | **569 KB (-19%)** | 63 KB |
| WE `//brush` 2M | 1.66 MB | **1.55 MB (-7%)** | 141 KB |
| WE `//replace` 2M | 2.54 MB | **2.41 MB (-5%)** | 1.53 MB |

Absolute WE cost vs Delta stays KB-scale: +66 KB (`//set`) to +683 KB (`//brush`) per **million** WE rows. Level 3's extra compress cost lands on ClickHouse merge threads (negligible at coordinate-column volumes); decode speed is level-independent (measured equal).

## Rejected with measurements (details in the round-4 comment on #155)
- **`Delta, T64, ZSTD` chain**: INSERT-time `CANNOT_COMPRESS` through CH 25.8 (Delta's output carries a frame header, so T64 sees misaligned input); works from at least 26.1, where it halves the WE regression but **gives the whole scattered win back** - 78.2 MiB on the reference log, *worse than plain Delta* (76.74 MiB). Dead regardless of server version; do not revisit on a CH bump.
- **`T64, Delta, ZSTD` reverse chain / `T64('bit')`** (both legal on 24.8): dominated on every dataset.
- **ZSTD(5)/(9) ladder**: keeps shaving WE (walls 569 -> 433 KB at level 9) but 2-4x merge-compress cost per step; 3 is the knee.
- **Chunk+offset column split** (`cx=floor(x/16)`, `cz`, packed 4+4-bit offset byte): +12% *worse* than T64,ZSTD(3) on session/mixed organic (the offset byte is incompressible entropy T64 already bit-packed in place), WE still 4-7x Delta. No schema surgery justified.

## Migration (non-destructive, Q4)
`MODIFY COLUMN` changing only the codec is an instant metadata ALTER. Verified against CH 24.8 for the exact `Delta,ZSTD(1) -> T64,ZSTD(3)` transition: **data checksum identical** before the ALTER, after the ALTER, and after `OPTIMIZE FINAL` re-encodes old parts. New parts get the new codec immediately; old parts converge on merge.

## Verification
- Codec matrix: 11 variants x 7 datasets x 2 CH versions (24.8 pinned + 26.5), plus the reference 21.6M-row leg with per-variant decode verification (all variant sums equal) and a read bench.
- `spyglass-core` ClickHouse ITs: 16 (RecordStore) + 5 (SynthesisParity) pass on testcontainers CH 24.8, none skipped.
- `Delta -> T64+ZSTD(3)` migration verified non-destructive (checksums above).

## Methodology caveat
The reference 21.6M log (source of the original -38%) is bench-seeded bulk data (median 3.8k rows/s, p99 368k rows/s), i.e. it validates the scattered regime rather than literal organic gameplay; the session-clustered and mixed synthetics bracket the organic side. Direction is robust across every dataset; exact magnitude is workload/column-mix dependent.
