### PR TITLE
fix(commands): tab-complete the /sg migrate backend argument

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -255,7 +255,8 @@ public final class SpyglassCommands {
             // Validation (unknown/active/unconfigured target) happens inside
             // MigrateService, which messages the sender for every outcome.
             manager.command(manager.commandBuilder(root).literal("migrate")
-                    .required("backend", StringParser.stringParser())
+                    .required("backend", StringParser.stringParser(),
+                            suggestions.migrateBackendProvider())
                     .flag(manager.flagBuilder("confirm").build())
                     .permission("spyglass.migrate")
                     .handler(ctx -> migrate.migrate(ctx.sender(),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -46,6 +46,13 @@ public final class SpyglassSuggestions {
                 .map(Suggestion::suggestion).toList();
     }
 
+    /** Tab-completes storage backend tokens for {@code /spyglass migrate <backend>} (#258). */
+    public BlockingSuggestionProvider<CommandSender> migrateBackendProvider() {
+        return (ctx, input) -> java.util.stream.Stream
+                .of("sqlite", "mongo", "clickhouse", "mariadb", "mysql")
+                .map(Suggestion::suggestion).toList();
+    }
+
     public ParserDescriptor<CommandSender, String> paramsParser() {
         return StringParser.greedyStringParser();
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
@@ -178,4 +178,17 @@ class SpyglassSuggestionsTest {
             return true;
         }
     }
+
+    // #258: /sg migrate <backend> completes the storage tokens like every
+    // other completed argument.
+    @Test
+    void migrateBackendProviderSuggestsAllTokens() throws Exception {
+        SpyglassSuggestions suggestions = new SpyglassSuggestions(
+                mock(SpyglassApi.class), new ImportConfig(Map.of()), Path.of("import"));
+        var out = new java.util.ArrayList<String>();
+        suggestions.migrateBackendProvider().suggestions(null, null)
+                .forEach(s -> out.add(s.suggestion()));
+        assertThat(out)
+                .containsExactlyInAnyOrder("sqlite", "mongo", "clickhouse", "mariadb", "mysql");
+    }
 }


### PR DESCRIPTION
Fixes #258. migrateBackendProvider suggests sqlite/mongo/clickhouse/mariadb/mysql, mirroring the import providers; the active backend stays listed (picking it hits the clear already-active refusal). Test asserts the token set.