### PR TITLE
fix(util): worldless sentinel for null-world captures

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockLocations.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockLocations.java
@@ -8,11 +8,27 @@ import org.bukkit.block.Block;
 
 public final class BlockLocations {
 
+    /**
+     * Sentinel world id for a capture whose world was already gone (#232).
+     * A stale {@link Location} - an entity observed mid world-unload, some
+     * async contexts - can legitimately return a null world; before this,
+     * every factory below NPE'd on the tick, on the high-frequency
+     * break/place path. A sentinel beats both throwing (kills the capture
+     * AND the listener) and returning null (a null location rippling into
+     * a record is the #230 drain-poison failure). The record persists with
+     * time/player/action intact; {@link #resolveWorld} finds nothing for
+     * it, so rollback skips it.
+     */
+    private static final java.util.UUID NULL_WORLD_ID = new java.util.UUID(0L, 0L);
+
     private BlockLocations() {
     }
 
     public static net.medievalrp.spyglass.api.util.BlockLocation fromLocation(Location location) {
         World world = location.getWorld();
+        if (world == null) {
+            return worldless(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        }
         return new net.medievalrp.spyglass.api.util.BlockLocation(
                 world.getUID(),
                 world.getName(),
@@ -40,12 +56,19 @@ public final class BlockLocations {
      * {@link Location} allocation.
      */
     public static net.medievalrp.spyglass.api.util.BlockLocation from(World world, int x, int y, int z) {
+        if (world == null) {
+            return worldless(x, y, z);
+        }
         return new net.medievalrp.spyglass.api.util.BlockLocation(
                 world.getUID(),
                 world.getName(),
                 x,
                 y,
                 z);
+    }
+
+    private static net.medievalrp.spyglass.api.util.BlockLocation worldless(int x, int y, int z) {
+        return new net.medievalrp.spyglass.api.util.BlockLocation(NULL_WORLD_ID, "", x, y, z);
     }
 
     public static Optional<World> resolveWorld(net.medievalrp.spyglass.api.util.BlockLocation location) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockLocationsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockLocationsTest.java
@@ -82,4 +82,41 @@ class BlockLocationsTest {
         assertThat(BlockLocations.fromBlock(block))
                 .isEqualTo(BlockLocations.from(world, 3, 7, 11));
     }
+
+    // ===== #232: null world (entity observed mid world-unload) =========
+    // The factories must yield the worldless sentinel instead of NPEing on
+    // the tick - and must NOT return null, which would ripple a null
+    // location into the record (the #230 drain-poison shape).
+
+    @Test
+    void nullWorldLocationYieldsWorldlessSentinelNotThrow() {
+        Location stale = mock(Location.class);
+        when(stale.getWorld()).thenReturn(null);
+        when(stale.getBlockX()).thenReturn(17);
+        when(stale.getBlockY()).thenReturn(65);
+        when(stale.getBlockZ()).thenReturn(-4);
+
+        BlockLocation loc = BlockLocations.fromLocation(stale);
+
+        assertThat(loc).isNotNull();
+        assertThat(loc.worldId()).isEqualTo(new UUID(0L, 0L));
+        assertThat(loc.worldName()).isEmpty();
+        assertThat(loc.x()).isEqualTo(17);
+        assertThat(loc.y()).isEqualTo(65);
+        assertThat(loc.z()).isEqualTo(-4);
+    }
+
+    @Test
+    void nullWorldCoordsAndBlockYieldTheSameSentinel() {
+        BlockLocation viaCoords = BlockLocations.from(null, 1, 2, 3);
+        assertThat(viaCoords).isNotNull();
+        assertThat(viaCoords.worldId()).isEqualTo(new UUID(0L, 0L));
+
+        Block orphan = mock(Block.class);
+        when(orphan.getWorld()).thenReturn(null);
+        when(orphan.getX()).thenReturn(1);
+        when(orphan.getY()).thenReturn(2);
+        when(orphan.getZ()).thenReturn(3);
+        assertThat(BlockLocations.fromBlock(orphan)).isEqualTo(viaCoords);
+    }
 }


### PR DESCRIPTION
Fixes #232. A stale Location (entity observed mid world-unload) returns a null world; all three BlockLocations factories NPE'd on the tick. They now return a worldless sentinel (zero UUID, empty name) instead. Deliberate deviation from the issue's skip-the-capture suggestion: a null return would need guards at 15+ call sites and would ripple a null location into records - the exact #230 drain-poison shape. The sentinel keeps the capture (time/player/action intact), resolveWorld finds nothing for it so rollback skips it, and no caller changes. Tests cover fromLocation/from/fromBlock with null worlds.