### PR TITLE
feat(command): add cr: chunk-radius query param

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -65,6 +65,7 @@ Values are plain terms. Wrap in double quotes to search for a value that contain
 | `m:` | `message:` | `m:hello` | Chat, sign, or book text (substring) |
 | `rcp:` | `recipient:` | `rcp:Steve` | Private-message recipient |
 | `r:` | `radius:` | `r:50` | Search radius around you in blocks. Default applies if omitted; use `-g` for global |
+| `cr:` | `chunkradius:` | `cr:1` · `cr:3` | Search radius in chunks, full height. `cr:1` = your chunk, `cr:2` = 3x3. Overrides the default radius |
 | `t:` | `since:` | `t:1d`, `t:30m`, `t:2w` | Lower time bound (how far back). Default is 4h |
 | `before:` | - | `t:12h before:6h` | Upper time bound. `t:12h before:6h` = events between 12h and 6h ago |
 | `w:` | `world:` | `w:world_nether` | Restrict to one world |

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -20,6 +20,7 @@ import net.medievalrp.spyglass.plugin.command.SpyglassSuggestions;
 import net.medievalrp.spyglass.plugin.command.PageCache;
 import net.medievalrp.spyglass.plugin.command.param.BlockParam;
 import net.medievalrp.spyglass.plugin.command.param.CauseParam;
+import net.medievalrp.spyglass.plugin.command.param.ChunkRadiusParam;
 import net.medievalrp.spyglass.plugin.command.param.CustomItemParam;
 import net.medievalrp.spyglass.plugin.command.param.EnchantParam;
 import net.medievalrp.spyglass.plugin.command.param.EntityParam;
