### PR TITLE
fix(config): accept keep-forever tokens for global storage.retention

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -98,7 +98,7 @@ public record SpyglassConfig(
                                 root.node("database", "mariadb", "password").getString(""),
                                 root.node("database", "mariadb", "ssl").getBoolean(false))),
                 new Storage(
-                        Duration.parse(root.node("storage", "retention").getString("26w")),
+                        parseGlobalRetention(root.node("storage", "retention").getString("26w")),
                         root.node("storage", "queue-capacity").getInt(100_000),
                         root.node("storage", "queue-max").getInt(500_000),
                         root.node("storage", "spill-to-disk").getBoolean(true),
@@ -377,6 +377,24 @@ public record SpyglassConfig(
     static Long readEventRetention(ConfigurationNode eventNode, String event,
             java.util.logging.Logger logger) {
         return parseEventRetention(eventNode.node("retention").getString(), event, logger);
+    }
+
+    /**
+     * Parse the global {@code storage.retention}, accepting the same
+     * keep-forever tokens as per-event retention ({@code "0"} / {@code "never"}
+     * / {@code "forever"} / {@code "off"} -> {@link
+     * net.medievalrp.spyglass.plugin.storage.RetentionPolicy#NEVER_SECONDS}).
+     * Before this, "never" was valid per-event but hard-disabled the plugin
+     * (config-load failure) when used globally - a trap the per-event docs
+     * invited operators into, and exactly what a CoreProtect migration wants
+     * to set so imported history is kept.
+     */
+    static Duration parseGlobalRetention(String raw) {
+        String v = raw == null ? "" : raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if (v.equals("0") || v.equals("never") || v.equals("forever") || v.equals("off")) {
+            return new Duration(net.medievalrp.spyglass.plugin.storage.RetentionPolicy.NEVER_SECONDS);
+        }
+        return Duration.parse(raw);
     }
 
     /**

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -93,7 +93,9 @@ storage {
   # this), so it bounds disk use and keeps searches fast. "26w" = 26 weeks
   # (about six months). Shorter = less disk and faster scans but a shorter
   # rollback / audit window; longer = more history at the cost of disk. Units
-  # are s/m/h/d/w; override per event under events.<name>.retention below.
+  # are s/m/h/d/w; "0" / "never" keeps everything forever (what you want when
+  # importing an old CoreProtect history). Override per event under
+  # events.<name>.retention below.
   retention = "26w"
   # How the per-block rollback audit trail is stored (#22).
   #   "synthesized" (default) — one rollback-op record per operation;

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -35,6 +35,25 @@ class SpyglassConfigTest {
         assertThat(SpyglassConfig.parseEventRetention("forever", "command", LOG)).isEqualTo(never);
     }
 
+    // Found live during the CoreProtect-import battery: the per-event docs
+    // bless "never", but global storage.retention fed it straight to
+    // Duration.parse -> IllegalArgumentException -> plugin hard-disabled on
+    // boot. The global parse must accept the same keep-forever tokens.
+    @Test
+    void globalRetentionAcceptsKeepForeverTokens() {
+        long never = net.medievalrp.spyglass.plugin.storage.RetentionPolicy.NEVER_SECONDS;
+        assertThat(SpyglassConfig.parseGlobalRetention("never").seconds()).isEqualTo(never);
+        assertThat(SpyglassConfig.parseGlobalRetention("0").seconds()).isEqualTo(never);
+        assertThat(SpyglassConfig.parseGlobalRetention("NEVER").seconds()).isEqualTo(never);
+        assertThat(SpyglassConfig.parseGlobalRetention("off").seconds()).isEqualTo(never);
+    }
+
+    @Test
+    void globalRetentionStillParsesPlainDurations() {
+        assertThat(SpyglassConfig.parseGlobalRetention("26w").seconds())
+                .isEqualTo(26L * 7 * 24 * 60 * 60);
+    }
+
     @Test
     void invalidPerEventRetentionFallsBackToTheGlobal() {
         // Unparseable -> warn + null (inherit), never a crash.


### PR DESCRIPTION
Fixes #235. storage.retention = "never" (or 0/forever/off - the tokens per-event retention already documents) fed Duration.parse and hard-disabled the plugin on boot. The global value now maps those tokens to RetentionPolicy.NEVER_SECONDS, same as per-event; config.conf documents it. Regression tests included; verified live (plugin boots clean with never).