### PR TITLE
command UX: complete paginated help, prefix spacing, house-styled import/migrate output

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/pipeline/ProgressReporter.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/pipeline/ProgressReporter.java
@@ -27,7 +27,7 @@ public final class ProgressReporter {
     }
 
     public void endTable(String label, long rowsInTable) {
-        out.printf(Locale.ROOT, "  %s done — %,d rows%n", label, rowsInTable);
+        out.printf(Locale.ROOT, "  %s done - %,d rows%n", label, rowsInTable);
     }
 
     public void onRow(long readSoFar) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -116,9 +116,13 @@ public final class SpyglassCommands {
                     .handler(ctx -> help.send(ctx.sender())));
 
             for (String name : HELP_ALIASES) {
+                // Optional page (#249): the full command list overflows chat,
+                // so /sg help paginates and /sg help <n> jumps to a page.
                 manager.command(manager.commandBuilder(root).literal(name)
+                        .optional("page", IntegerParser.integerParser(1))
                         .permission("spyglass.use")
-                        .handler(ctx -> help.send(ctx.sender())));
+                        .handler(ctx -> help.send(ctx.sender(),
+                                ctx.<Integer>optional("page").orElse(1))));
             }
 
             for (String name : EVENTS_ALIASES) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
@@ -47,10 +47,16 @@ public final class Feedback {
                 .asComponent();
     }
 
