### PR TITLE
fix(query): resolve never-joined player names via the record store

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -1097,6 +1097,31 @@ public final class MariaDbRecordStore implements RecordStore {
         }
     }
 
+    /**
+     * Name -> UUID against the {@code uuids} intern palette (same rationale
+     * as the SQLite override: no {@code player_name} column to filter on,
+     * so imported-player names must resolve to a playerId predicate).
+     * utf8mb4_unicode_ci makes the equality case-insensitive already.
+     */
+    @Override
+    public java.util.UUID resolvePlayerId(String playerName) {
+        if (playerName == null || playerName.isBlank()) {
+            return null;
+        }
+        Connection conn = borrow();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT hi, lo FROM uuids WHERE name = ? LIMIT 1")) {
+            ps.setString(1, playerName);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? new java.util.UUID(rs.getLong(1), rs.getLong(2)) : null;
+            }
+        } catch (SQLException ex) {
+            return null; // best-effort: caller falls back to the verbatim-name match
+        } finally {
+            giveBack(conn);
+        }
+    }
+
     // ===== Read pool ===========================================
 
     private Connection borrow() {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
@@ -173,6 +173,23 @@ public interface RecordStore extends AutoCloseable {
     }
 
     /**
+     * Best-effort player-name -> UUID lookup against the store's OWN data,
+     * for players this server has never seen. The Bukkit user cache only
+     * knows players who joined here, but a CoreProtect import (or a store
+     * shared across servers) holds records for players who never did -
+     * exactly the griefers an operator wants to {@code /sg rollback p:<name>}.
+     * Backends whose schema can't filter on {@code source.playerName}
+     * (SQLite / MariaDB palette-interned layouts) override this so the
+     * player param can turn an unknown name into a {@code source.playerId}
+     * predicate instead. Default: unknown ({@code null}), which preserves
+     * the verbatim-name fallback.
+     */
+    @Nullable
+    default UUID resolvePlayerId(String playerName) {
+        return null;
+    }
+
+    /**
      * Display-only query: hydrates just the fields the search renderer
      * needs (event, origin, source, location, target, scalar extras like
      * amount/damage/recipients/commandLine/address).

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -1027,6 +1027,35 @@ public final class SqliteRecordStore implements RecordStore {
 
     // ===== Read pool ===========================================
 
+    /**
+     * Name -> UUID against the {@code uuids} intern palette, so the player
+     * param can resolve players Bukkit never saw (CoreProtect-imported
+     * histories) into a {@code source.playerId} predicate - this schema has
+     * no {@code player_name} column to filter on, and the lean rollback
+     * reader can't post-filter in memory. Case-insensitive to match
+     * Minecraft name semantics. The palette also interns world UUIDs; a
+     * player named exactly like a world is a theoretical false hit we
+     * accept (same verbatim-name tradeoff v1 made).
+     */
+    @Override
+    public UUID resolvePlayerId(String playerName) {
+        if (playerName == null || playerName.isBlank()) {
+            return null;
+        }
+        Connection conn = borrow();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT hi, lo FROM uuids WHERE name = ? COLLATE NOCASE LIMIT 1")) {
+            ps.setString(1, playerName);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? new UUID(rs.getLong(1), rs.getLong(2)) : null;
+            }
+        } catch (SQLException ex) {
+            return null; // best-effort: caller falls back to the verbatim-name match
+        } finally {
+            giveBack(conn);
+        }
+    }
+
     private Connection borrow() {
         try {
             return readPool.take();

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
@@ -53,6 +53,16 @@ public final class SynthesizingRecordStore implements RecordStore {
     }
 
     @Override
+    public java.util.UUID resolvePlayerId(String playerName) {
+        // MUST delegate explicitly: this method has an interface default
+        // (returns null = "unknown"), so a decorator that doesn't forward it
+        // silently disables the backend's imported-player name resolution -
+        // exactly what happened live (the plugin wraps every store in this
+        // decorator when rolled-audit=synthesized, which is the default).
+        return delegate.resolvePlayerId(playerName);
+    }
+
+    @Override
     public QueryPage.Cursor streamRollback(QueryRequest request, QueryPage.Cursor cursor,
                                            int windowLimit, RecordSink sink) {
         // Rollback reads the real recorded events, never the synthesized

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ResolvePlayerIdTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ResolvePlayerIdTest.java
@@ -1,0 +1,60 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * {@link SqliteRecordStore#resolvePlayerId}: names of players known only to
+ * the store (imported histories) resolve to their UUID off the uuids intern
+ * palette, case-insensitively; unknown names resolve to null.
+ */
+class ResolvePlayerIdTest {
+
+    private static final UUID GRIEFER = UUID.fromString("c1386514-0fd1-4f0c-8591-997d92d74a7a");
+    private static final UUID WORLD = UUID.randomUUID();
+
+    @Test
+    void resolvesImportedPlayerNameCaseInsensitively(@TempDir Path dir) {
+        try (SqliteRecordStore store = new SqliteRecordStore(dir.resolve("t.db"))) {
+            Instant now = Instant.now();
+            store.save(List.of(new JoinRecord(EventIds.newId(), "join", now,
+                    now.plusSeconds(3600), Origin.player(),
+                    Source.player(GRIEFER, "ItzSh4rkyz"),
+                    new BlockLocation(WORLD, "world", 0, 64, 0), "srv", "ItzSh4rkyz", null)));
+
+            assertThat(store.resolvePlayerId("ItzSh4rkyz")).isEqualTo(GRIEFER);
+            assertThat(store.resolvePlayerId("itzsh4rkyz")).isEqualTo(GRIEFER);
+            assertThat(store.resolvePlayerId("NeverSeen")).isNull();
+        }
+    }
+
+    // The live-caught trap: the plugin wraps every store in
+    // SynthesizingRecordStore (rolled-audit=synthesized is the default), and
+    // a decorator that doesn't forward a default interface method silently
+    // serves the default (null) - disabling name resolution in production
+    // while unit tests on the bare store stay green.
+    @Test
+    void synthesizingDecoratorDelegatesResolvePlayerId(@TempDir Path dir) {
+        try (SqliteRecordStore store = new SqliteRecordStore(dir.resolve("t2.db"))) {
+            Instant now = Instant.now();
+            store.save(List.of(new JoinRecord(EventIds.newId(), "join", now,
+                    now.plusSeconds(3600), Origin.player(),
+                    Source.player(GRIEFER, "ItzSh4rkyz"),
+                    new BlockLocation(WORLD, "world", 0, 64, 0), "srv", "ItzSh4rkyz", null)));
+
+            SynthesizingRecordStore wrapped = new SynthesizingRecordStore(store, true);
+            assertThat(wrapped.resolvePlayerId("ItzSh4rkyz")).isEqualTo(GRIEFER);
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -459,7 +459,11 @@ public final class SpyglassPlugin extends JavaPlugin {
         SpyglassApiImpl apiImpl = new SpyglassApiImpl(
                 recorder, recordStore, queryExecutor, enabledEvents, apiLimits,
                 config.server().name(), getLogger());
-        apiImpl.registerQueryParamHandler(new PlayerParam());
+        // Store-backed name fallback: resolves players the Bukkit cache never
+        // saw (imported histories, shared stores) into playerId predicates so
+        // rollback-by-name works on the SQLite/MariaDB lean readers.
+        apiImpl.registerQueryParamHandler(
+                PlayerParam.withStoreFallback(recordStore::resolvePlayerId));
         apiImpl.registerQueryParamHandler(new EventParam(enabledEvents));
         apiImpl.registerQueryParamHandler(new RadiusParam());
         apiImpl.registerQueryParamHandler(new ChunkRadiusParam());

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/PlayerParam.java
@@ -24,6 +24,24 @@ public final class PlayerParam implements QueryParamHandler {
         this.nameResolver = nameResolver;
     }
 
+    /**
+     * Bukkit-cache-first resolution with a store-backed fallback. The
+     * Bukkit user cache only knows players who joined THIS server; a
+     * CoreProtect-imported history is full of players who never did, and
+     * "roll back the old griefer by name" is the core migration use case.
+     * When the cache misses, ask the record store's own intern data
+     * ({@link net.medievalrp.spyglass.plugin.storage.RecordStore#resolvePlayerId})
+     * before falling back to a verbatim-name match - which the SQLite /
+     * MariaDB rollback readers cannot evaluate at all. The store lookup is
+     * a single tiny indexed-table SELECT, safe on the command thread.
+     */
+    public static PlayerParam withStoreFallback(Function<String, UUID> storeLookup) {
+        return new PlayerParam(name -> {
+            UUID viaBukkit = resolveViaBukkit(name);
+            return viaBukkit != null ? viaBukkit : storeLookup.apply(name);
+        });
+    }
+
     @Override
     public List<String> aliases() {
         return List.of("p", "player");

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamResolveTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/PlayerParamResolveTest.java
@@ -93,6 +93,61 @@ class PlayerParamResolveTest {
         }
     }
 
+    // ===== Store fallback (imported-history players) ==================
+    // A CoreProtect import fills the store with players Bukkit never saw;
+    // "roll back the old griefer by name" must resolve them to a playerId
+    // predicate via RecordStore.resolvePlayerId, not a playerName match
+    // the SQLite/MariaDB rollback readers reject.
+
+    @Test
+    void bukkitMissFallsBackToStoreLookup() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
+
+            PlayerParam param = PlayerParam.withStoreFallback(
+                    name -> "ItzSh4rkyz".equals(name) ? ALICE : null);
+            QueryPredicate predicate = param.parse("p", "ItzSh4rkyz", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("source.playerId");
+            assertThat(eq.value()).isEqualTo(ALICE);
+            bukkit.verify(() -> Bukkit.getOfflinePlayer(anyString()), never());
+        }
+    }
+
+    @Test
+    void bukkitAndStoreMissKeepsVerbatimNameFallback() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+            bukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
+
+            PlayerParam param = PlayerParam.withStoreFallback(name -> null);
+            QueryPredicate predicate = param.parse("p", "NeverAnywhere", ctx());
+
+            QueryPredicate.Eq eq = (QueryPredicate.Eq) predicate;
+            assertThat(eq.field()).isEqualTo("source.playerName");
+            assertThat(eq.value()).isEqualTo("NeverAnywhere");
+        }
+    }
+
+    @Test
+    void bukkitHitNeverConsultsTheStore() throws Exception {
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            Player online = mock(Player.class);
+            when(online.getUniqueId()).thenReturn(ALICE);
+            bukkit.when(() -> Bukkit.getPlayerExact("Alice")).thenReturn(online);
+
+            boolean[] storeAsked = {false};
+            PlayerParam param = PlayerParam.withStoreFallback(name -> {
+                storeAsked[0] = true;
+                return null;
+            });
+            param.parse("p", "Alice", ctx());
+            assertThat(storeAsked[0]).as("store fallback consulted despite Bukkit hit").isFalse();
+        }
+    }
+
     private static ParamContext ctx() {
         return new ParamContext(null, null, 100);
     }


### PR DESCRIPTION
Fixes #236. p:<name> for a player this server never saw fell back to a source.playerName predicate, which the SQLite/MariaDB rollback readers reject - so rollback-by-name fails exactly for imported histories and shared stores. PlayerParam now falls back Bukkit cache -> RecordStore.resolvePlayerId (uuids intern palette on SQLite/MariaDB, case-insensitive) -> verbatim name.

Includes the SynthesizingRecordStore delegating override: the decorator wraps every store by default and does not forward default interface methods, which silently disabled the fix in production while bare-store tests stayed green. Regression test exercises the wrapped path. Note for future RecordStore default methods: add the delegation.

Verified live on a 10M-row store: /sg rollback p:ItzSh4rkyz (never joined) -> 2 reversals, ground-truthed via execute-if-block, undone.