### PR TITLE
feat(listener): log water/lava bucket empty and fill (#228)

### DIFF
--- a/regression/bot/_bucket-gameplay.js
+++ b/regression/bot/_bucket-gameplay.js
@@ -1,0 +1,163 @@
+// End-to-end proof for bucket fluid logging (#228). As a real player the bot:
+//   - empties a water / lava / powder-snow bucket  -> a `bucket-empty` record
+//   - fills a bucket from a water source            -> a `bucket-fill` record
+// then for each: /spyglass search finds it, and /spyglass rollback REMOVES the
+// poured fluid (empty) or RESTORES the scooped source (fill). World state is
+// asserted via RCON `execute if block`, never a plugin summary alone.
+//
+// Buckets fire PlayerBucketEmpty/FillEvent only from a real interaction, so the
+// bot uses the item (activateItem); vanilla BucketItem raycasts server-side from
+// the player's look, so lookAt(target) + activateItem() places/collects the
+// fluid at the looked-at block. Exits 0 all-pass, 1 failed check, 2 harness error.
+//
+// Env: SG_PORT / SG_RCON_PORT / SG_RCON_PASS (see the runner). BOT_VERSION optional.
+import mineflayer from 'mineflayer';
+import { Vec3 } from 'vec3';
+import {
+    HOST, PORT, rcon, sleep, blockIs,
+    nextPlot, claimPlot, releasePlot, give, equip,
+    sgSearch, sgOp, drain, grep,
+} from './cases/lib.js';
+
+const NAME = process.env.BOT_NAME || ('bk' + Date.now().toString(36).slice(-4));
+const VERSION = process.env.BOT_VERSION || false;
+
+const checks = [];
+const ck = (ok, note) => { checks.push({ ok: !!ok, note }); console.log(`${ok ? 'ok  ' : 'FAIL'}  ${note}`); };
+
+// Pour a fluid bucket (water/lava) so the fluid lands at (x,y,z): aim at the top
+// face of the solid block below the target and use the item. A fluid BucketItem
+// raycasts server-side on a use-item, so activateItem() places it. Re-equips (a
+// poured bucket empties) and verifies server-side across a couple of aim points.
+async function emptyBucket(bot, bucketItem, fluid, x, y, z) {
+    const aims = [
+        new Vec3(x + 0.5, y, z + 0.5),       // top face of block below target
+        new Vec3(x + 0.5, y + 0.5, z + 0.5), // target centre
+    ];
+    for (let attempt = 0; attempt < aims.length; attempt++) {
+        await equip(bot, bucketItem);
+        await bot.lookAt(aims[attempt], true);
+        await sleep(400);
+        try { bot.activateItem(); } catch { /* verified below */ }
+        await sleep(1000);
+        try { bot.deactivateItem(); } catch { }
+        if (await blockIs(x, y, z, fluid)) return true;
+        await sleep(600);
+    }
+    return blockIs(x, y, z, fluid);
+}
+
+// Fill a bucket from the fluid source at (x,y,z): aim at the source centre and
+// use an empty bucket. Verifies the source is gone server-side, one retry.
+async function fillBucket(bot, x, y, z) {
+    const aims = [
+        new Vec3(x + 0.5, y + 0.5, z + 0.5), // source centre
+        new Vec3(x + 0.5, y + 0.8, z + 0.5), // upper part (surface)
+        new Vec3(x + 0.5, y + 0.2, z + 0.5),
+    ];
+    for (let attempt = 0; attempt < aims.length; attempt++) {
+        await equip(bot, 'bucket');
+        await bot.lookAt(aims[attempt], true);
+        await sleep(400);
+        try { bot.activateItem(); } catch { /* verified below */ }
+        await sleep(1000);
+        try { bot.deactivateItem(); } catch { }
+        if (await blockIs(x, y, z, 'air')) return true;
+        await sleep(600);
+    }
+    return blockIs(x, y, z, 'air');
+}
+
+// One empty sub-test on its own plot: pour, search, rollback removes it.
+async function emptyCase(bot, label, bucketItem, fluid) {
+    const plot = nextPlot();
+    await claimPlot(bot, plot);
+    const T = [plot.cx + 2, plot.y, plot.cz];
+    try {
+        const poured = await emptyBucket(bot, bucketItem, fluid, ...T);
+        ck(poured, `${label}: emptied bucket -> ${fluid} source at ${T.join(',')}`);
+        await drain();
+
+        const lines = await sgSearch(bot, `p:${NAME} a:bucket-empty r:8 t:300s`);
+        const hit = grep(lines, new RegExp(`poured.*${fluid}|${fluid}`, 'i'));
+        ck(hit.length > 0, `${label}: /spyglass search a:bucket-empty shows ${fluid} (${(hit[0] || '(none)').trim()})`);
+
+        const rb = await sgOp(bot, 'rollback', `p:${NAME} a:bucket-empty r:8 t:300s`);
+        ck(rb.applied >= 1, `${label}: rollback applied ${rb.applied} (${rb.line.trim()})`);
+        await sleep(1500); // let any flow recede once the source is gone
+        ck(await blockIs(...T, 'air'), `${label}: rollback REMOVED the poured ${fluid} (${T.join(',')} -> air)`);
+    } finally {
+        await releasePlot(plot).catch(() => { });
+    }
+}
+
+// The fill sub-test: seed a water source (unlogged), scoop it, rollback restores.
+async function fillCase(bot) {
+    const plot = nextPlot();
+    await claimPlot(bot, plot);
+    const S = [plot.cx + 2, plot.y, plot.cz];
+    try {
+        // Unlogged setup: an open water source (no walls - a stone pocket would
+        // block the bot's line of sight to it). Flowing spread is harmless: an
+        // empty bucket raycasts SOURCE_ONLY, so it still collects the source.
+        await rcon(`setblock ${S[0]} ${S[1]} ${S[2]} water`);
+        await sleep(600);
+        ck(await blockIs(...S, 'water'), `fill: seeded a water source at ${S.join(',')}`);
+
+        const scooped = await fillBucket(bot, ...S);
+        ck(scooped, `fill: scooped the source (${S.join(',')} -> air)`);
+        await drain();
+
+        const lines = await sgSearch(bot, `p:${NAME} a:bucket-fill r:8 t:300s`);
+        const hit = grep(lines, /scooped.*WATER|WATER/i);
+        ck(hit.length > 0, `fill: /spyglass search a:bucket-fill shows WATER (${(hit[0] || '(none)').trim()})`);
+
+        // Plain coordinate lookup (no a:) must surface the bucket event too.
+        const plain = await sgSearch(bot, `p:${NAME} r:8 t:300s`);
+        ck(grep(plain, /scooped|bucket|WATER/i).length > 0, 'fill: plain lookup at the coords surfaces the event');
+
+        const rb = await sgOp(bot, 'rollback', `p:${NAME} a:bucket-fill r:8 t:300s`);
+        ck(rb.applied >= 1, `fill: rollback applied ${rb.applied} (${rb.line.trim()})`);
+        await sleep(1200);
+        ck(await blockIs(...S, 'water'), `fill: rollback RESTORED the scooped water (${S.join(',')} -> water)`);
+    } finally {
+        await releasePlot(plot).catch(() => { });
+    }
+}
+
+(async () => {
+    const bot = mineflayer.createBot({
+        host: HOST, port: PORT, username: NAME,
+        version: VERSION, auth: 'offline', checkTimeoutInterval: 180_000,
+    });
+    await new Promise((res, rej) => {
+        bot.once('spawn', res);
+        bot.once('error', rej);
+        bot.once('kicked', r => rej(new Error('kicked: ' + (typeof r === 'string' ? r : JSON.stringify(r)))));
+        setTimeout(() => rej(new Error('spawn timeout (60s)')), 60_000);
+    });
+    await rcon(`op ${NAME}`);
+    await rcon(`gamemode creative ${NAME}`);
+    await sleep(800);
+    bot.chatLog = [];
+    bot.on('messagestr', m => bot.chatLog.push(m));
+
+    // BUCKET_ONLY=water,fill restricts the run (default: all). Powder snow is a
+    // BlockItem (fires BlockPlaceEvent, logged as `place`) so it is out of scope
+    // for this listener and not exercised here.
+    const only = (process.env.BUCKET_ONLY || '').split(',').map(s => s.trim()).filter(Boolean);
+    const want = name => only.length === 0 || only.includes(name);
+    try {
+        if (want('water')) await emptyCase(bot, 'water', 'water_bucket', 'water');
+        if (want('lava')) await emptyCase(bot, 'lava', 'lava_bucket', 'lava');
+        if (want('fill')) await fillCase(bot);
+    } catch (e) {
+        ck(false, 'harness error: ' + (e?.message || e));
+    }
+
+    bot.quit();
+    await sleep(1000);
+    const failed = checks.filter(c => !c.ok).length;
+    console.log(`\nBUCKET ${failed === 0 ? 'PASS' : 'FAIL'} - ${checks.length - failed}/${checks.length} checks (v=${VERSION})`);
+    process.exit(failed === 0 ? 0 : 1);
+})().catch(e => { console.log('BUCKET ERROR:', e?.message || e); process.exit(2); });

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -64,6 +64,14 @@ public final class EventCatalog {
         // (transfer-in).
         m.put("transfer-out", ItemDropRecord.class);
         m.put("transfer-in", ItemPickupRecord.class);
+        // Bucket-placed / bucket-picked-up fluid (#228). A poured water/lava/
+        // powder-snow source fires no BlockPlaceEvent, so without these it is
+        // invisible and unrollbackable. They reuse the block place/break record
+        // shapes - already rollbackable and persisted by every backend, no
+        // codec/schema change - so bucket-empty rolls back like a place (removes
+        // the fluid) and bucket-fill like a break (restores it).
+        m.put("bucket-empty", BlockPlaceRecord.class);
+        m.put("bucket-fill", BlockBreakRecord.class);
         m.put("teleport", TeleportRecord.class);
         m.put("death", EntityDeathRecord.class);
         // Killer-perspective mirror of a death. Reuses EntityHitRecord

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -55,6 +55,7 @@ import net.medievalrp.spyglass.plugin.listener.RecordingListener;
 import net.medievalrp.spyglass.plugin.listener.block.BlockBreakListener;
 import net.medievalrp.spyglass.plugin.listener.block.BlockMultiPlaceListener;
 import net.medievalrp.spyglass.plugin.listener.block.BlockPlaceListener;
+import net.medievalrp.spyglass.plugin.listener.block.BucketListener;
 import net.medievalrp.spyglass.plugin.listener.block.ContainerDropListener;
 import net.medievalrp.spyglass.plugin.listener.block.DependantBreakListener;
 import net.medievalrp.spyglass.plugin.listener.block.FallingBlockLandListener;
@@ -392,6 +393,10 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new BlockBurnListener(recorder, support, this),
                 new BlockPlaceListener(recorder, support, deferredSerializer),
                 new BlockMultiPlaceListener(recorder, support),
+                // Bucket-placed / -removed fluid (#228). Reuses the block
+                // place/break records; per-event gated on enabledEvents like the
+                // hopper listener since one listener carries both toggles.
+                new BucketListener(recorder, support, deferredSerializer, enabledEvents),
                 new FallingBlockLandListener(recorder, support),
                 new ContainerTransactionListener(recorder, support, deferredSerializer),
                 new ContainerDragListener(recorder, support),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BucketListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/block/BucketListener.java
@@ -1,0 +1,165 @@
+package net.medievalrp.spyglass.plugin.listener.block;
+
+import java.util.Set;
+import java.util.concurrent.Executor;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.RecordContext;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.listener.RecordingListener;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import net.medievalrp.spyglass.plugin.util.BlockSnapshots;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Logs fluid placement and pickup by a bucket - CoreProtect's
+ * {@code PlayerBucketEmptyListener} / {@code PlayerBucketFillListener} parity
+ * (#228). A bucket-placed water or lava source does NOT fire a
+ * {@link org.bukkit.event.block.BlockPlaceEvent}, so without this listener a
+ * poured moat or a lava-griefed build leaves no trace and cannot be rolled
+ * back.
+ *
+ * <p>Scope is water and lava (including fish / axolotl / tadpole buckets, which
+ * place a water source). A powder-snow bucket is deliberately out of scope: it
+ * is a {@code SolidBucketItem} (a {@code BlockItem}), so emptying one fires a
+ * normal {@code BlockPlaceEvent} and is already logged and rolled back as a
+ * {@code place} by {@link BlockPlaceListener} - not a {@code PlayerBucketEmptyEvent}.
+ *
+ * <p>Two event names, both reusing an existing rollbackable record shape so
+ * there is no new record type and no store/codec change (the #226 lever):
+ * <ul>
+ *   <li>{@code bucket-empty} -> {@link BlockPlaceRecord}: the fluid source
+ *       block appeared, so a rollback removes it.</li>
+ *   <li>{@code bucket-fill} -> {@link BlockBreakRecord}: the fluid source
+ *       block was removed, so a rollback restores it.</li>
+ * </ul>
+ * Unlike the automated hopper flow (#226) these are player-driven, single
+ * block, player-rate actions - exactly what rollback is for - so they are
+ * rolled back and need no dedup.
+ *
+ * <p><b>Capture timing differs from {@link BlockPlaceListener}.</b> A
+ * {@code BlockPlaceEvent} fires <em>after</em> the world changes, so that
+ * listener reads {@code getBlock()} as the placed (after) state. A bucket event
+ * fires <em>before</em> the world changes and is cancellable, so at
+ * {@link EventPriority#MONITOR} the block is still in its pre-change state:
+ * <ul>
+ *   <li>bucket-empty: {@code getBlock()} is the soon-to-be-fluid block, still
+ *       holding the old state - captured as the "before". The "after" fluid
+ *       source is synthesized from the bucket material (matching {@code
+ *       BlockIgniteListener}, which synthesizes the FIRE it places).</li>
+ *   <li>bucket-fill: {@code getBlock()} is the fluid being picked up, still
+ *       present - captured as the "before". The "after" is air.</li>
+ * </ul>
+ *
+ * <p>As with the block listeners the live capture happens on the main thread
+ * ({@link BlockSnapshots#captureRawCached}) and only the {@code getAsString()}
+ * serialization is deferred to the injected serializer (#154). Sharing that
+ * serializer keeps the rollback read-your-writes flush barrier (#98) intact, so
+ * a rollback immediately after a pour still sees the record.
+ */
+@ApiStatus.Internal
+public final class BucketListener implements RecordingListener {
+
+    private final Recorder recorder;
+    private final RecordingSupport support;
+    private final Executor serializer;
+    // Per-event gating: the plugin gates only at listener-registration
+    // granularity (registers when any declared event is enabled), so the
+    // independent bucket-empty / bucket-fill toggles are honoured here. Live,
+    // thread-safe view of the enabled set.
+    private final Set<String> enabledEvents;
+
+    public BucketListener(Recorder recorder, RecordingSupport support, Executor serializer,
+            Set<String> enabledEvents) {
+        this.recorder = recorder;
+        this.support = support;
+        this.serializer = serializer;
+        this.enabledEvents = enabledEvents;
+    }
+
+    @Override
+    public Set<String> events() {
+        return Set.of("bucket-empty", "bucket-fill");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBucketEmpty(PlayerBucketEmptyEvent event) {
+        if (!enabledEvents.contains("bucket-empty")) {
+            return;
+        }
+        Material fluid = fluidOf(event.getBucket());
+        if (fluid == null) {
+            // A milk bucket (drunk, not emptied into the world) or an
+            // unrecognised bucket variant - nothing to place, so nothing to log.
+            return;
+        }
+        Block block = event.getBlock();
+        // Pre-change: the block still holds the state the pour replaces. This is
+        // the "before" a rollback restores when it removes the poured fluid.
+        BlockSnapshots.RawCapture rawBefore = BlockSnapshots.captureRawCached(block);
+        // The placed fluid source. createBlockData() on the main thread mirrors
+        // BlockIgniteListener; getAsString() stays deferred to the serializer.
+        BlockData afterData = fluid.createBlockData();
+        BlockLocation location = BlockLocations.fromBlock(block);
+        // Stamp occurred + id at event time (#98) so an immediately-following
+        // rollback flush sees a record dated to the pour, not to serialization.
+        RecordContext ctx = support.playerContext(event.getPlayer(), location);
+        String target = fluid.name();
+        serializer.execute(() -> {
+            BlockSnapshot before = BlockSnapshots.finishCapture(rawBefore);
+            BlockSnapshot after = BlockSnapshots.of(fluid, afterData.getAsString());
+            recorder.record(BlockPlaceRecord.of(ctx, "bucket-empty", target, before, after));
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBucketFill(PlayerBucketFillEvent event) {
+        if (!enabledEvents.contains("bucket-fill")) {
+            return;
+        }
+        Block block = event.getBlock();
+        // Pre-change: the fluid source is still present, so the live capture IS
+        // the "before" a rollback restores. The target material comes straight
+        // from it (WATER / LAVA / POWDER_SNOW) rather than the bucket, which
+        // avoids the empty-vs-filled ambiguity of getBucket() on a fill.
+        BlockSnapshots.RawCapture rawBefore = BlockSnapshots.captureRawCached(block);
+        BlockSnapshot after = BlockSnapshots.air();
+        BlockLocation location = BlockLocations.fromBlock(block);
+        RecordContext ctx = support.playerContext(event.getPlayer(), location);
+        String target = rawBefore.type().name();
+        serializer.execute(() -> {
+            BlockSnapshot before = BlockSnapshots.finishCapture(rawBefore);
+            recorder.record(BlockBreakRecord.of(ctx, "bucket-fill", target, before, after));
+        });
+    }
+
+    /**
+     * The world fluid a bucket empties, or {@code null} when this listener does
+     * not log it. Fish / axolotl / tadpole buckets empty a water source (and
+     * spawn an entity, which is out of scope here); lava maps to itself. Milk
+     * (drunk, not emptied) and a powder-snow bucket (a block placed via
+     * {@code BlockPlaceEvent}, logged as {@code place}) return null - the
+     * {@code PlayerBucketEmptyEvent} they would need never fires.
+     */
+    private static Material fluidOf(Material bucket) {
+        if (bucket == null) {
+            return null;
+        }
+        return switch (bucket) {
+            case LAVA_BUCKET -> Material.LAVA;
+            case WATER_BUCKET, COD_BUCKET, SALMON_BUCKET, PUFFERFISH_BUCKET,
+                    TROPICAL_FISH_BUCKET, AXOLOTL_BUCKET, TADPOLE_BUCKET -> Material.WATER;
+            default -> null;
+        };
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -322,6 +322,14 @@ events {
   # also defaults on).
   transfer-out = { enabled = true, past-tense = "piped out" }
   transfer-in = { enabled = true, past-tense = "piped in" }
+  # Fluid placed / picked up with a bucket (#228). bucket-empty logs the poured
+  # water or lava source (a fish or axolotl bucket logs the water; its entity is
+  # out of scope), bucket-fill logs the source scooped back up. Both are
+  # rollbackable, so a rollback removes poured fluid and restores a scooped-out
+  # moat - the reason to log buckets. (Powder-snow buckets place a block, not a
+  # fluid, so they log as `place`.) On by default for CoreProtect parity.
+  bucket-empty = { enabled = true, past-tense = "poured" }
+  bucket-fill = { enabled = true, past-tense = "scooped" }
   teleport = { enabled = true, past-tense = "teleported" }
   death = { enabled = true, past-tense = "died" }
   kill = { enabled = true, past-tense = "killed" }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BucketListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/block/BucketListenerTest.java
@@ -1,0 +1,341 @@
+package net.medievalrp.spyglass.plugin.listener.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Bucket fluid logging (#228). Pins the invariants that matter:
+ *
+ * <ul>
+ *   <li>Emptying a bucket records {@code bucket-empty} as a
+ *       {@link BlockPlaceRecord} at the fluid block with the fluid material and
+ *       the player; filling one records {@code bucket-fill} as a
+ *       {@link BlockBreakRecord} with the picked-up fluid material.</li>
+ *   <li>The rollback direction is right: an empty carries the pre-pour state as
+ *       {@code originalBlock} (what a rollback restores when it removes the
+ *       fluid) and the fluid as {@code newBlock}; a fill carries the fluid as
+ *       {@code originalBlock} (what a rollback restores) and air as
+ *       {@code newBlock}.</li>
+ *   <li>Fish / lava variants map to the right material; powder-snow (a
+ *       BlockItem, logged as {@code place}) and milk log nothing here.</li>
+ *   <li>getAsString() is deferred to the serializer, never called inline
+ *       (#154), and occurred + id are stamped at event time (#98).</li>
+ *   <li>Each of the two event names is independently gated.</li>
+ * </ul>
+ */
+class BucketListenerTest {
+
+    private static final UUID PLAYER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID WORLD_ID  = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support   = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Bukkit's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void emptyingAWaterBucketRecordsBucketEmptyPlaceOffThread() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+        Block block = block(Material.AIR, "minecraft:air");
+        BlockData fluidData = fluidBlockData("minecraft:water[level=0]");
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.createBlockData(Material.WATER)).thenReturn(fluidData);
+
+            listener.onBucketEmpty(emptyEvent(Material.WATER_BUCKET, block));
+
+            // Nothing recorded inline: one deferred task, no records, no getAsString.
+            assertThat(deferred).hasSize(1);
+            assertThat(recorder.records).isEmpty();
+            verify(block.getBlockData(), never()).getAsString();
+            verify(fluidData, never()).getAsString();
+
+            deferred.get(0).run();
+        }
+
+        assertThat(recorder.records).hasSize(1);
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.event()).isEqualTo("bucket-empty");
+        assertThat(record.target()).isEqualTo("WATER");
+        assertThat(record.source().playerName()).isEqualTo("Alice");
+        assertThat(record.location().x()).isEqualTo(10);
+        assertThat(record.location().y()).isEqualTo(64);
+        assertThat(record.location().z()).isEqualTo(20);
+        // Rollback removes the poured fluid: originalBlock (restored on rollback)
+        // is the pre-pour air; newBlock is the water source.
+        assertThat(record.originalBlock().material()).isEqualTo(Material.AIR);
+        assertThat(record.newBlock().material()).isEqualTo(Material.WATER);
+        assertThat(record.newBlock().blockData()).isEqualTo("minecraft:water[level=0]");
+    }
+
+    @Test
+    void fillingABucketRecordsBucketFillBreakWithTheFluidMaterial() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+        // Pre-pickup the block is still the lava source we scoop up.
+        Block block = block(Material.LAVA, "minecraft:lava[level=0]");
+
+        listener.onBucketFill(fillEvent(block));
+
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+        verify(block.getBlockData(), never()).getAsString();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        BlockBreakRecord record = (BlockBreakRecord) recorder.records.get(0);
+        assertThat(record.event()).isEqualTo("bucket-fill");
+        // Material comes from the scooped block, not the bucket.
+        assertThat(record.target()).isEqualTo("LAVA");
+        assertThat(record.source().playerName()).isEqualTo("Alice");
+        // Rollback restores the scooped fluid: originalBlock is the lava source,
+        // newBlock is air.
+        assertThat(record.originalBlock().material()).isEqualTo(Material.LAVA);
+        assertThat(record.originalBlock().blockData()).isEqualTo("minecraft:lava[level=0]");
+        assertThat(record.newBlock().isAir()).isTrue();
+    }
+
+    @Test
+    void lavaBucketEmptyRecordsLavaSource() {
+        assertThat(emptyTargetFor(Material.LAVA_BUCKET, Material.LAVA, "minecraft:lava[level=0]"))
+                .isEqualTo("LAVA");
+    }
+
+    @Test
+    void powderSnowBucketIsNotLoggedHere() {
+        // Powder snow is a SolidBucketItem (a BlockItem): emptying it fires
+        // BlockPlaceEvent - logged as `place` by BlockPlaceListener - not
+        // PlayerBucketEmptyEvent. This listener must ignore it. (In practice the
+        // event never even fires for it; this pins the fluidOf guard regardless.)
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+
+        listener.onBucketEmpty(emptyEvent(Material.POWDER_SNOW_BUCKET, block(Material.AIR, "minecraft:air")));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void fishBucketEmptiesWaterAndLogsTheWaterSource() {
+        // A cod bucket places water (and spawns a cod, which is out of scope) -
+        // so it must log a WATER bucket-empty, not the bucket item.
+        assertThat(emptyTargetFor(Material.COD_BUCKET, Material.WATER, "minecraft:water[level=0]"))
+                .isEqualTo("WATER");
+    }
+
+    @Test
+    void milkBucketRecordsNothing() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+
+        // Milk is drunk, not emptied into the world; even if the event fired it
+        // places no block. No createBlockData call, so no Bukkit stub needed.
+        listener.onBucketEmpty(emptyEvent(Material.MILK_BUCKET, block(Material.AIR, "minecraft:air")));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void getAsStringIsDeferredAndOccurredStampedAtEventTime() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+        Block block = block(Material.AIR, "minecraft:air");
+        BlockData fluidData = fluidBlockData("minecraft:water[level=0]");
+
+        Instant before = Instant.now();
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.createBlockData(Material.WATER)).thenReturn(fluidData);
+            listener.onBucketEmpty(emptyEvent(Material.WATER_BUCKET, block));
+
+            // Neither blockdata string built on the handling thread (#154).
+            verify(block.getBlockData(), never()).getAsString();
+            verify(fluidData, never()).getAsString();
+
+            deferred.get(0).run();
+
+            // Both built exactly once on the serializer thread.
+            verify(block.getBlockData()).getAsString();
+            verify(fluidData).getAsString();
+        }
+        Instant after = Instant.now();
+
+        BlockPlaceRecord record = (BlockPlaceRecord) recorder.records.get(0);
+        assertThat(record.occurred())
+                .as("occurred must be stamped at event time, not serialization time")
+                .isBetween(before, after);
+        assertThat(record.id()).isNotNull();
+    }
+
+    @Test
+    void bucketEmptyToggleGatesTheEmptyHandlerOnly() {
+        List<Runnable> deferred = new ArrayList<>();
+        // Only fills enabled: an empty must record nothing (and not even touch
+        // Bukkit.createBlockData), while a fill still records.
+        BucketListener listener = listener(deferred, enabled("bucket-fill"));
+
+        listener.onBucketEmpty(emptyEvent(Material.WATER_BUCKET, block(Material.AIR, "minecraft:air")));
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+
+        listener.onBucketFill(fillEvent(block(Material.WATER, "minecraft:water[level=0]")));
+        deferred.get(0).run();
+        assertThat(recorder.records).hasSize(1);
+        assertThat(recorder.records.get(0).event()).isEqualTo("bucket-fill");
+    }
+
+    @Test
+    void bucketFillToggleGatesTheFillHandlerOnly() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty"));
+
+        listener.onBucketFill(fillEvent(block(Material.WATER, "minecraft:water[level=0]")));
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void bothDisabledDoesNothingAndDefersNothing() {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled());
+
+        listener.onBucketEmpty(emptyEvent(Material.WATER_BUCKET, block(Material.AIR, "minecraft:air")));
+        listener.onBucketFill(fillEvent(block(Material.WATER, "minecraft:water[level=0]")));
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────
+
+    /** Empties {@code bucket} over an air block and returns the resulting target material. */
+    private String emptyTargetFor(Material bucket, Material fluid, String fluidDataString) {
+        List<Runnable> deferred = new ArrayList<>();
+        BucketListener listener = listener(deferred, enabled("bucket-empty", "bucket-fill"));
+        BlockData fluidData = fluidBlockData(fluidDataString);
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.createBlockData(fluid)).thenReturn(fluidData);
+            listener.onBucketEmpty(emptyEvent(bucket, block(Material.AIR, "minecraft:air")));
+            deferred.get(0).run();
+        }
+        EventRecord record = recorder.records.get(recorder.records.size() - 1);
+        assertThat(record.event()).isEqualTo("bucket-empty");
+        return ((BlockPlaceRecord) record).target();
+    }
+
+    private BucketListener listener(List<Runnable> deferred, Set<String> enabled) {
+        return new BucketListener(recorder, support, deferred::add, enabled);
+    }
+
+    private static Set<String> enabled(String... names) {
+        return new HashSet<>(List.of(names));
+    }
+
+    private PlayerBucketEmptyEvent emptyEvent(Material bucket, Block block) {
+        // Build the player before opening any stubbing on the event: nesting a
+        // when() (player()) inside .thenReturn() trips UnfinishedStubbingException.
+        Player player = player();
+        PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+        when(event.getBucket()).thenReturn(bucket);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+
+    private PlayerBucketFillEvent fillEvent(Block block) {
+        Player player = player();
+        PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+
+    private Player player() {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+        return player;
+    }
+
+    /**
+     * A live block of {@code type}. Stubs both getBlockData() and
+     * getState().getBlockData() to the same mock so the capture is deterministic
+     * whether or not the static plainness cache is already warm for {@code type}
+     * (BlockSnapshots.captureRawCached takes different paths cold vs warm).
+     */
+    private Block block(Material type, String blockDataString) {
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        BlockData data = mock(BlockData.class);
+        when(data.getAsString()).thenReturn(blockDataString);
+        when(data.getMaterial()).thenReturn(type);
+        BlockState state = mock(BlockState.class);
+        when(state.getType()).thenReturn(type);
+        when(state.getBlockData()).thenReturn(data);
+        Block block = mock(Block.class);
+        when(block.getBlockData()).thenReturn(data);
+        when(block.getState()).thenReturn(state);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(10);
+        when(block.getY()).thenReturn(64);
+        when(block.getZ()).thenReturn(20);
+        when(block.getType()).thenReturn(type);
+        return block;
+    }
+
+    private static BlockData fluidBlockData(String asString) {
+        BlockData data = mock(BlockData.class);
+        when(data.getAsString()).thenReturn(asString);
+        return data;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #228.

## What

Logs bucket fluid placement and pickup, the last unlogged discrete-and-rollbackable grief vector (poured lava, flooded builds). A bucket-placed water/lava source fires **no** `BlockPlaceEvent`, so it was previously invisible and un-rollbackable.

- `bucket-empty` (fluid poured) -> `BlockPlaceRecord` -> a rollback **removes** the fluid
- `bucket-fill` (fluid scooped) -> `BlockBreakRecord` -> a rollback **restores** the source

## How

Same lever as the hopper work (#226): reuse existing rollbackable record shapes, so **no store/codec/schema change** on any backend. `BlockPlaceRecord.of` / `BlockBreakRecord.of` already carry the event name, so unlike #226 this didn't even need a new record factory overload. Player-driven, single-block, player-rate -> rollbackable, no dedup.

Bucket events fire **pre-change** (opposite of `BlockPlaceEvent`), so the live block at `MONITOR` is the pre-pour state: it is captured as the "before" (`captureRawCached`, `getAsString()` deferred off-main per #154), and the poured fluid "after" is synthesized from the bucket material (mirroring `BlockIgniteListener`). Fish / axolotl / tadpole buckets log their water source (entity out of scope); milk logs nothing. Registered with per-event gating (honours disabling either name).

Touch points: `BucketListener` (+ registration), 2 `EventCatalog` names, 2 `events.*` config defaults (on by default, CoreProtect parity). SQLite/MariaDB ride the auto codec.

## Finding: powder snow is out of scope (issue premise correction)

The issue listed powder snow as a `PlayerBucketEmptyEvent` variant. Live testing showed that is **not** the case: a powder-snow bucket is a `SolidBucketItem` (a `BlockItem`), so emptying one fires a normal `BlockPlaceEvent` and is **already logged and rolled back as `place`** by `BlockPlaceListener` (verified: DB row `place / POWDER_SNOW / orig=air / new=powder_snow`). It never fires `PlayerBucketEmptyEvent`. Per discussion, powder snow was dropped from the listener (it is already covered), keeping scope to the genuinely-invisible fluids (water, lava).

## Verification

- **Unit:** `BucketListenerTest` (10 tests) - record shape/target/player/location, rollback-direction fields, off-main deferral (#154), event-time stamping (#98), per-event gating, milk + powder-snow ignored.
- **`./gradlew check build`:** green, all modules, jacoco floors held.
- **Store ITs (Docker):** ClickHouse 16, MariaDB 14, Mongo 20, SQLite - 0 skipped, 0 failed (all four backends round-trip the reused records).
- **Live (throwaway Paper 1.21.8, SQLite, mineflayer):** `BUCKET PASS - 14/14`. Emptying water/lava records `poured WATER`/`poured LAVA` and a rollback **removes** the fluid (block -> air); filling records `scooped WATER` and a rollback **restores** the source (block -> water). `a:bucket-empty` / `a:bucket-fill` and a plain coordinate lookup all render. Regression script: `regression/bot/_bucket-gameplay.js`.

This lands on `dev`; a `dev -> main` release + prod deploy is the separate step to ship it live.
