### PR TITLE
fix(storage): stop null-location records from poisoning the ClickHouse drain

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -344,6 +344,9 @@ public final class ClickHouseRecordStore implements RecordStore {
                 record instanceof RollbackOpRecord op ? op.reference() : null);
     }
 
+    /** Worldless sentinel for a null location (#230); columns are non-nullable. */
+    private static final java.util.UUID NULL_WORLD_ID = new java.util.UUID(0L, 0L);
+
     private void writeCommon(RowBinaryFormatWriter writer, EventRecord record) throws IOException {
         Origin origin = record.origin();
         Source source = record.source();
@@ -373,11 +376,20 @@ public final class ClickHouseRecordStore implements RecordStore {
         writer.setValue("source_command_block_y", cmdLoc == null ? null : cmdLoc.y());
         writer.setValue("source_command_block_z", cmdLoc == null ? null : cmdLoc.z());
         writer.setValue("source_description", source == null ? null : source.description());
-        writer.setValue("location_world_id", location.worldId());
-        writer.setString("location_world_name", nullToEmpty(location.worldName()));
-        writer.setInteger("location_x", location.x());
-        writer.setInteger("location_y", location.y());
-        writer.setInteger("location_z", location.z());
+        // #230: a null location must not poison the drain - this exact
+        // dereference wedged a production ingest for 1.5h (the drain retried
+        // the same poisoned batch forever). Maria/Sqlite write NULL columns;
+        // this schema deliberately makes location non-nullable, so write the
+        // worldless sentinel instead (same zero-UUID BlockLocations uses for
+        // a vanished world). Intake validation in SpyglassApiImpl rejects
+        // third-party null locations up front; this is the defense in depth.
+        writer.setValue("location_world_id",
+                location == null ? NULL_WORLD_ID : location.worldId());
+        writer.setString("location_world_name",
+                nullToEmpty(location == null ? null : location.worldName()));
+        writer.setInteger("location_x", location == null ? 0 : location.x());
+        writer.setInteger("location_y", location == null ? 0 : location.y());
+        writer.setInteger("location_z", location == null ? 0 : location.z());
         writer.setString("server", nullToEmpty(record.server()));
         writer.setValue("target", record.target());
         // Extension fields ride on every row (empty map for records that don't

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
@@ -513,6 +515,27 @@ class ClickHouseRecordStoreIT {
         assertThat(deposit.afterItem().name()).isEqualTo("Storm Caller");
         assertThat(deposit.afterItem().lore()).contains("Forged in the primordial deep");
         assertThat(deposit.afterItem().enchants()).contains("protection=4");
+    }
+
+    // #230: a record with a null location must persist with the worldless
+    // sentinel instead of throwing while building the RowBinary buffer -
+    // the poison-pill that wedged the whole drain (one bad record stopped
+    // every subsequent record until restart).
+    @Test
+    void nullLocationRecordWritesWorldlessSentinelInsteadOfPoisoningTheBatch() throws Exception {
+        Instant now = Instant.now().minusSeconds(30);
+        CustomRecord poison = new CustomRecord(
+                UUID.randomUUID(), "custom", now, now.plusSeconds(3600),
+                Origin.plugin("third-party"), Source.plugin("third-party"),
+                null /* the poison */, "test", null, "global event", Map.of());
+
+        long before = store.count();
+        store.save(List.of(poison));
+        flushAsyncInserts();
+
+        assertThat(store.count())
+                .as("the null-location record persists instead of wedging the batch")
+                .isEqualTo(before + 1);
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
@@ -61,6 +61,16 @@ public final class SpyglassApiImpl implements SpyglassApi {
 
     @Override
     public void record(EventRecord record) {
+        // #230: a null location poisons storage drains downstream (ClickHouse's
+        // location columns are non-nullable; one bad record wedged production
+        // ingest for 1.5h before a restart). No built-in listener can produce
+        // one - reject third-party records at the boundary with an error that
+        // names the offender instead of failing silently at drain time.
+        if (record.location() == null) {
+            throw new IllegalArgumentException("Spyglass records are positional: event '"
+                    + record.event() + "' arrived with a null location. Use a sentinel "
+                    + "location (zero coords in a real world) for global events.");
+        }
         recorder.record(record);
     }
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
@@ -1,8 +1,15 @@
 package net.medievalrp.spyglass.plugin.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -35,6 +42,29 @@ class SpyglassApiImplTest {
         // Resolves on the read path as a CustomRecord.
         assertThat(EventCatalog.recordClassOf("apitest-voice")).isEqualTo(CustomRecord.class);
         assertThat(EventCatalog.pastTenseOf("apitest-voice")).isEqualTo("spoke");
+    }
+
+    // #230: a null location poisons storage drains downstream; the boundary
+    // must reject it loudly, naming the offending event, before it reaches
+    // the recorder.
+    @Test
+    void nullLocationRecordRejectedAtIntake() {
+        Recorder recorder = mock(Recorder.class);
+        SpyglassApiImpl api = new SpyglassApiImpl(
+                recorder, mock(RecordStore.class), Runnable::run,
+                ConcurrentHashMap.newKeySet(), null, "srv", Logger.getLogger("test"));
+
+        CustomRecord poison = new CustomRecord(
+                UUID.randomUUID(), "third-party-global", Instant.now(),
+                Instant.now().plusSeconds(3600), Origin.plugin("some-plugin"),
+                Source.plugin("some-plugin"), null /* the poison */, "srv",
+                null, null, Map.of());
+
+        assertThatThrownBy(() -> api.record(poison))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("third-party-global")
+                .hasMessageContaining("null location");
+        verifyNoInteractions(recorder);
     }
 
     @Test


### PR DESCRIPTION
Fixes #230, two of the issue's three layers (the drain-quarantine layer stays on its own issue):

- writeCommon guards a null location with the worldless sentinel (zero UUID, empty name, 0/0/0) - parity with MariaDB/SQLite which write NULLs; the CH schema is deliberately non-nullable so a sentinel is the equivalent. Same sentinel BlockLocations now uses for a vanished world (#232), so the two fixes tell one story.
- SpyglassApiImpl.record() rejects a null location at the boundary with an IllegalArgumentException naming the offending event, so a third-party plugin fails at call time with a clear message instead of silently wedging the drain 1.5h later.

Verified: unit test for the intake rejection (recorder never touched); ClickHouseRecordStoreIT case for the sentinel write (runs under testcontainers in CI); plus a live probe against a real ClickHouse here - the poison record persists as custom | 00000000-0000-0000-0000-000000000000 | 0,0,0 with count intact.