@@ -448,6 +449,7 @@ public final class SpyglassPlugin extends JavaPlugin {
         apiImpl.registerQueryParamHandler(new PlayerParam());
         apiImpl.registerQueryParamHandler(new EventParam(enabledEvents));
         apiImpl.registerQueryParamHandler(new RadiusParam());
+        apiImpl.registerQueryParamHandler(new ChunkRadiusParam());
         apiImpl.registerQueryParamHandler(new TimeParam());
         apiImpl.registerQueryParamHandler(new BeforeParam());
         apiImpl.registerQueryParamHandler(new BlockParam());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ChunkRadiusParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/ChunkRadiusParam.java
@@ -1,0 +1,71 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Chunk-based counterpart to {@link RadiusParam}. {@code cr:1} matches the
+ * chunk the sender stands in; {@code cr:N} widens the box by {@code N-1}
+ * chunks in every horizontal direction, so {@code cr:2} is 3x3 and {@code cr:3}
+ * is 5x5. The box always spans the full world height, and its reach is capped
+ * at {@code maxRadius / 16} chunks so a large value can't scan the whole world.
+ */
+public final class ChunkRadiusParam implements QueryParamHandler {
+    // Height bounds used only when the sender's world can't be resolved (standard overworld).
+    private static final int FALLBACK_MIN_Y = -64;
+    private static final int FALLBACK_MAX_Y = 319;
+
+    @Override
+    public List<String> aliases() {
+        return List.of("cr", "chunkradius");
+    }
+
+    @Override
+    public QueryPredicate parse(String alias, String value, ParamContext context) throws ParamParseException {
+        BlockLocation origin = context.senderLocation();
+        if (origin == null) {
+            throw new ParamParseException("Chunk radius requires a located sender.");
+        }
+        int chunks;
+        try {
+            chunks = Integer.parseInt(value);
+        } catch (NumberFormatException ex) {
+            throw new ParamParseException("Chunk radius must be a number.", ex);
+        }
+        if (chunks <= 0) {
+            throw new ParamParseException("Chunk radius must be positive.");
+        }
+
+        World world = BlockLocations.resolveWorld(origin).orElse(null);
+        int minY = world != null ? world.getMinHeight() : FALLBACK_MIN_Y;
+        int maxY = world != null ? world.getMaxHeight() - 1 : FALLBACK_MAX_Y;
+        return boxAround(origin, chunks, context.maxRadius(), minY, maxY);
+    }
+
+    public static QueryPredicate boxAround(BlockLocation origin, int chunks, int maxRadius, int minY, int maxY) {
+        int expand = Math.min(chunks - 1, maxRadius / 16);
+        int cx = origin.x() >> 4;
+        int cz = origin.z() >> 4;
+        return new QueryPredicate.And(List.of(
+                new QueryPredicate.Eq("location.worldId", origin.worldId()),
+                new QueryPredicate.Range("location.x", (cx - expand) << 4, ((cx + expand) << 4) + 15),
+                new QueryPredicate.Range("location.y", minY, maxY),
+                new QueryPredicate.Range("location.z", (cz - expand) << 4, ((cz + expand) << 4) + 15)));
+    }
+
+    @Override
+    public boolean suppressesDefaultRadius(String alias) {
+        return true;
+    }
+
+    @Override
+    public List<String> suggestions(CommandSender sender, String input) {
+        return input.isEmpty() ? List.of("1", "2", "3", "5") : List.of();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ChunkRadiusParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/ChunkRadiusParamTest.java
@@ -1,0 +1,90 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.param.QueryParamHandler.ParamContext;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+class ChunkRadiusParamTest {
+
+    private static final UUID WORLD = UUID.fromString("77777777-7777-7777-7777-777777777777");
+    private static final BlockLocation ORIGIN = new BlockLocation(WORLD, "world", 100, 64, -50);
+
+    @Test
+    void singleChunkCoversOriginChunkFullHeight() {
+        QueryPredicate predicate = ChunkRadiusParam.boxAround(ORIGIN, 1, 1000, -64, 319);
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.And.class);
+        QueryPredicate.And and = (QueryPredicate.And) predicate;
+        assertThat(and.predicates()).hasSize(4);
+
+        QueryPredicate.Eq worldEq = (QueryPredicate.Eq) and.predicates().get(0);
+        assertThat(worldEq.field()).isEqualTo("location.worldId");
+        assertThat(worldEq.value()).isEqualTo(WORLD);
+
+        assertRange(and.predicates().get(1), "location.x", 96, 111);
+        assertRange(and.predicates().get(2), "location.y", -64, 319);
+        assertRange(and.predicates().get(3), "location.z", -64, -49);
+    }
+
+    @Test
+    void expandsOneChunkOutwardForCrTwo() {
+        QueryPredicate predicate = ChunkRadiusParam.boxAround(ORIGIN, 2, 1000, -64, 319);
+        QueryPredicate.And and = (QueryPredicate.And) predicate;
+        assertRange(and.predicates().get(1), "location.x", 80, 127);
+        assertRange(and.predicates().get(3), "location.z", -80, -33);
+    }
+
+    @Test
+    void clampsChunkReachToBlockCap() {
+        QueryPredicate predicate = ChunkRadiusParam.boxAround(ORIGIN, 5, 16, -64, 319);
+        QueryPredicate.And and = (QueryPredicate.And) predicate;
+        assertRange(and.predicates().get(1), "location.x", 80, 127);
+        assertRange(and.predicates().get(3), "location.z", -80, -33);
+    }
+
+    @Test
+    void unlocatedSenderRejected() {
+        assertThatThrownBy(() -> new ChunkRadiusParam().parse("cr", "1", ctx(null, 1000)))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("located sender");
+    }
+
+    @Test
+    void nonNumericRejected() {
+        assertThatThrownBy(() -> new ChunkRadiusParam().parse("cr", "big", ctx(ORIGIN, 1000)))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("must be a number");
+    }
+
+    @Test
+    void zeroRejected() {
+        assertThatThrownBy(() -> new ChunkRadiusParam().parse("cr", "0", ctx(ORIGIN, 1000)))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("must be positive");
+    }
+
+    @Test
+    void suppressesDefaultRadiusContract() {
+        ChunkRadiusParam param = new ChunkRadiusParam();
+        assertThat(param.suppressesDefaultRadius("cr")).isTrue();
+        assertThat(param.suppressesDefaultRadius("chunkradius")).isTrue();
+    }
+
+    private static void assertRange(QueryPredicate p, String field, int lower, int upper) {
+        assertThat(p).isInstanceOf(QueryPredicate.Range.class);
+        QueryPredicate.Range range = (QueryPredicate.Range) p;
+        assertThat(range.field()).isEqualTo(field);
+        assertThat(range.lowerInclusive()).isEqualTo(lower);
+        assertThat(range.upperInclusive()).isEqualTo(upper);
+    }
+
+    private static ParamContext ctx(BlockLocation origin, int maxRadius) {
+        return new ParamContext(null, origin, maxRadius);
+    }
+}


### PR DESCRIPTION
Adds a `cr:`/`chunkradius:` query param. `cr:1` matches the sender's chunk; `cr:N` widens the box by N-1 chunks in each direction (`cr:2` = 3x3), full world height, capped at maxRadius/16 chunks so a big value can't scan the whole world.

Reworked from @Error11O's #187: split out the unrelated build/publish changes, condensed `boxAround`, fixed the world-height fallback (320 to 319), and rebased onto current dev.

Tested: ChunkRadiusParamTest passes 7/7, plus an in-game run driving `/sg s cr:N` against real break records across chunks 0/1/2/4/15/16. Counts match (cr:1 to cr:5 pull in 1..4 blocks; cr:16 reaches chunk 15) and cr:1000 stays clamped, excluding chunk 16.