### PR TITLE
feat(commands): /s root alias behind a config toggle

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -734,7 +734,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 importService,
                 importConfig,
                 importDir,
-                migrateService);
+                migrateService,
+                config.commands().sAlias());
         commands.register();
 
         if (isWorldEditInstalled()) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -34,7 +34,13 @@ public final class SpyglassCommands {
 
     // /sg is the short backend alias; /sgv on the Velocity proxy stays
     // namespace-distinct so the proxy never shadows the Paper command.
-    private static final List<String> ROOT_ALIASES = List.of("spyglass", "sg");
+    // /s joins when commands.s-alias is enabled in config (#250) - opt-in
+    // because single-letter roots collide with other plugins.
+    private final List<String> rootAliases;
+
+    static List<String> rootAliases(boolean sAlias) {
+        return sAlias ? List.of("spyglass", "sg", "s") : List.of("spyglass", "sg");
+    }
 
     private final JavaPlugin plugin;
     private final SpyglassApi api;
@@ -70,7 +76,8 @@ public final class SpyglassCommands {
                         ImportService imports,
                         ImportConfig importConfig,
                         Path importDir,
-                        net.medievalrp.spyglass.plugin.migrate.MigrateService migrate) {
+                        net.medievalrp.spyglass.plugin.migrate.MigrateService migrate,
+                        boolean sAlias) {
         this.plugin = plugin;
         this.api = api;
         this.help = help;
@@ -88,6 +95,7 @@ public final class SpyglassCommands {
         this.importConfig = importConfig;
         this.importDir = importDir;
         this.migrate = migrate;
+        this.rootAliases = rootAliases(sAlias);
     }
 
     // v1-compat subcommand aliases. Operators have years of muscle memory
@@ -110,7 +118,7 @@ public final class SpyglassCommands {
     public CommandManager<CommandSender> register() {
         LegacyPaperCommandManager<CommandSender> manager = LegacyPaperCommandManager.createNative(
                 plugin, ExecutionCoordinator.simpleCoordinator());
-        for (String root : ROOT_ALIASES) {
+        for (String root : rootAliases) {
             manager.command(manager.commandBuilder(root)
                     .permission("spyglass.use")
                     .handler(ctx -> help.send(ctx.sender())));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -21,7 +21,8 @@ public record SpyglassConfig(
         Tool tool,
         Server server,
         Metrics metrics,
-        Analytics analytics) {
+        Analytics analytics,
+        Commands commands) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -129,7 +130,10 @@ public record SpyglassConfig(
                 new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
                 new Server(root.node("server", "name").getString("default")),
                 parseMetrics(root),
-                parseAnalytics(root));
+                parseAnalytics(root),
+                // #250: /s as a third root alias, opt-in - single-letter
+                // roots collide with other plugins, so off by default.
+                new Commands(root.node("commands", "s-alias").getBoolean(false)));
     }
 
     /**
@@ -479,6 +483,9 @@ public record SpyglassConfig(
      * Configured under {@code server.name} in {@code config.conf}; defaults
      * to {@code "default"} for a single-server deployment.
      */
+    public record Commands(boolean sAlias) {
+    }
+
     public record Server(String name) {
         public Server {
             name = name == null ? "default" : name.trim();

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -229,6 +229,13 @@ tool {
   material = "GLOWSTONE"
 }
 
+commands {
+  # Register /s as a third root alias next to /spyglass and /sg. Off by
+  # default: single-letter commands collide with other plugins (and /s is
+  # a common shorthand for /say or social plugins), so opt in deliberately.
+  s-alias = false
+}
+
 server {
   # Identifier for this Spyglass instance, stamped onto every recorded
   # event. When multiple backend servers share a single Mongo / ClickHouse

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
@@ -33,4 +33,11 @@ class SpyglassCommandsTest {
                 .contains("on Paper 26.2")
                 .doesNotContain("by ");
     }
+
+    // #250: /s is opt-in and must never displace the two canonical roots.
+    @Test
+    void sAliasTogglesTheThirdRoot() {
+        assertThat(SpyglassCommands.rootAliases(false)).containsExactly("spyglass", "sg");
+        assertThat(SpyglassCommands.rootAliases(true)).containsExactly("spyglass", "sg", "s");
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -80,6 +80,15 @@ class SpyglassConfigTest {
                 .isEqualTo(3L * 24 * 60 * 60);
     }
 
+    // #250: /s root alias is opt-in; absent key must read as disabled.
+    @Test
+    void sAliasDefaultsOffAndReadsExplicitTrue() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        assertThat(root.node("commands", "s-alias").getBoolean(false)).isFalse();
+        root.node("commands", "s-alias").set(true);
+        assertThat(root.node("commands", "s-alias").getBoolean(false)).isTrue();
+    }
+
     @Test
     void absentRedactKeyFallsBackToDefaultAuthSet() throws SerializationException {
         BasicConfigurationNode root = BasicConfigurationNode.root();


### PR DESCRIPTION
Fixes #250. commands.s-alias (default false, documented in config.conf) adds /s as a third root next to /spyglass and /sg at registration time. Off by default - single-letter roots collide with other plugins. Tests cover the config read and the alias list.