### PR TITLE
feat(listener): log automated hopper/dropper transfers (#226)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -55,6 +55,15 @@ public final class EventCatalog {
         m.put("drop", ItemDropRecord.class);
         m.put("pickup", ItemPickupRecord.class);
         m.put("clone", ItemPickupRecord.class);
+        // Automated container-to-container movement by a hopper / dropper /
+        // dispenser (InventoryMoveItemEvent, #226). Informational only, so it
+        // reuses the item drop/pickup record shapes - both storage backends
+        // already persist those, no codec/schema change. Both endpoints are
+        // logged so inspecting either container surfaces the flow: the source
+        // loses items (transfer-out) and the destination gains them
+        // (transfer-in).
+        m.put("transfer-out", ItemDropRecord.class);
+        m.put("transfer-in", ItemPickupRecord.class);
         m.put("teleport", TeleportRecord.class);
         m.put("death", EntityDeathRecord.class);
         // Killer-perspective mirror of a death. Reuses EntityHitRecord

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemDropRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemDropRecord.java
@@ -18,8 +18,19 @@ public record ItemDropRecord(
         StoredItem item) implements EventRecord {
 
     public static ItemDropRecord of(RecordContext ctx, String target, int amount, StoredItem item) {
+        return of(ctx, "drop", target, amount, item);
+    }
+
+    /**
+     * Same shape with an explicit event name, for events that reuse the drop
+     * record without being a world "drop" - e.g. the source side of an
+     * automated hopper/dropper transfer ("transfer-out", #226). Keeps
+     * EventCatalog's name to record-class mapping honest with no codec change.
+     */
+    public static ItemDropRecord of(RecordContext ctx, String event, String target, int amount,
+            StoredItem item) {
         return new ItemDropRecord(
-                ctx.id(), "drop", ctx.occurred(), ctx.expiresAt(),
+                ctx.id(), event, ctx.occurred(), ctx.expiresAt(),
                 ctx.origin(), ctx.source(), ctx.location(), ctx.server(), target, amount, item);
     }
 }

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemPickupRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemPickupRecord.java
@@ -18,8 +18,19 @@ public record ItemPickupRecord(
         StoredItem item) implements EventRecord {
 
     public static ItemPickupRecord of(RecordContext ctx, String target, int amount, StoredItem item) {
+        return of(ctx, "pickup", target, amount, item);
+    }
+
+    /**
+     * Same shape with an explicit event name, for events that reuse the pickup
+     * record without being a world "pickup" - e.g. the destination side of an
+     * automated hopper/dropper transfer ("transfer-in", #226). Keeps
+     * EventCatalog's name to record-class mapping honest with no codec change.
+     */
+    public static ItemPickupRecord of(RecordContext ctx, String event, String target, int amount,
+            StoredItem item) {
         return new ItemPickupRecord(
-                ctx.id(), "pickup", ctx.occurred(), ctx.expiresAt(),
+                ctx.id(), event, ctx.occurred(), ctx.expiresAt(),
                 ctx.origin(), ctx.source(), ctx.location(), ctx.server(), target, amount, item);
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -83,8 +83,10 @@ import net.medievalrp.spyglass.plugin.listener.environment.EntityExplodeListener
 import net.medievalrp.spyglass.plugin.listener.environment.LeavesDecayListener;
 import net.medievalrp.spyglass.plugin.listener.environment.StructureGrowListener;
 import net.medievalrp.spyglass.plugin.listener.item.CreativeCloneListener;
+import net.medievalrp.spyglass.plugin.listener.item.HopperTransferListener;
 import net.medievalrp.spyglass.plugin.listener.item.ItemDropListener;
 import net.medievalrp.spyglass.plugin.listener.item.ItemPickupListener;
+import net.medievalrp.spyglass.plugin.listener.item.TransferDedup;
 import net.medievalrp.spyglass.plugin.listener.modern.BookshelfListener;
 import net.medievalrp.spyglass.plugin.listener.modern.BrushListener;
 import net.medievalrp.spyglass.plugin.listener.modern.BundleTransactionListener;
@@ -373,6 +375,10 @@ public final class SpyglassPlugin extends JavaPlugin {
         net.medievalrp.spyglass.api.util.EventIds.bindInstance(config.server().name().hashCode());
         RecordingSupport support = new RecordingSupport(config.storage().retention(), config.server().name());
         DelayedInteractionTracker delayedTracker = new DelayedInteractionTracker(this);
+        // #226: shared between the hopper-transfer listener and the purge timer
+        // below. Collapses repeating automated hopper flow so a farm line does
+        // not flood the store; holds no Bukkit state.
+        TransferDedup transferDedup = new TransferDedup();
 
         // Every recording listener in one list. `events()` declares the event
         // names each emits; we register with Bukkit only when at least one is
@@ -405,6 +411,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new BlockIgniteListener(recorder, support, this),
                 new ItemDropListener(recorder, support),
                 new ItemPickupListener(recorder, support, deferredSerializer),
+                new HopperTransferListener(recorder, support, deferredSerializer,
+                        enabledEvents, transferDedup),
                 new CreativeCloneListener(recorder, support),
                 new TeleportListener(recorder, support),
                 new EntityDeathListener(recorder, support, enabledEvents, deferredSerializer),
@@ -681,10 +689,15 @@ public final class SpyglassPlugin extends JavaPlugin {
         // is 2x the TTL (30 s), meaning every cohort of cascade cells is guaranteed
         // at least one full sweep opportunity before a second TTL window elapses.
         // Delay matches the period so the first pass is not immediately at boot.
+        // #226: the transfer dedup is a ConcurrentHashMap on the same 30 s
+        // window, so it piggybacks on this sweep - same off-main, no
+        // Bukkit-access safety as the falling-block purge.
         final long PURGE_PERIOD_TICKS = 1200L; // 60 s at 20 TPS
         this.fallingBlockPurgeTask = getServer().getScheduler()
-                .runTaskTimerAsynchronously(this, FallingBlockTracker::purgeExpired,
-                        PURGE_PERIOD_TICKS, PURGE_PERIOD_TICKS);
+                .runTaskTimerAsynchronously(this, () -> {
+                    FallingBlockTracker.purgeExpired();
+                    transferDedup.purgeExpired();
+                }, PURGE_PERIOD_TICKS, PURGE_PERIOD_TICKS);
 
         // #168: periodic ingest analytics report (off the main thread; only
         // reads concurrent counters + cheap gauges). Off unless analytics.enabled.

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/HopperTransferListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/HopperTransferListener.java
@@ -1,0 +1,130 @@
+package net.medievalrp.spyglass.plugin.listener.item;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import net.medievalrp.spyglass.api.event.ItemDropRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
+import net.medievalrp.spyglass.api.event.RecordContext;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.listener.RecordingListener;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Logs automated container-to-container item movement by a hopper, dropper or
+ * dispenser ({@code InventoryMoveItemEvent}) - CoreProtect's {@code
+ * hopper-transactions} parity (#226). Player container access is handled by
+ * {@link net.medievalrp.spyglass.plugin.listener.container.ContainerTransactionListener};
+ * this is the automated flow that had no listener before.
+ *
+ * <p>Both endpoints are recorded so inspecting either container surfaces the
+ * movement: {@code transfer-out} on the source (items left it, an {@link
+ * ItemDropRecord}) and {@code transfer-in} on the destination (items arrived,
+ * an {@link ItemPickupRecord}). Both are forensic-only, never rolled back - an
+ * area rollback must not try to reverse thousands of hopper ticks, and the
+ * records reuse the informational item shapes so no store change is needed.
+ *
+ * <p>This event fires on the server thread on every hopper tick, so the
+ * handler only takes a bounded snapshot inline (clone the moved stack, read
+ * the two block coordinates and the mover type). The {@link TransferDedup}
+ * check, the item projection, the record build and {@code recorder.record}
+ * all run off-main on the injected serializer, matching {@link
+ * ItemPickupListener}.
+ */
+@ApiStatus.Internal
+public final class HopperTransferListener implements RecordingListener {
+
+    private final Recorder recorder;
+    private final RecordingSupport support;
+    private final Executor serializer;
+    // Per-event gating: the plugin gates only at listener-registration
+    // granularity, so the independent transfer-in / transfer-out toggles must
+    // be honoured here. Live, thread-safe view of the enabled set.
+    private final Set<String> enabledEvents;
+    private final TransferDedup dedup;
+
+    public HopperTransferListener(Recorder recorder, RecordingSupport support, Executor serializer,
+            Set<String> enabledEvents, TransferDedup dedup) {
+        this.recorder = recorder;
+        this.support = support;
+        this.serializer = serializer;
+        this.enabledEvents = enabledEvents;
+        this.dedup = dedup;
+    }
+
+    @Override
+    public Set<String> events() {
+        return Set.of("transfer-in", "transfer-out");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryMoveItem(InventoryMoveItemEvent event) {
+        boolean logOut = enabledEvents.contains("transfer-out");
+        boolean logIn = enabledEvents.contains("transfer-in");
+        if (!logOut && !logIn) {
+            return;
+        }
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        Location sourceLoc = event.getSource().getLocation();
+        Location destLoc = event.getDestination().getLocation();
+        if (sourceLoc == null || destLoc == null) {
+            // A virtual inventory with no world position: nothing to attribute.
+            return;
+        }
+        // Cheap snapshot on the server thread: clone the moved stack (the live
+        // one is about to be transferred and may be merged/mutated), read the
+        // two block coordinates and the mover mechanic. Everything expensive
+        // runs off-main below.
+        ItemStack snapshot = item.clone();
+        String material = item.getType().name();
+        int amount = item.getAmount();
+        // The mover mechanic (hopper / dropper / dispenser) for attribution.
+        // Guarded because a mocked or unusual inventory can report a null type.
+        InventoryType initiatorType = event.getInitiator().getType();
+        String mover = initiatorType != null
+                ? initiatorType.name().toLowerCase(Locale.ROOT)
+                : "hopper";
+        BlockLocation source = BlockLocations.fromLocation(sourceLoc);
+        BlockLocation dest = BlockLocations.fromLocation(destLoc);
+        TransferDedup.Key key = new TransferDedup.Key(
+                source.worldName(), source.x(), source.y(), source.z(),
+                dest.x(), dest.y(), dest.z(), material);
+
+        serializer.execute(() -> {
+            if (!dedup.shouldLog(key)) {
+                return;      // steady farm flow already logged this window
+            }
+            StoredItem stored = ItemSerialization.storedItemProjection(0, snapshot);
+            if (stored == null) {
+                return;
+            }
+            if (logOut) {
+                RecordContext ctx = support.context(
+                        support.environmentOrigin("transfer:" + mover),
+                        support.environmentSource(mover), source);
+                recorder.record(ItemDropRecord.of(ctx, "transfer-out", material, amount, stored));
+            }
+            if (logIn) {
+                RecordContext ctx = support.context(
+                        support.environmentOrigin("transfer:" + mover),
+                        support.environmentSource(mover), dest);
+                recorder.record(ItemPickupRecord.of(ctx, "transfer-in", material, amount, stored));
+            }
+        });
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/TransferDedup.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/item/TransferDedup.java
@@ -1,0 +1,93 @@
+package net.medievalrp.spyglass.plugin.listener.item;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Time-windowed dedup for automated hopper/dropper transfers (#226).
+ *
+ * <p>{@code InventoryMoveItemEvent} fires once per item per hopper tick, so a
+ * single farm hopper line would otherwise flood the store (the #197 disk
+ * case). This collapses a repeating {@code (source, destination, material)}
+ * transfer to at most one logged record per {@code windowMillis}. The window
+ * is anchored on the first log in a burst: once a key logs, identical
+ * transfers are suppressed until the window elapses, then the next one logs
+ * and re-arms. It is the analogue of CoreProtect's {@code hopperAbort}.
+ *
+ * <p>Consulted off the main thread from the recorder's serializer stage, so it
+ * is thread-safe (a {@link ConcurrentHashMap} with an atomic {@code compute}).
+ * It holds no Bukkit state; {@link #purgeExpired()} drops stale keys and is
+ * swept on the same async timer as the falling-block tracker.
+ */
+@ApiStatus.Internal
+public final class TransferDedup {
+
+    /** At most one transfer record per this long, per distinct key. */
+    public static final long DEFAULT_WINDOW_MILLIS = 30_000L;
+
+    /**
+     * Safety cap on tracked keys. The live key count is bounded by the number
+     * of active hopper pairs on the server, but a cap plus an opportunistic
+     * purge keeps a pathological setup from growing the map without bound
+     * between scheduled sweeps.
+     */
+    public static final int DEFAULT_MAX_ENTRIES = 100_000;
+
+    /**
+     * Identity of a transfer: the source and destination block coordinates
+     * (always the same world for adjacent containers) plus the moved material.
+     */
+    public record Key(String world, int sx, int sy, int sz, int dx, int dy, int dz, String material) {
+    }
+
+    private final long windowMillis;
+    private final int maxEntries;
+    // key -> epoch millis of the log that opened the current window.
+    private final Map<Key, Long> lastLogged = new ConcurrentHashMap<>();
+
+    public TransferDedup() {
+        this(DEFAULT_WINDOW_MILLIS, DEFAULT_MAX_ENTRIES);
+    }
+
+    public TransferDedup(long windowMillis, int maxEntries) {
+        this.windowMillis = windowMillis;
+        this.maxEntries = maxEntries;
+    }
+
+    /** True when this transfer should be logged now (production entry point). */
+    public boolean shouldLog(Key key) {
+        return shouldLog(key, System.currentTimeMillis());
+    }
+
+    // Package-private with an injected clock, for deterministic tests.
+    boolean shouldLog(Key key, long nowMillis) {
+        boolean[] log = {false};
+        lastLogged.compute(key, (k, anchor) -> {
+            if (anchor != null && nowMillis - anchor < windowMillis) {
+                return anchor;      // still inside the window: suppress, keep the anchor
+            }
+            log[0] = true;
+            return nowMillis;       // first of a fresh window: log and (re)arm
+        });
+        if (log[0] && lastLogged.size() > maxEntries) {
+            purgeExpired(nowMillis);
+        }
+        return log[0];
+    }
+
+    /** Drop keys whose window has fully elapsed (keeping them would be a no-op). */
+    public void purgeExpired() {
+        purgeExpired(System.currentTimeMillis());
+    }
+
+    // Package-private with an injected clock, for deterministic tests.
+    void purgeExpired(long nowMillis) {
+        lastLogged.entrySet().removeIf(entry -> nowMillis - entry.getValue() >= windowMillis);
+    }
+
+    // Package-private, for tests.
+    int size() {
+        return lastLogged.size();
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -313,6 +313,15 @@ events {
   drop = { enabled = true, past-tense = "dropped" }
   pickup = { enabled = true, past-tense = "picked up" }
   clone = { enabled = true, past-tense = "cloned" }
+  # Automated container-to-container item movement by a hopper / dropper /
+  # dispenser (#226). transfer-out logs on the source container (items left
+  # it), transfer-in on the destination (items arrived). Repeated identical
+  # moves are collapsed to at most one record per ~30s, so a farm hopper line
+  # does not flood the store; disable either side here if you do not want the
+  # traffic. On by default for CoreProtect parity (its hopper-transactions
+  # also defaults on).
+  transfer-out = { enabled = true, past-tense = "piped out" }
+  transfer-in = { enabled = true, past-tense = "piped in" }
   teleport = { enabled = true, past-tense = "teleported" }
   death = { enabled = true, past-tense = "died" }
   kill = { enabled = true, past-tense = "killed" }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/HopperTransferListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/HopperTransferListenerTest.java
@@ -1,0 +1,213 @@
+package net.medievalrp.spyglass.plugin.listener.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.ItemDropRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The automated hopper/dropper transfer listener (#226). Pins the two
+ * invariants that matter: the source and destination are both logged
+ * (transfer-out / transfer-in) with no work done inline on the server thread
+ * (everything runs on the injected serializer), and a sustained flow is
+ * collapsed by the dedup instead of flooding the store.
+ */
+class HopperTransferListenerTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Location's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void logsBothEndpointsOnTheExecutorNotInline() {
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled("transfer-in", "transfer-out"),
+                new TransferDedup(60_000L, 1000));
+
+        listener.onInventoryMoveItem(move(mockStack(Material.COBBLESTONE, 3)));
+
+        // Nothing recorded inline: one deferred task, no records yet.
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(2);
+        ItemDropRecord out = (ItemDropRecord) find("transfer-out");
+        ItemPickupRecord in = (ItemPickupRecord) find("transfer-in");
+        // transfer-out sits on the source block, transfer-in on the destination.
+        assertThat(out.location().y()).isEqualTo(64);
+        assertThat(in.location().y()).isEqualTo(63);
+        assertThat(out.target()).isEqualTo("COBBLESTONE");
+        assertThat(in.target()).isEqualTo("COBBLESTONE");
+        assertThat(out.amount()).isEqualTo(3);
+        assertThat(in.amount()).isEqualTo(3);
+        assertThat(in.item().material()).isEqualTo("COBBLESTONE");
+    }
+
+    @Test
+    void collapsesRepeatedMovesToASinglePair() {
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled("transfer-in", "transfer-out"),
+                new TransferDedup(60_000L, 1000));
+
+        // A hopper line firing the identical move five times in one window.
+        for (int i = 0; i < 5; i++) {
+            listener.onInventoryMoveItem(move(mockStack(Material.COBBLESTONE, 1)));
+        }
+        assertThat(deferred).hasSize(5);
+        deferred.forEach(Runnable::run);
+
+        // Only the first move logs; the rest are deduped away.
+        assertThat(recorder.records).hasSize(2);
+    }
+
+    @Test
+    void honoursPerEventToggle() {
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled("transfer-out"),
+                new TransferDedup(60_000L, 1000));
+
+        listener.onInventoryMoveItem(move(mockStack(Material.COBBLESTONE, 1)));
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        assertThat(recorder.records.get(0).event()).isEqualTo("transfer-out");
+    }
+
+    @Test
+    void bothDisabledDoesNothingAndDefersNothing() {
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled(), new TransferDedup(60_000L, 1000));
+
+        listener.onInventoryMoveItem(move(mockStack(Material.COBBLESTONE, 1)));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void ignoresAirWithoutCloningOrDeferring() {
+        ItemStack air = mock(ItemStack.class);
+        when(air.getType()).thenReturn(Material.AIR);
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled("transfer-in", "transfer-out"),
+                new TransferDedup(60_000L, 1000));
+
+        listener.onInventoryMoveItem(move(air));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+        verify(air, never()).clone();
+    }
+
+    @Test
+    void skipsVirtualInventoryWithNoLocation() {
+        List<Runnable> deferred = new ArrayList<>();
+        HopperTransferListener listener = listener(deferred, enabled("transfer-in", "transfer-out"),
+                new TransferDedup(60_000L, 1000));
+
+        InventoryMoveItemEvent event = move(mockStack(Material.COBBLESTONE, 1));
+        when(event.getSource().getLocation()).thenReturn(null);  // a virtual (blockless) inventory
+
+        listener.onInventoryMoveItem(event);
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────
+
+    private HopperTransferListener listener(List<Runnable> deferred, Set<String> enabled, TransferDedup dedup) {
+        return new HopperTransferListener(recorder, support, deferred::add, enabled, dedup);
+    }
+
+    private static Set<String> enabled(String... names) {
+        return new HashSet<>(List.of(names));
+    }
+
+    private EventRecord find(String event) {
+        return recorder.records.stream()
+                .filter(r -> r.event().equals(event))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no record for event " + event));
+    }
+
+    private InventoryMoveItemEvent move(ItemStack stack) {
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+
+        Inventory source = mock(Inventory.class);
+        when(source.getLocation()).thenReturn(new Location(world, 10, 64, 20));
+        Inventory destination = mock(Inventory.class);
+        when(destination.getLocation()).thenReturn(new Location(world, 10, 63, 20));
+        // getType() is left unstubbed (defaults to null): referencing a real
+        // InventoryType constant here would hit the registry, which is not
+        // bootstrapped in a unit test. The listener null-guards it to "hopper".
+        Inventory initiator = mock(Inventory.class);
+
+        InventoryMoveItemEvent event = mock(InventoryMoveItemEvent.class);
+        when(event.getItem()).thenReturn(stack);
+        when(event.getSource()).thenReturn(source);
+        when(event.getDestination()).thenReturn(destination);
+        when(event.getInitiator()).thenReturn(initiator);
+        return event;
+    }
+
+    private static ItemStack mockStack(Material material, int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(material);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.getItemMeta()).thenReturn(null);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
+        ItemStack clone = mock(ItemStack.class);
+        when(clone.getType()).thenReturn(material);
+        when(clone.getAmount()).thenReturn(amount);
+        when(clone.getItemMeta()).thenReturn(null);
+        when(clone.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
+        when(stack.clone()).thenReturn(clone);
+        return stack;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/TransferDedupTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/item/TransferDedupTest.java
@@ -1,0 +1,86 @@
+package net.medievalrp.spyglass.plugin.listener.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The automated-transfer throttle (#226): a repeating (source, dest, material)
+ * hopper flow must collapse to at most one record per window, or a farm line
+ * floods the store. Time is injected so the window behaviour is deterministic.
+ */
+class TransferDedupTest {
+
+    private static TransferDedup.Key key(String material) {
+        return new TransferDedup.Key("world", 0, 64, 0, 0, 63, 0, material);
+    }
+
+    @Test
+    void logsFirstThenSuppressesWithinWindow() {
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        TransferDedup.Key k = key("COBBLESTONE");
+        assertThat(dedup.shouldLog(k, 0L)).isTrue();
+        assertThat(dedup.shouldLog(k, 200L)).isFalse();
+        assertThat(dedup.shouldLog(k, 999L)).isFalse();
+    }
+
+    @Test
+    void reArmsOnceTheWindowElapses() {
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        TransferDedup.Key k = key("COBBLESTONE");
+        assertThat(dedup.shouldLog(k, 0L)).isTrue();
+        assertThat(dedup.shouldLog(k, 1000L)).isTrue();   // window elapsed, re-arm
+        assertThat(dedup.shouldLog(k, 1500L)).isFalse();  // suppressed again
+    }
+
+    @Test
+    void distinctKeysAreIndependent() {
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        assertThat(dedup.shouldLog(key("COBBLESTONE"), 0L)).isTrue();
+        assertThat(dedup.shouldLog(key("DIRT"), 0L)).isTrue();
+        // A different destination coordinate is a different transfer.
+        TransferDedup.Key otherDest = new TransferDedup.Key("world", 0, 64, 0, 5, 63, 0, "COBBLESTONE");
+        assertThat(dedup.shouldLog(otherDest, 0L)).isTrue();
+    }
+
+    @Test
+    void collapsesASustainedStreamToOnePerWindow() {
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        TransferDedup.Key k = key("COBBLESTONE");
+        int logged = 0;
+        // A hopper "moving" every 25 ms for 2.5 s: 100 ticks.
+        for (int t = 0; t < 2500; t += 25) {
+            if (dedup.shouldLog(k, t)) {
+                logged++;
+            }
+        }
+        // Windows anchored at 0, 1000, 2000 -> three logged, not one hundred.
+        assertThat(logged).isEqualTo(3);
+    }
+
+    @Test
+    void purgeExpiredDropsStaleKeys() {
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        dedup.shouldLog(key("COBBLESTONE"), 0L);
+        dedup.shouldLog(key("DIRT"), 0L);
+        assertThat(dedup.size()).isEqualTo(2);
+
+        dedup.purgeExpired(500L);   // still inside the window: nothing dropped
+        assertThat(dedup.size()).isEqualTo(2);
+
+        dedup.purgeExpired(1000L);  // window elapsed for both: dropped
+        assertThat(dedup.size()).isZero();
+    }
+
+    @Test
+    void purgeCannotResurrectSuppression() {
+        // Purging a key that has expired is a no-op for correctness: the next
+        // transfer logs either way. Guard against a regression that would purge
+        // a still-live anchor and let a farm burst through.
+        TransferDedup dedup = new TransferDedup(1000L, 1000);
+        TransferDedup.Key k = key("COBBLESTONE");
+        assertThat(dedup.shouldLog(k, 0L)).isTrue();
+        dedup.purgeExpired(500L);                     // live anchor kept
+        assertThat(dedup.shouldLog(k, 600L)).isFalse();
+    }
+}


### PR DESCRIPTION
Closes #226.

## What

Logs automated container-to-container item movement by a hopper, dropper or dispenser (`InventoryMoveItemEvent`), which had no listener. Player container access was already logged; this is the automated flow that CoreProtect logs on by default (`hopper-transactions`) and we did not, so a migrating server silently lost that coverage.

Both endpoints are recorded so inspecting either container surfaces the movement:
- `transfer-out` on the source (items left it)
- `transfer-in` on the destination (items arrived)

## Design (decisions set with the maintainer)

- **On by default**, for CoreProtect drop-in parity. Survivable only because of the dedup below.
- **Off-main.** `InventoryMoveItemEvent` fires on the server thread every hopper tick, so the handler takes only a bounded snapshot inline (clone the moved stack, read the two block coords and the mover type). Dedup, item projection, record build and `recorder.record` all run on the deferred serializer, matching `ItemPickupListener`.
- **Informational only, not rollbackable.** Reuses the `ItemDrop` / `ItemPickup` record shapes, so there is no new record type, no sealed-permit change, and no Mongo/ClickHouse codec or schema change. Keeps full who/what/where forensics; deliberately does not let an area rollback try to reverse thousands of automated hopper ticks. This is the one axis where we diverge from CoreProtect on purpose.

## Dedup (the volume control)

`TransferDedup` collapses a repeating `(source, dest, material)` transfer to at most one record per 30s window (anchored on the first log in a burst, then re-arms). This is the analogue of CoreProtect's `hopperAbort` and keeps a farm hopper line from flooding the store (the #197 disk case). It holds no Bukkit state and is swept on the existing falling-block purge timer. Window is a constant for now; exposing it as config is a possible follow-up.

## Touch points

`EventCatalog` (two name mappings), `config.conf` (two `events.*` defaults, both enabled), the new `HopperTransferListener` + `TransferDedup`, and the plugin wiring. Both events decode via `EventCatalog.recordClassOf` on all five store paths, so SQLite / MariaDB / ClickHouse / Mongo persist and return them with no store change.

## Testing

- `TransferDedupTest` (6): window suppress/re-arm, distinct-key independence, a sustained stream collapsing to 3 logs not 100, purge eviction, and a purge-cannot-resurrect-suppression guard.
- `HopperTransferListenerTest` (6): both endpoints logged off-main (nothing inline), repeated moves collapsed to a single pair, per-event toggle honored, both-disabled no-op, AIR ignored, virtual (blockless) inventory skipped.
- `./gradlew check build` green across all modules; jacoco floors held. Docker was up, so the ClickHouse / MariaDB / Mongo store ITs ran (173 core tests, 0 failed, 0 skipped).

Not verified in-game yet - flagging that for a live smoke on a throwaway server before this ships to prod.
