### PR TITLE
import hardening: retention warning, expiry clamp, macOS test fix

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/mapping/MappingContext.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/mapping/MappingContext.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.plugin.importer.world.WorldMap;
+import net.medievalrp.spyglass.plugin.storage.RetentionPolicy;
 
 /**
  * Common state shared by every per-table mapper: world UUID resolver,
@@ -34,6 +35,16 @@ public final class MappingContext {
     public Instant importStart() { return importStart; }
     public Origin importOrigin() { return importOrigin; }
 
-    /** {@code expires_at} is import-time + retention, NOT event-time + retention. */
-    public Instant expiresAt() { return importStart.plus(retention); }
+    /**
+     * {@code expires_at} is import-time + retention, NOT event-time + retention.
+     * Clamped to {@link RetentionPolicy#MAX_EXPIRY} so a keep-forever ("never")
+     * retention can't push the value past ClickHouse's 32-bit {@code DateTime}
+     * TTL ceiling (2106), where {@code toDateTime(expires_at)} would overflow to
+     * the past and get the row TTL-deleted. Matches the clamp RetentionPolicy
+     * already applies on the store side.
+     */
+    public Instant expiresAt() {
+        Instant e = importStart.plus(retention);
+        return e.isAfter(RetentionPolicy.MAX_EXPIRY) ? RetentionPolicy.MAX_EXPIRY : e;
+    }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/source/CoreProtectSource.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/source/CoreProtectSource.java
@@ -35,6 +35,33 @@ public interface CoreProtectSource extends AutoCloseable {
     void streamItemRows(Consumer<CoreProtectItemRow> consumer) throws IOException;
 
     /**
+     * Pre-flight retention preview over the tables the importer actually
+     * reads: the oldest and newest event time (epoch seconds) and how many
+     * rows predate {@code cutoffEpochSeconds} — i.e. how many would be aged
+     * out by the configured retention right after import. Rows with a
+     * non-positive time are ignored. Lets {@code /spyglass import} warn the
+     * operator, before doing the heavy streaming pass, that part of their
+     * history is older than {@code storage.retention} and will not be kept.
+     */
+    RetentionPreview retentionPreview(long cutoffEpochSeconds) throws IOException;
+
+    /**
+     * Time span + how much of it predates the retention cutoff.
+     *
+     * @param oldestEpochSeconds  oldest event time across imported tables (0 if none)
+     * @param newestEpochSeconds  newest event time across imported tables (0 if none)
+     * @param rowsBeforeCutoff    rows older than the cutoff (would be aged out)
+     * @param totalRows           total rows across imported tables (with time &gt; 0)
+     */
+    record RetentionPreview(long oldestEpochSeconds, long newestEpochSeconds,
+                            long rowsBeforeCutoff, long totalRows) {
+
+        public boolean hasAgedOutRows() {
+            return rowsBeforeCutoff > 0;
+        }
+    }
+
+    /**
      * <strong>Not currently exposed as a stream.</strong> CoreProtect's
      * {@code co_sign} table records sign edits made in-place (right-click
      * a placed sign and rewrite a line). Spyglass has no sealed

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/source/JdbcCoreProtectSource.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/source/JdbcCoreProtectSource.java
@@ -257,6 +257,49 @@ public final class JdbcCoreProtectSource implements CoreProtectSource {
                 parseUuidOrNull(rs.getString("uuid")))), "co_item");
     }
 
+    @Override
+    public RetentionPreview retentionPreview(long cutoffEpochSeconds) throws IOException {
+        // Aggregate MIN/MAX/COUNT and a before-cutoff tally across the tables
+        // the importer streams. Same missing-table tolerance as worldNames():
+        // an operator who disabled an event type just contributes nothing.
+        String[] tables = {"co_block", "co_session", "co_chat",
+                "co_command", "co_container", "co_item"};
+        long oldest = Long.MAX_VALUE;
+        long newest = Long.MIN_VALUE;
+        long rowsBeforeCutoff = 0;
+        long totalRows = 0;
+        for (String t : tables) {
+            String sql = "SELECT MIN(time), MAX(time), COUNT(*), "
+                    + "SUM(CASE WHEN time < ? THEN 1 ELSE 0 END) "
+                    + "FROM " + t + " WHERE time > 0";
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setLong(1, cutoffEpochSeconds);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        continue;
+                    }
+                    long count = rs.getLong(3);
+                    if (count == 0) {
+                        continue;
+                    }
+                    oldest = Math.min(oldest, rs.getLong(1));
+                    newest = Math.max(newest, rs.getLong(2));
+                    rowsBeforeCutoff += rs.getLong(4);
+                    totalRows += count;
+                }
+            } catch (SQLException ex) {
+                if (!isMissingTable(ex)) {
+                    throw new IOException("Failed retention preview on " + t
+                            + " from " + label + ": " + ex.getMessage(), ex);
+                }
+            }
+        }
+        if (totalRows == 0) {
+            return new RetentionPreview(0, 0, 0, 0);
+        }
+        return new RetentionPreview(oldest, newest, rowsBeforeCutoff, totalRows);
+    }
+
     @FunctionalInterface
     private interface RowHandler {
         void accept(ResultSet rs) throws SQLException;

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/importer/mapping/MappingContextTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/importer/mapping/MappingContextTest.java
@@ -1,0 +1,36 @@
+package net.medievalrp.spyglass.plugin.importer.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import net.medievalrp.spyglass.plugin.storage.RetentionPolicy;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link MappingContext#expiresAt()} is import-time + retention, clamped to
+ * {@link RetentionPolicy#MAX_EXPIRY} (#2) so a keep-forever retention can't
+ * push it past ClickHouse's 32-bit {@code DateTime} TTL ceiling (2106),
+ * where {@code toDateTime(expires_at)} would overflow to the past and get
+ * {@code OPTIMIZE FINAL} to delete the row. worldMap is unused by
+ * {@code expiresAt()} so a null is fine here.
+ */
+class MappingContextTest {
+
+    private static final Instant START = Instant.parse("2026-07-08T00:00:00Z");
+
+    @Test
+    void expiresAtIsImportTimePlusRetentionUnderTheCeiling() {
+        MappingContext ctx = new MappingContext(null, "srv", Duration.ofDays(182), START);
+        assertThat(ctx.expiresAt()).isEqualTo(START.plus(Duration.ofDays(182)));
+    }
+
+    @Test
+    void neverRetentionClampsToMaxExpiryNotPastTheDateTime32Ceiling() {
+        // ~100 years would land in 2126, past DateTime32's 2106 ceiling.
+        MappingContext ctx = new MappingContext(
+                null, "srv", Duration.ofSeconds(RetentionPolicy.NEVER_SECONDS), START);
+        assertThat(ctx.expiresAt()).isEqualTo(RetentionPolicy.MAX_EXPIRY);
+        assertThat(ctx.expiresAt()).isBefore(Instant.parse("2106-01-01T00:00:00Z"));
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/importer/source/RetentionPreviewTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/importer/source/RetentionPreviewTest.java
@@ -1,0 +1,69 @@
+package net.medievalrp.spyglass.plugin.importer.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import net.medievalrp.spyglass.plugin.importer.source.CoreProtectSource.RetentionPreview;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * {@link JdbcCoreProtectSource#retentionPreview} aggregates MIN/MAX/COUNT
+ * and a before-cutoff tally across every imported event table, ignores
+ * non-positive times, and tolerates disabled (missing) tables. Drives the
+ * {@code /spyglass import} pre-flight warning that tells operators how much
+ * of their history predates {@code storage.retention}.
+ */
+class RetentionPreviewTest {
+
+    @TempDir
+    Path dir;
+
+    private Connection open(String name) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        return DriverManager.getConnection("jdbc:sqlite:" + dir.resolve(name).toAbsolutePath());
+    }
+
+    @Test
+    void aggregatesAcrossTablesIgnoresZeroTimeAndMissingTables() throws Exception {
+        Path db = dir.resolve("cp.db");
+        try (Connection c = open("cp.db"); Statement s = c.createStatement()) {
+            // Only two of the six imported tables exist; the other four are
+            // "disabled" and must be tolerated (no such table -> skipped).
+            s.executeUpdate("CREATE TABLE co_block(time INTEGER)");
+            s.executeUpdate("CREATE TABLE co_session(time INTEGER)");
+            // co_block: 100, 200, 300, plus a 0 that must be ignored.
+            s.executeUpdate("INSERT INTO co_block(time) VALUES (100),(200),(300),(0)");
+            // co_session: 50 (the overall oldest) and 400 (the overall newest).
+            s.executeUpdate("INSERT INTO co_session(time) VALUES (50),(400)");
+        }
+
+        try (Connection c = DriverManager.getConnection(
+                "jdbc:sqlite:" + db.toAbsolutePath())) {
+            JdbcCoreProtectSource source = new JdbcCoreProtectSource(c, "test");
+            RetentionPreview p = source.retentionPreview(250);
+
+            assertThat(p.totalRows()).as("time>0 rows across both tables").isEqualTo(5);
+            assertThat(p.rowsBeforeCutoff()).as("50,100,200 predate cutoff 250").isEqualTo(3);
+            assertThat(p.oldestEpochSeconds()).isEqualTo(50);
+            assertThat(p.newestEpochSeconds()).isEqualTo(400);
+            assertThat(p.hasAgedOutRows()).isTrue();
+        }
+    }
+
+    @Test
+    void emptySourceReportsNoAgedOutRows() throws Exception {
+        try (Connection c = open("empty.db"); Statement s = c.createStatement()) {
+            s.executeUpdate("CREATE TABLE co_block(time INTEGER)"); // present but empty
+        }
+        try (Connection c = DriverManager.getConnection(
+                "jdbc:sqlite:" + dir.resolve("empty.db").toAbsolutePath())) {
+            RetentionPreview p = new JdbcCoreProtectSource(c, "test").retentionPreview(250);
+            assertThat(p.totalRows()).isZero();
+            assertThat(p.hasAgedOutRows()).isFalse();
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
@@ -163,6 +163,7 @@ public final class ImportService {
                                 String serverName, SourceOpener opener) throws IOException {
         String senderName = sender.getName();
         try (CoreProtectSource source = opener.open()) {
+            warnIfHistoryOlderThanRetention(sender, source);
             WorldMap worldMap = ImportPipeline.resolveWorlds(source, worldContainer);
             MappingContext ctx = new MappingContext(worldMap, serverName, retention, Instant.now());
             RecordStoreSink sink = new RecordStoreSink(store, batchSize);
@@ -240,6 +241,46 @@ public final class ImportService {
         } catch (Exception ex) {
             throw new RuntimeException("ClickHouse async-insert flush failed: " + ex.getMessage(), ex);
         }
+    }
+
+    /**
+     * Pre-flight transparency (#1): if part of the source history predates
+     * the configured retention, warn the operator up front — before the
+     * heavy streaming pass — that those events will be aged out after import
+     * (immediately on ClickHouse via {@code OPTIMIZE FINAL}, on the next
+     * prune sweep otherwise), and how far back it goes. Informational only:
+     * the import proceeds; the operator can raise {@code storage.retention}
+     * (or set it {@code "never"}) and re-import to keep the full history.
+     * Best-effort — a preview query failure skips the warning, never fails
+     * an otherwise-valid import.
+     */
+    private void warnIfHistoryOlderThanRetention(CommandSender sender, CoreProtectSource source) {
+        CoreProtectSource.RetentionPreview preview;
+        long cutoffSec;
+        try {
+            cutoffSec = Instant.now().minus(retention).getEpochSecond();
+            preview = source.retentionPreview(cutoffSec);
+        } catch (IOException | RuntimeException ex) {
+            logger.log(Level.WARNING, "Retention preview failed; skipping the pre-import warning", ex);
+            return;
+        }
+        if (!preview.hasAgedOutRows()) {
+            return;
+        }
+        long aged = preview.rowsBeforeCutoff();
+        long total = preview.totalRows();
+        double pct = 100.0 * aged / total;
+        java.time.LocalDate cutoff = java.time.LocalDate.ofInstant(
+                Instant.ofEpochSecond(cutoffSec), java.time.ZoneOffset.UTC);
+        java.time.LocalDate oldest = java.time.LocalDate.ofInstant(
+                Instant.ofEpochSecond(preview.oldestEpochSeconds()), java.time.ZoneOffset.UTC);
+        tell(sender, String.format(java.util.Locale.ROOT,
+                "WARNING: %,d of %,d events (%.1f%%) are older than your retention cutoff "
+                        + "%s (retention %dd) and will be aged out after import - immediately "
+                        + "on ClickHouse, on the next prune sweep otherwise. Oldest source "
+                        + "event: %s. To keep the full history, raise storage.retention (or "
+                        + "set it \"never\") and re-import.",
+                aged, total, pct, cutoff, retention.toDays(), oldest));
     }
 
     private String blankToDefault(String serverName) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/imports/ImportPathsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/imports/ImportPathsTest.java
@@ -27,7 +27,12 @@ class ImportPathsTest {
     @Test
     void resolvesValidInDirectoryFile() throws IOException {
         Path result = ImportPaths.resolveInside(importDir, "test1.db");
-        assertThat(result).isEqualTo(importDir.resolve("test1.db"));
+        // resolveInside builds its result from the CANONICAL import dir
+        // (toRealPath), so compare against the canonical expectation - on
+        // macOS @TempDir lives under /var/folders/..., a symlink to
+        // /private/var/..., and the raw importDir.resolve() would not match
+        // (green on Linux CI, red on every Mac).
+        assertThat(result).isEqualTo(importDir.toRealPath().resolve("test1.db"));
         assertThat(Files.isRegularFile(result)).isTrue();
     }
 


### PR DESCRIPTION
Review fixes for #202, found testing it against a real 29M-event CoreProtect 2.23.2 dump (full 2x4 source/backend matrix + live-server runs).

- Fixes #233: /spyglass import now pre-flights the source and warns how much history predates storage.retention (measured: 7d retention silently dropped 92.9% of the dump while reporting success). Warn-only by design; the import proceeds.
- Fixes #234: MappingContext expiry clamped to RetentionPolicy.MAX_EXPIRY so a keep-forever retention cannot overflow the ClickHouse DateTime32 TTL ceiling (unclamped, OPTIMIZE FINAL deleted every imported row through the no-policy store constructor).
- Fixes #238: ImportPathsTest compared the raw @TempDir path against resolveInside's canonical result; red on every Mac (symlinked /var), green on Linux CI.

Verified: unit tests per fix; 8/8 import matrix (sqlite+mysql sources x all four backends) unchanged after the fixes; live 1.21.11 server runs including the warning firing on real data and correct silence under retention=never.

Stacked on #202; merge after it.