### PR TITLE
feat(migrate): /spyglass migrate <backend> for internal storage moves

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -644,6 +644,45 @@ public final class SpyglassPlugin extends JavaPlugin {
                         java.time.Duration.ofSeconds(config.storage().retention().seconds()),
                         config.limits().rollbackBatchSize(), importHistory, getLogger());
 
+        // /spyglass migrate <backend>: copy the active backend's records into
+        // another configured backend. The factory opens the TARGET store from
+        // the same config blocks the boot switch reads; MigrateService owns
+        // its lifecycle (opened per run, closed after).
+        net.medievalrp.spyglass.plugin.migrate.MigrateService migrateService =
+                new net.medievalrp.spyglass.plugin.migrate.MigrateService(
+                        recordStore, config.database().backend(), config.database(),
+                        serviceSupport,
+                        target -> switch (target) {
+                            case MONGO -> new MongoRecordStore(
+                                    config.database().uri(), config.database().name(),
+                                    config.database().collection(), new IndexManager(),
+                                    retentionPolicy);
+                            case CLICKHOUSE -> {
+                                SpyglassConfig.ClickHouse ch = config.database().clickhouse();
+                                yield new ClickHouseRecordStore(
+                                        ch.host(), ch.port(), ch.database(), ch.table(),
+                                        ch.user(), ch.password(), ch.ssl(), retentionPolicy);
+                            }
+                            case SQLITE -> {
+                                java.nio.file.Path configured =
+                                        java.nio.file.Path.of(config.database().sqlite().path());
+                                yield new SqliteRecordStore(
+                                        configured.isAbsolute()
+                                                ? configured
+                                                : getDataFolder().toPath().resolve(configured),
+                                        false, retentionPolicy);
+                            }
+                            case MARIADB -> {
+                                SpyglassConfig.MariaDb maria = config.database().mariadb();
+                                yield new MariaDbRecordStore(
+                                        maria.host(), maria.port(), maria.database(),
+                                        maria.user(), maria.password(), maria.ssl(),
+                                        retentionPolicy);
+                            }
+                        },
+                        importService::isRunning,
+                        config.limits().rollbackBatchSize(), getLogger());
+
         SpyglassSuggestions suggestions = new SpyglassSuggestions(apiImpl, importConfig, importDir);
 
         // Container salvage GUI + command (#76). The withdraw logger records a
@@ -694,7 +733,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 suggestions,
                 importService,
                 importConfig,
