### PR TITLE
build(release): publish spyglass-api to Maven Central (#194)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      release_exists: ${{ steps.exists.outputs.exists }}
+      has_central: ${{ steps.guard.outputs.has_central }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,6 +39,21 @@ jobs:
             echo "Release v${{ steps.ver.outputs.version }} already exists - nothing to do."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Gate the Maven Central publish on the credentials existing, so releases
+      # keep working before the one-time Central setup is done (see PUBLISHING.md).
+      # secrets can't be read in a job-level `if`, so surface presence as an output.
+      - name: Detect Central Portal credentials
+        id: guard
+        env:
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+        run: |
+          if [ -n "$CENTRAL_PORTAL_USERNAME" ]; then
+            echo "has_central=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_central=false" >> "$GITHUB_OUTPUT"
+            echo "CENTRAL_PORTAL_USERNAME not set - the Maven Central publish will be skipped."
           fi
 
       - name: Set up JDK 21
@@ -95,3 +114,31 @@ jobs:
             dist/Spyglass.jar dist/Spyglass-shaded.jar dist/Spyglass-Velocity.jar \
             --title "Spyglass ${{ steps.ver.outputs.version }}" \
             --notes-file dist/NOTES.md
+
+  # Publishes spyglass-api (Apache-2.0) to Maven Central, aligned with the
+  # GitHub release above. Runs only when a new release was just cut and the
+  # Central credentials are configured; otherwise it is skipped, not failed.
+  # One-time setup (account, namespace, signing key, secrets) is in PUBLISHING.md.
+  publish-maven-central:
+    needs: release
+    if: needs.release.outputs.release_exists == 'false' && needs.release.outputs.has_central == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Publish spyglass-api to Maven Central
+        env:
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishAggregationToCentralPortal --no-daemon --stacktrace

--- a/API.md
+++ b/API.md
@@ -12,20 +12,22 @@ access to the Spyglass plugin source.
 
 ## 1. Adding the dependency
 
-The API artifact is `net.medievalrp:spyglass-api:1.0.0`. Mark it
-`compileOnly` (Gradle) or `provided` (Maven) — at runtime the
-Spyglass plugin supplies the classes. Bundling them into your
+The API artifact is `net.medievalrp:spyglass-api`, published on
+Maven Central. Use the version matching the Spyglass release you
+build against (see the [releases page](https://github.com/medievalrp-net/Spyglass/releases)).
+Mark it `compileOnly` (Gradle) or `provided` (Maven): at runtime
+the Spyglass plugin supplies the classes. Bundling them into your
 shaded jar will cause classloader conflicts.
 
 ### Gradle (Kotlin DSL)
 
 ```kotlin
 repositories {
-    maven("https://repo.medievalrp.net/releases") // or wherever it's published
+    mavenCentral()
 }
 
 dependencies {
-    compileOnly("net.medievalrp:spyglass-api:1.0.0")
+    compileOnly("net.medievalrp:spyglass-api:1.0.7")
     compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
 }
 ```
@@ -34,7 +36,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    compileOnly 'net.medievalrp:spyglass-api:1.0.0'
+    compileOnly 'net.medievalrp:spyglass-api:1.0.7'
     compileOnly 'io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT'
 }
 ```
@@ -45,18 +47,18 @@ dependencies {
 <dependency>
     <groupId>net.medievalrp</groupId>
     <artifactId>spyglass-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.7</version>
     <scope>provided</scope>
 </dependency>
 ```
 
 ### Local jar (for prototyping)
 
-Drop `spyglass-api-1.0.0.jar` into a `libs/` folder and:
+Drop `spyglass-api-1.0.7.jar` into a `libs/` folder and:
 
 ```kotlin
 dependencies {
-    compileOnly(files("libs/spyglass-api-1.0.0.jar"))
+    compileOnly(files("libs/spyglass-api-1.0.7.jar"))
 }
 ```
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,75 @@
+# Publishing spyglass-api to Maven Central
+
+Only `spyglass-api` is published (Apache-2.0). The GPL modules
+(`spyglass-core`, `spyglass`, `spyglass-velocity`) stay unpublished internals.
+
+Coordinates: `net.medievalrp:spyglass-api:<version>`, where `<version>` is the
+project version in `gradle.properties`, so the library tracks each release.
+
+## How a release publishes it
+
+`.github/workflows/release.yml` runs on a version bump to `main`. After it cuts
+the GitHub release, the `publish-maven-central` job runs
+`./gradlew publishAggregationToCentralPortal`, which builds, signs, and uploads
+the artifact. The job is skipped (not failed) until the credentials below are
+set, so nothing here changes the release flow before setup is done.
+
+With `publishingType = "USER_MANAGED"` (in the root `build.gradle.kts`) the
+upload is validated and staged, then you log in to the Portal and click
+**Publish**. Central deployments are immutable once published, so this is the
+safe default. Switch to `"AUTOMATIC"` to release without the manual click.
+
+## One-time setup
+
+Done once, by a human. Until it is finished the publish job stays skipped.
+
+### 1. Central Portal account and namespace
+
+1. Sign in at [central.sonatype.com](https://central.sonatype.com) (GitHub works).
+2. Register the namespace `net.medievalrp`. The Portal gives you a TXT record;
+   add it to the `medievalrp.net` DNS (Cloudflare) and verify. This proves
+   domain ownership and reserves the group id.
+3. Generate a user token (Account -> Generate User Token). It returns a
+   username and password pair.
+
+### 2. GPG signing key
+
+Central rejects unsigned artifacts.
+
+```bash
+gpg --full-generate-key                       # RSA 4096, no expiry is fine
+gpg --list-secret-keys --keyid-format=long    # note the KEYID
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEYID>   # publish the public key
+gpg --armor --export-secret-keys <KEYID>      # the armored private key for CI
+```
+
+Central verifies signatures against the public key on the keyserver, so the
+`--send-keys` step is required.
+
+### 3. GitHub Actions secrets
+
+Repo -> Settings -> Secrets and variables -> Actions -> New repository secret:
+
+| Secret | Value |
+|--------|-------|
+| `CENTRAL_PORTAL_USERNAME` | username from the Portal user token |
+| `CENTRAL_PORTAL_PASSWORD` | password from the Portal user token |
+| `SIGNING_KEY` | the full armored private key block from `--export-secret-keys` (keep the newlines) |
+| `SIGNING_PASSWORD` | the key's passphrase |
+
+## Checking it locally (optional)
+
+No account needed.
+
+```bash
+# Inspect the generated POM and artifacts.
+./gradlew :spyglass-api:publishApiPublicationToLocalRepository
+ls build/repo/net/medievalrp/spyglass-api/
+
+# Stage the exact bundle CI would upload. Set the signing env first to include
+# the .asc signatures; without it the bundle is unsigned (fine for a dry run).
+export SIGNING_KEY="$(gpg --armor --export-secret-keys <KEYID>)"
+export SIGNING_PASSWORD=...
+./gradlew nmcpZipAggregation
+unzip -l build/nmcp/zip/aggregation.zip
+```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Root command is `/spyglass`, aliased to `/sg`. The full reference - every comman
 
 ## Modules
 
-- `spyglass-api/` is the public API. Third-party plugins depend on this only.
+- `spyglass-api/` is the public API. Third-party plugins depend on this only. Published to Maven Central as `net.medievalrp:spyglass-api`; see [API.md](API.md).
 - `spyglass-core/` holds the shared internals (codecs, storage glue).
 - `spyglass/` is the Paper plugin.
 - `spyglass-velocity/` is an optional Velocity proxy companion for cross-server search. It is read-only by design: it never writes records and never rolls back.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,29 @@
 plugins {
     base
+    // Aggregates module publications and uploads them to the Maven Central
+    // Portal. Only :spyglass-api is included (see the dependencies block below),
+    // so spyglass-core / spyglass / spyglass-velocity stay unpublished GPL
+    // internals. Publish task: publishAggregationToCentralPortal.
+    id("com.gradleup.nmcp.aggregation") version "1.6.1"
+}
+
+nmcpAggregation {
+    // Root project "Spyglass" and module "spyglass" collide under nmcp's
+    // case-insensitive duplicate-name guard. We aggregate exactly one project
+    // by path (:spyglass-api) below, so the name overlap is harmless here.
+    allowDuplicateProjectNames.set(true)
+    centralPortal {
+        username = System.getenv("CENTRAL_PORTAL_USERNAME")
+        password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+        // USER_MANAGED: CI uploads and validates the deployment, then a human
+        // clicks "Publish" in the Central Portal (releases are immutable once
+        // published). Switch to "AUTOMATIC" to release without that step.
+        publishingType = "USER_MANAGED"
+    }
+}
+
+dependencies {
+    nmcpAggregation(project(":spyglass-api"))
 }
 
 val paperApiVersion = "1.21.8-R0.1-SNAPSHOT"

--- a/spyglass-api/build.gradle.kts
+++ b/spyglass-api/build.gradle.kts
@@ -1,6 +1,13 @@
 plugins {
     `java-library`
     `maven-publish`
+    signing
+    // Marks this module as a Central Portal publishable unit. nmcp 1.x has no
+    // per-module publish task; the root aggregation plugin owns the upload task
+    // (publishAggregationToCentralPortal). Version comes from the root
+    // aggregation plugin's classpath, so it is omitted here. See the root
+    // build.gradle.kts.
+    id("com.gradleup.nmcp")
 }
 
 val paperApiVersion: String by rootProject.extra
@@ -44,12 +51,25 @@ publishing {
             artifactId = "spyglass-api"
             pom {
                 name.set("Spyglass API")
-                description.set("Public record / query / rollback types for the Spyglass forensics plugin.")
+                description.set("Public record, query, and rollback types for the Spyglass forensics plugin.")
                 url.set("https://github.com/medievalrp-net/Spyglass")
                 licenses {
                     license {
-                        name.set("MIT")
+                        name.set("Apache License 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
                     }
+                }
+                developers {
+                    developer {
+                        id.set("medievalrp")
+                        name.set("MedievalRP")
+                        url.set("https://medievalrp.net")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/medievalrp-net/Spyglass.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/medievalrp-net/Spyglass.git")
+                    url.set("https://github.com/medievalrp-net/Spyglass")
                 }
             }
         }
@@ -59,5 +79,18 @@ publishing {
             name = "local"
             url = uri(rootProject.layout.buildDirectory.dir("repo"))
         }
+    }
+}
+
+signing {
+    // Central requires every artifact be GPG-signed. CI supplies an
+    // ASCII-armored key and its passphrase via env; sign only when they are
+    // present so a local `build` / `publishToMavenLocal` still works keyless.
+    val signingKey = providers.environmentVariable("SIGNING_KEY").orNull
+    val signingPassword = providers.environmentVariable("SIGNING_PASSWORD").orNull
+    isRequired = signingKey != null
+    if (signingKey != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["api"])
     }
 }


### PR DESCRIPTION
Closes #194.

Publishes the Apache-2.0 `spyglass-api` module to Maven Central (Central Portal), aligned with each GitHub release. The GPL-3.0 `spyglass-core` / `spyglass` / `spyglass-velocity` modules stay unpublished.

## Decisions (the issue's "to define" list)

- **What's published:** `spyglass-api` only, coordinates `net.medievalrp:spyglass-api:<version>`.
- **Host:** Maven Central via the Central Portal (`net.medievalrp` namespace, verifiable through the `medievalrp.net` domain we own).
- **Versioning:** inherited from `gradle.properties`, so the library version equals the plugin release.
- **Workflow:** `release.yml` gains a `publish-maven-central` job on the existing release trigger.

## How it's wired

- **Root `build.gradle.kts`:** applies `com.gradleup.nmcp.aggregation`, includes only `:spyglass-api`, `USER_MANAGED` publishing type (upload + validate, then a human clicks Publish; Central releases are immutable).
- **`spyglass-api/build.gradle.kts`:** applies `com.gradleup.nmcp`, adds conditional GPG signing (in-memory key from env, skipped when keyless so local builds still work), and completes the POM for Central. Fixes the POM license, which incorrectly said **MIT** (the module is **Apache-2.0**), and adds the required `developers` + `scm`.
- **`release.yml`:** the publish job runs only when a new release was cut **and** the Central credentials exist; otherwise it's **skipped, not failed**, so the release flow keeps working until setup is done.
- **Docs:** `PUBLISHING.md` (one-time setup + release flow); `API.md`/`README.md` point consumers at Maven Central.

## Verification (local, no Central account needed)

- `./gradlew build` green, keyless — no regression (signing is a no-op without a key).
- Generated POM: `net.medievalrp:spyglass-api:1.0.7`, license Apache-2.0, developers + scm present, sources + javadoc jars.
- `nmcpZipAggregation` with an ephemeral GPG key staged the exact upload bundle: every artifact (jar/sources/javadoc/module/pom) had a `.asc` signature + md5/sha1/sha512, and **only** spyglass-api was included. One signature verified `Good signature`.
- `publishAggregationToCentralPortal` task resolves ("Publishes the aggregation to the Central Releases repository").

## Requires a one-time human setup before the first publish (in PUBLISHING.md)

The publish job stays skipped until these exist:
1. Central Portal account + verify the `net.medievalrp` namespace (DNS TXT on `medievalrp.net`).
2. A GPG key, public half pushed to a keyserver.
3. Four Actions secrets: `CENTRAL_PORTAL_USERNAME`, `CENTRAL_PORTAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD`.

I can't do these (they need the account + domain + repo-secret access).
