### PR TITLE
fix(help): red clickable page nav matching search results

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -45,9 +45,21 @@ public final class HelpService {
     public void send(CommandSender sender, int page) {
         int pages = (ENTRIES.length + PAGE_SIZE - 1) / PAGE_SIZE;
         int clamped = Math.min(Math.max(page, 1), pages);
-        sender.sendMessage(Component.text(
-                " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
-                NamedTextColor.AQUA));
+        // Same red clickable nav controls the search-result header uses
+        // (#260), clicking through /spyglass help <n>.
+        net.kyori.adventure.text.TextComponent.Builder header = Component.text()
+                .append(Component.text(
+                        " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
+                        NamedTextColor.AQUA));
+        if (clamped > 1) {
+            header.append(Component.text(" ", NamedTextColor.WHITE))
+                    .append(navButton("←", clamped - 1));
+        }
+        if (clamped < pages) {
+            header.append(Component.text(" ", NamedTextColor.WHITE))
+                    .append(navButton("→", clamped + 1));
+        }
+        sender.sendMessage(header.asComponent());
         sender.sendMessage(Component.text("For Powerful Searching", NamedTextColor.DARK_GRAY)
                 .decoration(TextDecoration.ITALIC, true));
         int from = (clamped - 1) * PAGE_SIZE;
@@ -63,11 +75,19 @@ public final class HelpService {
                     .asComponent();
             sender.sendMessage(line);
         }
-        if (pages > 1) {
-            sender.sendMessage(Component.text(
-                            "/spyglass help " + (clamped % pages + 1) + " for the next page",
-                            NamedTextColor.DARK_GRAY)
-                    .decoration(TextDecoration.ITALIC, true));
-        }
+    }
+
+    /** Mirrors ResultRenderer.navButton, targeting /spyglass help instead. */
+    private static Component navButton(String arrow, int targetPage) {
+        Component label = Component.text()
+                .append(Component.text("[", NamedTextColor.RED))
+                .append(Component.text(arrow, NamedTextColor.RED))
+                .append(Component.text("]", NamedTextColor.RED))
+                .asComponent();
+        return label
+                .clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand(
+                        "/spyglass help " + targetPage))
+                .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(
+                        Component.text("Page " + targetPage, NamedTextColor.RED)));
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
@@ -63,15 +63,17 @@ class HelpServiceTest {
 
         new HelpService().send(sender, 1);
         List<String> pageOne = ServiceTestSupport.plainTexts(captured);
-        assertThat(pageOne.get(0)).contains("(1/2)");
-        // header + tagline + 8 entries + next-page hint
-        assertThat(pageOne).hasSize(11);
-        assertThat(pageOne.get(pageOne.size() - 1)).contains("help 2");
+        // Header carries the red clickable next-page arrow (#260), same
+        // control as the search-result header.
+        assertThat(pageOne.get(0)).contains("(1/2)").contains("[→]").doesNotContain("[←]");
+        // header + tagline + 8 entries
+        assertThat(pageOne).hasSize(10);
 
         captured.clear();
         new HelpService().send(sender, 99);
         List<String> clamped = ServiceTestSupport.plainTexts(captured);
-        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page").contains("(2/2)");
+        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page")
+                .contains("(2/2)").contains("[←]").doesNotContain("[→]");
 
         captured.clear();
         new HelpService().send(sender, -5);


### PR DESCRIPTION
Fixes #260. The help header now carries the same red [<-]/[->] controls as the search-result header (hover Page N, click runs /spyglass help <n>); the gray text hint is gone. Tests assert arrow presence per page edge.