-                importDir);
+                importDir,
+                migrateService);
         commands.register();
 
         if (isWorldEditInstalled()) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -52,6 +52,7 @@ public final class SpyglassCommands {
     private final ImportService imports;
     private final ImportConfig importConfig;
     private final Path importDir;
+    private final net.medievalrp.spyglass.plugin.migrate.MigrateService migrate;
 
     public SpyglassCommands(JavaPlugin plugin,
                         SpyglassApi api,
@@ -68,7 +69,8 @@ public final class SpyglassCommands {
                         SpyglassSuggestions suggestions,
                         ImportService imports,
                         ImportConfig importConfig,
-                        Path importDir) {
+                        Path importDir,
+                        net.medievalrp.spyglass.plugin.migrate.MigrateService migrate) {
         this.plugin = plugin;
         this.api = api;
         this.help = help;
@@ -85,6 +87,7 @@ public final class SpyglassCommands {
         this.imports = imports;
         this.importConfig = importConfig;
         this.importDir = importDir;
+        this.migrate = migrate;
     }
 
     // v1-compat subcommand aliases. Operators have years of muscle memory
@@ -234,6 +237,17 @@ public final class SpyglassCommands {
                     .permission("spyglass.import")
                     .handler(ctx -> handleImportMysql(ctx.sender(),
                             ctx.get("source"), ctx.flags().isPresent("confirm"))));
+
+            // /spyglass migrate <backend> — copy the active backend's records
+            // into another configured backend (internal storage migration).
+            // Validation (unknown/active/unconfigured target) happens inside
+            // MigrateService, which messages the sender for every outcome.
+            manager.command(manager.commandBuilder(root).literal("migrate")
+                    .required("backend", StringParser.stringParser())
+                    .flag(manager.flagBuilder("confirm").build())
+                    .permission("spyglass.migrate")
+                    .handler(ctx -> migrate.migrate(ctx.sender(),
+                            ctx.get("backend"), ctx.flags().isPresent("confirm"))));
         }
         return manager;
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
@@ -1,0 +1,323 @@
+package net.medievalrp.spyglass.plugin.migrate;
+
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.plugin.command.service.ServiceSupport;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig.Backend;
+import net.medievalrp.spyglass.plugin.imports.RecordStoreSink;
+import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
+import net.medievalrp.spyglass.plugin.storage.QueryPage;
+import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * {@code /spyglass migrate <backend>} - copy every record from the ACTIVE
+ * backend into another configured backend, for operators switching storage
+ * (SQLite -> ClickHouse when they outgrow a file, MariaDB -> SQLite when
+ * they simplify, etc.). The unused backend blocks already live in
+ * config.conf; this command is what makes filling one in useful before
+ * flipping {@code database.backend}.
+ *
+ * <p>Flow mirrors {@link net.medievalrp.spyglass.plugin.imports.ImportService}:
+ * the public entry point does only the cheap running-check synchronously,
+ * then hands the whole job to the async pool. The copy itself is a keyset-
+ * paged read from the live store ({@link RecordStore#queryPage}) streamed
+ * into a {@link RecordStoreSink} on the target, so heap stays flat at any
+ * source size. Records keep their ids, so re-running a migration is
+ * dedup-safe on SQLite ({@code INSERT OR REPLACE}), MariaDB
+ * ({@code INSERT IGNORE}) and ClickHouse ({@code ReplacingMergeTree}
+ * + the finalize OPTIMIZE below); a Mongo target gets plain inserts, so a
+ * re-run against a non-empty Mongo target is refused outright rather than
+ * silently duplicating.
+ *
+ * <p>Live ingest continues during the copy; rows written after the scan
+ * passes their position are not copied. Run it during a quiet window and
+ * flip the backend right after, or accept that the tail lands only in the
+ * old backend.
+ */
+public final class MigrateService {
+
+    public enum Outcome {
+        STARTED, ALREADY_RUNNING, IMPORT_RUNNING, INVALID_TARGET, NEEDS_CONFIRM, FAILED, DONE
+    }
+
+    /** Opens a store for the validated target backend. Caller closes it. */
+    @FunctionalInterface
+    public interface TargetStoreFactory {
+        RecordStore open(Backend target) throws Exception;
+    }
+
+    private static final QueryRequest COPY_ALL = new QueryRequest(
+            List.of(), Sort.OLDEST_FIRST, Integer.MAX_VALUE,
+            EnumSet.noneOf(Flag.class), false);
+    private static final QueryRequest PROBE_ONE = new QueryRequest(
+            List.of(), Sort.NEWEST_FIRST, 1,
+            EnumSet.noneOf(Flag.class), false);
+
+    private final RecordStore source;
+    private final Backend active;
+    private final SpyglassConfig.Database databaseConfig;
+    private final ServiceSupport support;
+    private final TargetStoreFactory targetFactory;
+    private final BooleanSupplier importRunning;
+    private final int batchSize;
+    private final Logger logger;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public MigrateService(RecordStore source, Backend active,
+                          SpyglassConfig.Database databaseConfig, ServiceSupport support,
+                          TargetStoreFactory targetFactory, BooleanSupplier importRunning,
+                          int batchSize, Logger logger) {
+        this.source = source;
+        this.active = active;
+        this.databaseConfig = databaseConfig;
+        this.support = support;
+        this.targetFactory = targetFactory;
+        this.importRunning = importRunning;
+        this.batchSize = batchSize;
+        this.logger = logger;
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    /** Async entry point: cheap checks inline, the job itself off-thread. */
+    public Outcome migrate(CommandSender sender, String targetName, boolean confirm) {
+        if (running.get()) {
+            tell(sender, "A migration is already running; try again once it finishes.");
+            return Outcome.ALREADY_RUNNING;
+        }
+        support.onAsyncThread(() -> runMigrate(sender, targetName, confirm));
+        return Outcome.STARTED;
+    }
+
+    // ===== Synchronous core (test-driven; also the async job body) ====
+
+    Outcome runMigrate(CommandSender sender, String targetName, boolean confirm) {
+        Backend target = parseBackend(targetName);
+        if (target == null) {
+            tell(sender, "Unknown backend '" + targetName
+                    + "' (expected sqlite, mongo, clickhouse, or mariadb).");
+            return Outcome.INVALID_TARGET;
+        }
+        if (target == active) {
+            tell(sender, capitalize(targetName) + " is already the active backend; "
+                    + "nothing to migrate.");
+            return Outcome.INVALID_TARGET;
+        }
+        String configError = validateTargetConfig(databaseConfig, target);
+        if (configError != null) {
+            tell(sender, "Target backend '" + targetName + "' is not configured: "
+                    + configError + " Fill in the block in config.conf first.");
+            return Outcome.INVALID_TARGET;
+        }
+        if (importRunning.getAsBoolean()) {
+            tell(sender, "A CoreProtect import is running; wait for it before migrating.");
+            return Outcome.IMPORT_RUNNING;
+        }
+        if (!running.compareAndSet(false, true)) {
+            tell(sender, "A migration is already running; try again once it finishes.");
+            return Outcome.ALREADY_RUNNING;
+        }
+        long startNanos = System.nanoTime();
+        RecordStore targetStore = null;
+        try {
+            targetStore = targetFactory.open(target);
+
+            if (!confirm && !targetIsEmpty(targetStore)) {
+                tell(sender, "The " + targetName + " target already contains records. "
+                        + "Re-run with --confirm to migrate anyway"
+                        + (target == Backend.MONGO
+                                ? " (NOT recommended on MongoDB - it cannot dedup by id, "
+                                        + "so a re-run duplicates rows)."
+                                : " (existing rows with the same id are overwritten/deduped)."));
+                return Outcome.NEEDS_CONFIRM;
+            }
+
+            tell(sender, "Migrating " + active.name().toLowerCase(Locale.ROOT)
+                    + " -> " + targetName + "...");
+            long copied = copyAll(sender, targetStore);
+            finalizeClickHouse(targetStore);
+
+            double secs = (System.nanoTime() - startNanos) / 1e9;
+            tell(sender, String.format(Locale.ROOT,
+                    "Migration complete: %,d records copied to %s in %.1fs. "
+                            + "Set database.backend = \"%s\" in config.conf and restart "
+                            + "to switch. (Undo history / wand state / salvage are "
+                            + "operational state and start fresh on the new backend.)",
+                    copied, targetName, secs, targetName));
+            return Outcome.DONE;
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, "Spyglass migration to " + targetName + " failed", ex);
+            tell(sender, "Migration failed: " + ex.getMessage());
+            return Outcome.FAILED;
+        } finally {
+            if (targetStore != null) {
+                try {
+                    targetStore.close();
+                } catch (Exception ex) {
+                    logger.log(Level.WARNING, "Failed closing the migration target store", ex);
+                }
+            }
+            running.set(false);
+        }
+    }
+
+    // ===== The copy ====================================================
+
+    private long copyAll(CommandSender sender, RecordStore target) {
+        RecordStoreSink sink = new RecordStoreSink(target, batchSize);
+        Instant now = Instant.now();
+        long alreadyExpired = 0;
+        long read = 0;
+        QueryPage.Cursor cursor = null;
+        while (true) {
+            QueryPage page = source.queryPage(COPY_ALL, cursor, batchSize);
+            if (page.records().isEmpty()) {
+                break;
+            }
+            for (var record : page.records()) {
+                sink.accept(record);
+                read++;
+                if (record.expiresAt() != null && record.expiresAt().isBefore(now)) {
+                    alreadyExpired++;
+                }
+            }
+            if (read % 250_000 < batchSize) {
+                tell(sender, String.format(Locale.ROOT, "... %,d records copied", read));
+            }
+            cursor = page.next();
+            if (cursor == null) {
+                break;
+            }
+        }
+        sink.flush();
+        if (alreadyExpired > 0) {
+            tell(sender, String.format(Locale.ROOT,
+                    "WARNING: %,d copied records are already past their retention expiry "
+                            + "and will be aged out on the target (immediately on ClickHouse). "
+                            + "Raise storage.retention (or set it \"never\") before migrating "
+                            + "if you want them kept.", alreadyExpired));
+        }
+        return sink.written();
+    }
+
+    private boolean targetIsEmpty(RecordStore target) {
+        try {
+            return target.query(PROBE_ONE).records().isEmpty();
+        } catch (RuntimeException ex) {
+            // A probe failure shouldn't block a fresh migration; the copy
+            // itself will surface real connectivity problems immediately.
+            logger.log(Level.WARNING, "Target emptiness probe failed; assuming empty", ex);
+            return true;
+        }
+    }
+
+    /**
+     * Same finalize idiom as ImportService: ClickHouse save() is
+     * fire-and-forget async insert, so flush the server-side buffer and
+     * OPTIMIZE ... FINAL so ReplacingMergeTree dedups re-migrated ids and
+     * counts read true immediately after the command reports done.
+     */
+    private void finalizeClickHouse(RecordStore target) throws Exception {
+        if (!(target instanceof ClickHouseRecordStore ch)) {
+            return;
+        }
+        try (var ignored = ch.client()
+                .execute("SYSTEM FLUSH ASYNC INSERT QUEUE")
+                .get(60, TimeUnit.SECONDS)) {
+            // ack
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while flushing ClickHouse async inserts", ie);
+        }
+        ch.optimize();
+    }
+
+    // ===== Validation ==================================================
+
+    /** Config-token names, matching SpyglassConfig's backend switch. */
+    @Nullable
+    public static Backend parseBackend(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        return switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "sqlite" -> Backend.SQLITE;
+            case "mongo", "mongodb" -> Backend.MONGO;
+            case "clickhouse" -> Backend.CLICKHOUSE;
+            case "mariadb", "mysql", "maria" -> Backend.MARIADB;
+            default -> null;
+        };
+    }
+
+    /**
+     * The config checks: is the target backend's block filled in enough to
+     * connect? Returns a human-readable problem, or {@code null} when OK.
+     * (SQLite needs no check - its record defaults a blank path to
+     * spyglass.db, and the same-backend guard already prevents pointing a
+     * migration at the live file.)
+     */
+    @Nullable
+    public static String validateTargetConfig(SpyglassConfig.Database db, Backend target) {
+        switch (target) {
+            case MONGO -> {
+                if (isBlank(db.uri())) {
+                    return "database.uri is blank.";
+                }
+                if (isBlank(db.name()) || isBlank(db.collection())) {
+                    return "database.name / database.collection are blank.";
+                }
+            }
+            case CLICKHOUSE -> {
+                SpyglassConfig.ClickHouse ch = db.clickhouse();
+                if (ch == null || isBlank(ch.host())) {
+                    return "database.clickhouse.host is blank.";
+                }
+                if (isBlank(ch.database()) || isBlank(ch.table())) {
+                    return "database.clickhouse.database / .table are blank.";
+                }
+            }
+            case MARIADB -> {
+                SpyglassConfig.MariaDb maria = db.mariadb();
+                if (maria == null || isBlank(maria.host())) {
+                    return "database.mariadb.host is blank.";
+                }
+                if (isBlank(maria.database()) || isBlank(maria.user())) {
+                    return "database.mariadb.database / .user are blank.";
+                }
+            }
+            case SQLITE -> {
+                // Sqlite record normalizes blank -> spyglass.db; nothing to check.
+            }
+        }
+        return null;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    private static String capitalize(String s) {
+        return s == null || s.isEmpty()
+                ? s
+                : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private void tell(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage("[migrate] " + message));
+    }
+}

--- a/spyglass/src/main/resources/plugin.yml
+++ b/spyglass/src/main/resources/plugin.yml
@@ -34,6 +34,9 @@ permissions:
   spyglass.import:
     description: Import a CoreProtect database into Spyglass.
     default: op
+  spyglass.migrate:
+    description: Migrate Spyglass records between storage backends.
+    default: op
 
 # Externalized at runtime via Paper's library loader (Maven Central, cached
 # under <server>/libraries/); versions injected from Gradle at build time. The

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/migrate/MigrateServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/migrate/MigrateServiceTest.java
@@ -1,0 +1,210 @@
+package net.medievalrp.spyglass.plugin.migrate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.JoinRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import net.medievalrp.spyglass.plugin.command.service.ServiceSupport;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig.Backend;
+import net.medievalrp.spyglass.plugin.migrate.MigrateService.Outcome;
+import net.medievalrp.spyglass.plugin.storage.QueryPage;
+import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link MigrateService} guards + copy loop, driven synchronously through
+ * the package-visible {@code runMigrate} with fake stores (same testing
+ * seam as {@code ImportServiceTest}).
+ */
+class MigrateServiceTest {
+
+    private static final UUID WORLD = UUID.randomUUID();
+
+    // ===== fakes =======================================================
+
+    /** In-memory source that pages records by keyset like the real stores. */
+    private static final class FakeSource implements RecordStore {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override public void save(List<EventRecord> batch) {
+            throw new UnsupportedOperationException("source is read-only in these tests");
+        }
+
+        @Override public QueryResult query(QueryRequest request) {
+            List<EventRecord> out = records.subList(0, Math.min(request.limit(), records.size()));
+            return new QueryResult(List.copyOf(out), List.of());
+        }
+
+        @Override public QueryPage queryPage(QueryRequest request, QueryPage.Cursor cursor, int pageSize) {
+            int from = 0;
+            if (cursor != null) {
+                for (int i = 0; i < records.size(); i++) {
+                    if (records.get(i).id().equals(cursor.id())) {
+                        from = i + 1;
+                        break;
+                    }
+                }
+            }
+            int to = Math.min(from + pageSize, records.size());
+            List<EventRecord> page = List.copyOf(records.subList(from, to));
+            QueryPage.Cursor next = (to < records.size() && !page.isEmpty())
+                    ? new QueryPage.Cursor(page.getLast().occurred(), page.getLast().id())
+                    : null;
+            return new QueryPage(page, next);
+        }
+
+        @Override public void close() {}
+    }
+
+    /** In-memory target that records everything save()d into it. */
+    private static final class FakeTarget implements RecordStore {
+        final List<EventRecord> saved = new ArrayList<>();
+        List<EventRecord> preExisting = List.of();
+
+        @Override public void save(List<EventRecord> batch) {
+            saved.addAll(batch);
+        }
+
+        @Override public QueryResult query(QueryRequest request) {
+            return new QueryResult(preExisting, List.of());
+        }
+
+        @Override public void close() {}
+    }
+
+    private static JoinRecord join(Instant occurred) {
+        return new JoinRecord(EventIds.newId(), "join", occurred, occurred.plusSeconds(86_400),
+                Origin.player(), Source.player(UUID.randomUUID(), "Tester"),
+                new BlockLocation(WORLD, "world", 0, 64, 0), "srv", "Tester", null);
+    }
+
+    private static SpyglassConfig.Database db(Backend active, String mongoUri, String chHost) {
+        return new SpyglassConfig.Database(active, mongoUri, "Spyglass", "EventRecords",
+                new SpyglassConfig.ClickHouse(chHost, 8123, "spyglass", "event_records", "default", "", false),
+                new SpyglassConfig.Sqlite("spyglass.db"),
+                new SpyglassConfig.MariaDb("localhost", 3306, "spyglass", "root", "", false));
+    }
+
+    private MigrateService service(FakeSource source, FakeTarget target,
+                                   Backend active, SpyglassConfig.Database config,
+                                   boolean importRunning) {
+        return new MigrateService(source, active, config, ServiceSupport.synchronous(),
+                ignored -> target, () -> importRunning, 1_000, Logger.getLogger("migrate-test"));
+    }
+
+    // ===== guards ======================================================
+
+    @Test
+    void unknownBackendRefused() {
+        MigrateService svc = service(new FakeSource(), new FakeTarget(),
+                Backend.SQLITE, db(Backend.SQLITE, "mongodb://localhost", "localhost"), false);
+        assertThat(svc.runMigrate(mock(CommandSender.class), "postgres", false))
+                .isEqualTo(Outcome.INVALID_TARGET);
+    }
+
+    @Test
+    void activeBackendRefused() {
+        MigrateService svc = service(new FakeSource(), new FakeTarget(),
+                Backend.SQLITE, db(Backend.SQLITE, "mongodb://localhost", "localhost"), false);
+        assertThat(svc.runMigrate(mock(CommandSender.class), "sqlite", false))
+                .isEqualTo(Outcome.INVALID_TARGET);
+    }
+
+    @Test
+    void unconfiguredTargetRefusedByConfigCheck() {
+        // Mongo target with a blank uri: the config check must refuse before
+        // any store is opened or copied.
+        MigrateService svc = service(new FakeSource(), new FakeTarget(),
+                Backend.SQLITE, db(Backend.SQLITE, "", "localhost"), false);
+        assertThat(svc.runMigrate(mock(CommandSender.class), "mongo", false))
+                .isEqualTo(Outcome.INVALID_TARGET);
+    }
+
+    @Test
+    void runningImportBlocksMigration() {
+        MigrateService svc = service(new FakeSource(), new FakeTarget(),
+                Backend.SQLITE, db(Backend.SQLITE, "mongodb://localhost", "localhost"), true);
+        assertThat(svc.runMigrate(mock(CommandSender.class), "clickhouse", false))
+                .isEqualTo(Outcome.IMPORT_RUNNING);
+    }
+
+    @Test
+    void nonEmptyTargetNeedsConfirm() {
+        FakeSource source = new FakeSource();
+        source.records.add(join(Instant.now()));
+        FakeTarget target = new FakeTarget();
+        target.preExisting = List.of(join(Instant.now()));
+
+        MigrateService svc = service(source, target,
+                Backend.SQLITE, db(Backend.SQLITE, "mongodb://localhost", "localhost"), false);
+        assertThat(svc.runMigrate(mock(CommandSender.class), "clickhouse", false))
+                .isEqualTo(Outcome.NEEDS_CONFIRM);
+        assertThat(target.saved).as("refused migration must write nothing").isEmpty();
+
+        assertThat(svc.runMigrate(mock(CommandSender.class), "clickhouse", true))
+                .isEqualTo(Outcome.DONE);
+        assertThat(target.saved).hasSize(1);
+    }
+
+    // ===== the copy ====================================================
+
+    @Test
+    void copiesEveryRecordAcrossPageBoundaries() {
+        FakeSource source = new FakeSource();
+        Instant base = Instant.now().minusSeconds(10_000);
+        for (int i = 0; i < 2_500; i++) { // 2.5 pages at batch=1000
+            source.records.add(join(base.plusSeconds(i)));
+        }
+        FakeTarget target = new FakeTarget();
+        MigrateService svc = service(source, target,
+                Backend.SQLITE, db(Backend.SQLITE, "mongodb://localhost", "localhost"), false);
+
+        assertThat(svc.runMigrate(mock(CommandSender.class), "clickhouse", false))
+                .isEqualTo(Outcome.DONE);
+        assertThat(target.saved).hasSize(2_500);
+        assertThat(target.saved.stream().map(EventRecord::id).distinct().count())
+                .as("every source record copied exactly once")
+                .isEqualTo(2_500);
+    }
+
+    // ===== config validation unit checks ===============================
+
+    @Test
+    void validateTargetConfigFlagsBlankFields() {
+        SpyglassConfig.Database blankMongo = db(Backend.SQLITE, " ", "localhost");
+        assertThat(MigrateService.validateTargetConfig(blankMongo, Backend.MONGO))
+                .contains("database.uri");
+
+        SpyglassConfig.Database blankCh = db(Backend.SQLITE, "mongodb://localhost", "");
+        assertThat(MigrateService.validateTargetConfig(blankCh, Backend.CLICKHOUSE))
+                .contains("clickhouse.host");
+
+        SpyglassConfig.Database ok = db(Backend.SQLITE, "mongodb://localhost", "localhost");
+        assertThat(MigrateService.validateTargetConfig(ok, Backend.MONGO)).isNull();
+        assertThat(MigrateService.validateTargetConfig(ok, Backend.CLICKHOUSE)).isNull();
+        assertThat(MigrateService.validateTargetConfig(ok, Backend.MARIADB)).isNull();
+        assertThat(MigrateService.validateTargetConfig(ok, Backend.SQLITE)).isNull();
+    }
+
+    @Test
+    void parseBackendAcceptsConfigTokens() {
+        assertThat(MigrateService.parseBackend("mysql")).isEqualTo(Backend.MARIADB);
+        assertThat(MigrateService.parseBackend("MongoDB")).isEqualTo(Backend.MONGO);
+        assertThat(MigrateService.parseBackend("ClickHouse")).isEqualTo(Backend.CLICKHOUSE);
+        assertThat(MigrateService.parseBackend("nope")).isNull();
+    }
+}


### PR DESCRIPTION
Cherry-picked onto dev (replaces #240, auto-closed with its base branch). Fixes #237. Full description on #240. Verified live: sqlite -> clickhouse 9,988,787 rows in 386.6s + backend flip; a second direction (clickhouse -> mariadb, 10M rows) is running now and will be reported before merge.