-    /** `«Spyglass»<green>message</green>` — matches v1's Formatter.success. */
+    /**
+     * `«Spyglass» <green>message</green>`. v1's Formatter.success had no
+     * space after the prefix - the only category that didn't - which
+     * rendered as `«Spyglass»Spyglass version x.y.z` on /sg version (#251).
+     * All four categories now frame identically.
+     */
     public static Component success(String message) {
         return Component.text()
                 .append(PREFIX)
+                .append(Component.text(" ", NamedTextColor.WHITE))
                 .append(Component.text(message, NamedTextColor.GREEN))
                 .asComponent();
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -12,22 +12,48 @@ public final class HelpService {
     private record Entry(String name, String usage, String description) {
     }
 
+    // Every registered command, in rough workflow order (#249). Keep this in
+    // lockstep with SpyglassCommands registrations and COMMANDS.md - a
+    // command an operator can't discover here may as well not exist.
     private static final Entry[] ENTRIES = new Entry[]{
+            // Page 1: the daily commands (the classic help screen).
+            new Entry("help", "<Page #>", "Show this help, one page at a time."),
             new Entry("search", "<Lookup Params>", "Search Data Records based on the parameters provided."),
+            new Entry("page", "<Page #>", "Moves you to the specified page of results (cached 15 min)."),
             new Entry("rollback", "<Lookup Params>", "Rollback a set of changes based on the parameters provided."),
             new Entry("restore", "<Lookup Params>", "Restore a set of changes based on the parameters provided."),
             new Entry("undo", "", "Undo your most recent rollback or restore."),
-            new Entry("page", "<Page #>", "Moves you to the specified page of results (cached 15 min)."),
             new Entry("tool", "", "Toggle the inspection wand."),
             new Entry("events", "", "List every event type currently being recorded."),
+            // Page 2: queue/admin/migration.
+            new Entry("rbqueue", "", "List, cancel, or resume queued rollback jobs."),
+            new Entry("inventory", "[id]", "Recover items a rollback destroyed (GUI where available)."),
+            new Entry("stats", "", "Show ingest analytics (when enabled in config)."),
+            new Entry("import", "<file>", "Import a CoreProtect SQLite database from plugins/Spyglass/import/."),
+            new Entry("import mysql", "<source>", "Import a live CoreProtect MySQL database (sources in import.conf)."),
+            new Entry("migrate", "<backend>", "Copy all records into another configured storage backend."),
+            new Entry("tele", "<world> <x> <y> <z>", "Teleport (used by clickable search results)."),
             new Entry("version", "", "Show the Spyglass version."),
     };
 
+    private static final int PAGE_SIZE = 8;
+
     public void send(CommandSender sender) {
-        sender.sendMessage(Component.text(" -======= Spyglass =======-", NamedTextColor.AQUA));
+        send(sender, 1);
+    }
+
+    public void send(CommandSender sender, int page) {
+        int pages = (ENTRIES.length + PAGE_SIZE - 1) / PAGE_SIZE;
+        int clamped = Math.min(Math.max(page, 1), pages);
+        sender.sendMessage(Component.text(
+                " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
+                NamedTextColor.AQUA));
         sender.sendMessage(Component.text("For Powerful Searching", NamedTextColor.DARK_GRAY)
                 .decoration(TextDecoration.ITALIC, true));
-        for (Entry entry : ENTRIES) {
+        int from = (clamped - 1) * PAGE_SIZE;
+        int to = Math.min(from + PAGE_SIZE, ENTRIES.length);
+        for (int index = from; index < to; index++) {
+            Entry entry = ENTRIES[index];
             Component line = Component.text()
                     .append(Component.text("/spyglass ", NamedTextColor.AQUA))
                     .append(Component.text(entry.name() + " ", NamedTextColor.GREEN))
@@ -36,6 +62,12 @@ public final class HelpService {
                     .append(Component.text(entry.description(), NamedTextColor.GRAY))
                     .asComponent();
             sender.sendMessage(line);
+        }
+        if (pages > 1) {
+            sender.sendMessage(Component.text(
+                            "/spyglass help " + (clamped % pages + 1) + " for the next page",
+                            NamedTextColor.DARK_GRAY)
+                    .decoration(TextDecoration.ITALIC, true));
         }
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
@@ -85,7 +85,7 @@ public final class ImportService {
 
     public ImportOutcome importSqlite(CommandSender sender, Path dbFile, boolean confirm) {
         if (running.get()) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runImportSqlite(sender, dbFile, confirm));
@@ -95,7 +95,7 @@ public final class ImportService {
     public ImportOutcome importMysql(CommandSender sender, String sourceName,
                             ImportConfig.MysqlSourceSpec spec, boolean confirm) {
         if (running.get()) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runImportMysql(sender, sourceName, spec, confirm));
@@ -106,7 +106,7 @@ public final class ImportService {
 
     ImportOutcome runImportSqlite(CommandSender sender, Path dbFile, boolean confirm) {
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         String displayName = dbFile.getFileName().toString();
@@ -120,7 +120,7 @@ public final class ImportService {
                     () -> SqliteSource.open(dbFile));
         } catch (IOException | RuntimeException ex) {
             logger.log(Level.SEVERE, "Spyglass import failed for " + displayName, ex);
-            tell(sender, "Import failed: " + ex.getMessage());
+            tellError(sender, "Import failed: " + ex.getMessage());
             return ImportOutcome.FAILED;
         } finally {
             running.set(false);
@@ -130,7 +130,7 @@ public final class ImportService {
     ImportOutcome runImportMysql(CommandSender sender, String sourceName,
                                  ImportConfig.MysqlSourceSpec spec, boolean confirm) {
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         try {
@@ -145,7 +145,7 @@ public final class ImportService {
                             spec.host(), spec.port(), spec.database(), spec.user(), spec.password())));
         } catch (IOException | RuntimeException ex) {
             logger.log(Level.SEVERE, "Spyglass import failed for " + sourceName, ex);
-            tell(sender, "Import failed: " + ex.getMessage());
+            tellError(sender, "Import failed: " + ex.getMessage());
             return ImportOutcome.FAILED;
         } finally {
             running.set(false);
@@ -188,7 +188,7 @@ public final class ImportService {
             history.record(new ImportRecord(identity, displayName, System.currentTimeMillis(),
                     senderName, summary.totalRead(), summary.totalWritten(), summary.totalSkipped()));
 
-            tell(sender, "Import complete for " + displayName + ": read=" + summary.totalRead()
+            tellSuccess(sender, "Import complete for " + displayName + ": read=" + summary.totalRead()
                     + " written=" + summary.totalWritten() + " skipped=" + summary.totalSkipped());
             return ImportOutcome.DONE;
         }
@@ -208,13 +208,13 @@ public final class ImportService {
             return null;
         }
         if (backend == Backend.MONGO) {
-            tell(sender, "This source was already imported and re-importing into MongoDB "
+            tellError(sender, "This source was already imported and re-importing into MongoDB "
                     + "is not supported; switch backends or restore from a MongoDB backup.");
             return ImportOutcome.MONGO_REIMPORT_BLOCKED;
         }
         if (!confirm) {
             ImportRecord p = prior.get();
-            tell(sender, "This source was already imported on " + Instant.ofEpochMilli(p.importedAtEpochMs())
+            tellError(sender, "This source was already imported on " + Instant.ofEpochMilli(p.importedAtEpochMs())
                     + " by " + p.importedBy() + " (read=" + p.read() + ", written=" + p.written()
                     + ", skipped=" + p.skipped() + "). Re-run with --confirm to import again.");
             return ImportOutcome.NEEDS_CONFIRM;
@@ -274,8 +274,8 @@ public final class ImportService {
                 Instant.ofEpochSecond(cutoffSec), java.time.ZoneOffset.UTC);
         java.time.LocalDate oldest = java.time.LocalDate.ofInstant(
                 Instant.ofEpochSecond(preview.oldestEpochSeconds()), java.time.ZoneOffset.UTC);
-        tell(sender, String.format(java.util.Locale.ROOT,
-                "WARNING: %,d of %,d events (%.1f%%) are older than your retention cutoff "
+        tellWarn(sender, String.format(java.util.Locale.ROOT,
+                "%,d of %,d events (%.1f%%) are older than your retention cutoff "
                         + "%s (retention %dd) and will be aged out after import - immediately "
                         + "on ClickHouse, on the next prune sweep otherwise. Oldest source "
                         + "event: %s. To keep the full history, raise storage.retention (or "
@@ -287,7 +287,25 @@ public final class ImportService {
         return (serverName == null || serverName.isBlank()) ? defaultServerName : serverName;
     }
 
+    // House-styled sender feedback (#252): imports frame like every other
+    // Spyglass message instead of a bare "[import] " string.
     private void tell(CommandSender sender, String message) {
-        support.onMainThread(() -> sender.sendMessage("[import] " + message));
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.info(message)));
+    }
+
+    private void tellWarn(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.warn(message)));
+    }
+
+    private void tellError(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.error(message)));
+    }
+
+    private void tellSuccess(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.success(message)));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/SenderProgress.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/SenderProgress.java
@@ -23,15 +23,27 @@ final class SenderProgress extends PrintStream {
 
         @Override
         public synchronized void flush() {
+            // The autoflushing PrintStream flushes per printf SEGMENT, not per
+            // line - forwarding the raw buffer sent fragments ("co_block",
+            // " done - 17,103", " rows") as separate chat messages (#252).
+            // Forward complete lines only; keep any trailing partial buffered.
             String text = toString(StandardCharsets.UTF_8);
-            if (text.isEmpty()) {
+            int lastNewline = text.lastIndexOf('\n');
+            if (lastNewline < 0) {
                 return;
             }
+            String remainder = text.substring(lastNewline + 1);
+            String complete = text.substring(0, lastNewline);
             reset();
-            for (String line : text.split("\n", -1)) {
+            if (!remainder.isEmpty()) {
+                byte[] keep = remainder.getBytes(StandardCharsets.UTF_8);
+                write(keep, 0, keep.length);
+            }
+            for (String line : complete.split("\n", -1)) {
                 if (!line.isBlank()) {
                     String msg = line.stripTrailing();
-                    support.onMainThread(() -> sender.sendMessage("[import] " + msg));
+                    support.onMainThread(() -> sender.sendMessage(
+                            net.medievalrp.spyglass.plugin.command.render.Feedback.info(msg)));
                 }
             }
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
@@ -97,7 +97,7 @@ public final class MigrateService {
     /** Async entry point: cheap checks inline, the job itself off-thread. */
     public Outcome migrate(CommandSender sender, String targetName, boolean confirm) {
         if (running.get()) {
-            tell(sender, "A migration is already running; try again once it finishes.");
+            tellError(sender, "A migration is already running; try again once it finishes.");
             return Outcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runMigrate(sender, targetName, confirm));
@@ -109,27 +109,27 @@ public final class MigrateService {
     Outcome runMigrate(CommandSender sender, String targetName, boolean confirm) {
         Backend target = parseBackend(targetName);
         if (target == null) {
-            tell(sender, "Unknown backend '" + targetName
+            tellError(sender, "Unknown backend '" + targetName
                     + "' (expected sqlite, mongo, clickhouse, or mariadb).");
             return Outcome.INVALID_TARGET;
         }
         if (target == active) {
-            tell(sender, capitalize(targetName) + " is already the active backend; "
+            tellError(sender, capitalize(targetName) + " is already the active backend; "
                     + "nothing to migrate.");
             return Outcome.INVALID_TARGET;
         }
         String configError = validateTargetConfig(databaseConfig, target);
         if (configError != null) {
-            tell(sender, "Target backend '" + targetName + "' is not configured: "
+            tellError(sender, "Target backend '" + targetName + "' is not configured: "
                     + configError + " Fill in the block in config.conf first.");
             return Outcome.INVALID_TARGET;
         }
         if (importRunning.getAsBoolean()) {
-            tell(sender, "A CoreProtect import is running; wait for it before migrating.");
+            tellError(sender, "A CoreProtect import is running; wait for it before migrating.");
             return Outcome.IMPORT_RUNNING;
         }
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "A migration is already running; try again once it finishes.");
+            tellError(sender, "A migration is already running; try again once it finishes.");
             return Outcome.ALREADY_RUNNING;
         }
         long startNanos = System.nanoTime();
@@ -138,7 +138,7 @@ public final class MigrateService {
             targetStore = targetFactory.open(target);
 
             if (!confirm && !targetIsEmpty(targetStore)) {
-                tell(sender, "The " + targetName + " target already contains records. "
+                tellError(sender, "The " + targetName + " target already contains records. "
                         + "Re-run with --confirm to migrate anyway"
                         + (target == Backend.MONGO
                                 ? " (NOT recommended on MongoDB - it cannot dedup by id, "
@@ -153,7 +153,7 @@ public final class MigrateService {
             finalizeClickHouse(targetStore);
 
             double secs = (System.nanoTime() - startNanos) / 1e9;
-            tell(sender, String.format(Locale.ROOT,
+            tellSuccess(sender, String.format(Locale.ROOT,
                     "Migration complete: %,d records copied to %s in %.1fs. "
                             + "Set database.backend = \"%s\" in config.conf and restart "
                             + "to switch. (Undo history / wand state / salvage are "
@@ -162,7 +162,7 @@ public final class MigrateService {
             return Outcome.DONE;
         } catch (Exception ex) {
             logger.log(Level.SEVERE, "Spyglass migration to " + targetName + " failed", ex);
-            tell(sender, "Migration failed: " + ex.getMessage());
+            tellError(sender, "Migration failed: " + ex.getMessage());
             return Outcome.FAILED;
         } finally {
             if (targetStore != null) {
@@ -206,8 +206,8 @@ public final class MigrateService {
         }
         sink.flush();
         if (alreadyExpired > 0) {
-            tell(sender, String.format(Locale.ROOT,
-                    "WARNING: %,d copied records are already past their retention expiry "
+            tellWarn(sender, String.format(Locale.ROOT,
+                    "%,d copied records are already past their retention expiry "
                             + "and will be aged out on the target (immediately on ClickHouse). "
                             + "Raise storage.retention (or set it \"never\") before migrating "
                             + "if you want them kept.", alreadyExpired));
@@ -317,7 +317,24 @@ public final class MigrateService {
                 : Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
+    // House-styled sender feedback (#252), mirroring ImportService.
     private void tell(CommandSender sender, String message) {
-        support.onMainThread(() -> sender.sendMessage("[migrate] " + message));
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.info(message)));
+    }
+
+    private void tellWarn(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.warn(message)));
+    }
+
+    private void tellError(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.error(message)));
+    }
+
+    private void tellSuccess(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.success(message)));
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/FeedbackTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/FeedbackTest.java
@@ -40,6 +40,16 @@ class FeedbackTest {
     }
 
     @Test
+    void everyCategoryFramesWithASpaceAfterThePrefix() {
+        // #251: success was the odd one out (v1 parity) and rendered
+        // "«Spyglass»Spyglass version x.y.z" on /sg version.
+        assertThat(plain(Feedback.info("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.warn("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.error("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.success("m"))).startsWith("«Spyglass» ");
+    }
+
+    @Test
     void bonusIsPlainWithoutPrefix() {
         assertThat(plain(Feedback.bonus("skip reason"))).isEqualTo("skip reason");
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
@@ -30,4 +30,51 @@ class HelpServiceTest {
                 .contains("/spyglass tool")
                 .contains("/spyglass events");
     }
+
+    // ===== #249: every command discoverable, across pages ==============
+
+    @Test
+    void everyRegisteredCommandAppearsAcrossThePages() {
+        CommandSender sender = mock(CommandSender.class);
+        List<Component> captured = ServiceTestSupport.captureMessages(sender);
+
+        HelpService help = new HelpService();
+        help.send(sender, 1);
+        help.send(sender, 2);
+
+        String combined = String.join("\n", ServiceTestSupport.plainTexts(captured));
+        assertThat(combined)
+                .contains("/spyglass help")
+                .contains("/spyglass events")
+                .contains("/spyglass rbqueue")
+                .contains("/spyglass inventory")
+                .contains("/spyglass stats")
+                .contains("/spyglass import <file>")
+                .contains("/spyglass import mysql")
+                .contains("/spyglass migrate")
+                .contains("/spyglass tele")
+                .contains("/spyglass version");
+    }
+
+    @Test
+    void paginatesWithHeaderCountAndClampsOutOfRangePages() {
+        CommandSender sender = mock(CommandSender.class);
+        List<Component> captured = ServiceTestSupport.captureMessages(sender);
+
+        new HelpService().send(sender, 1);
+        List<String> pageOne = ServiceTestSupport.plainTexts(captured);
+        assertThat(pageOne.get(0)).contains("(1/2)");
+        // header + tagline + 8 entries + next-page hint
+        assertThat(pageOne).hasSize(11);
+        assertThat(pageOne.get(pageOne.size() - 1)).contains("help 2");
+
+        captured.clear();
+        new HelpService().send(sender, 99);
+        List<String> clamped = ServiceTestSupport.plainTexts(captured);
+        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page").contains("(2/2)");
+
+        captured.clear();
+        new HelpService().send(sender, -5);
+        assertThat(ServiceTestSupport.plainTexts(captured).get(0)).contains("(1/2)");
+    }
 }


### PR DESCRIPTION
Three commits, one per issue:

- Fixes #249: /sg help lists every command (rbqueue, inventory, stats, import, import mysql, migrate, tele were undiscoverable) and paginates - page 1 keeps the classic daily commands, page 2 holds queue/admin/migration, /sg help <n> jumps, out-of-range pages clamp, footer hints the next page. Same aqua/green/gray line style for every entry.
- Fixes #251: Feedback.success now frames "«Spyglass» message" like info/warn/error - /sg version no longer renders "«Spyglass»Spyglass version x.y.z". Test pins the space on all four categories.
- Fixes #252: import/migrate output goes through the house Feedback components instead of bare "[import] "/"[migrate] " strings (errors red, warnings yellow, completions green). Also fixes the import progress stream flushing printf FRAGMENTS as separate chat lines (SenderProgress now forwards complete lines only) and replaces an em dash in ProgressReporter output with a hyphen per the repo rule.

Full :spyglass:test green.