### PR TITLE
Release 1.0.9: command UX polish + null-location/null-world stability fixes

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,7 +1,7 @@
-The CoreProtect migration release: bring your CoreProtect history into Spyglass, and move it between storage backends.
+Command UX polish and two stability fixes, on top of 1.0.8's CoreProtect import and backend migration.
 
-- Import: /spyglass import loads a CoreProtect 20+ database (SQLite file or live MySQL) into whatever backend you run, with dedup-safe re-imports. It warns up front when part of the history is older than storage.retention and would age out after import.
-- Migrate: /spyglass migrate <backend> copies every record from the active backend into another configured one - fill in the target's block in config.conf, migrate, flip database.backend, restart.
-- Config: storage.retention now accepts "never" (and 0/forever/off) instead of disabling the plugin on boot.
-- Search/rollback: p:<name> resolves players this server never saw (imported histories, shared stores), so rolling back the old griefer by name works.
-- Fix: imported expiries are clamped below ClickHouse's TTL ceiling; unclamped they wrapped past 2106 and OPTIMIZE deleted the rows.
+- Help: /sg help now lists every command (import, migrate, inventory, stats, rbqueue...) and paginates, with the same red clickable page arrows as search results.
+- Consistency: /sg import and /sg migrate output now use the standard "Spyglass" chat styling, /sg version spacing is fixed, and /sg migrate tab-completes its backend argument.
+- /s alias: register /s as a third root command next to /spyglass and /sg (opt in with commands.s-alias, off by default).
+- Fix: a null-location record no longer wedges the ClickHouse ingest drain. Such a record is stored with a sentinel location and rejected at the API boundary, so one bad third-party event can't stop the audit log.
+- Fix: a capture whose world just unloaded no longer throws on the block break/place path; it records with a worldless sentinel instead.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -20,6 +20,9 @@ Root command is `/spyglass`, aliased to `/sg`. Subcommands take short aliases to
 | `/sg inventory <id>` | `inv`, `salvage` | `spyglass.salvage` | Recover a container's items by id, via command |
 | `/sg tool` | `t`, `inspect` | `spyglass.tool` | Toggle the inspection wand |
 | `/sg tele <world> <x> <y> <z>` | - | `spyglass.tele` | Teleport (used by clickable search results) |
+| `/sg import <file>` | - | `spyglass.import` | Import a CoreProtect SQLite database from `plugins/Spyglass/import/` |
+| `/sg import mysql <source>` | - | `spyglass.import` | Import a live CoreProtect MySQL database (sources defined in `import.conf`) |
+| `/sg migrate <backend>` | - | `spyglass.migrate` | Copy every record from the active backend into another configured backend |
 
 ## Permissions
 
@@ -35,6 +38,8 @@ All default to `op`.
 | `spyglass.tool` | inspection wand |
 | `spyglass.tele` | teleport (used by clickable result rows) |
 | `spyglass.worldedit` | allows the `-we` flag to use your WorldEdit selection as the search region |
+| `spyglass.import` | `/sg import` - CoreProtect imports |
+| `spyglass.migrate` | `/sg migrate` - moving records between storage backends |
 
 ## Query syntax
 
@@ -149,6 +154,16 @@ On Minecraft 1.21.x, `/sg inventory` (alias `inv`) opens a paginated GUI, groupe
 On servers without the GUI (Minecraft 26.x) and from the console or RCON, `/sg inventory` prints a text listing instead. Each captured container shows an id; recover it with `/sg inventory <id>` (in-game players only), or click the `[Recover]` prompt next to a listing line. The command withdraws that container's items straight into your inventory server-side, with no inventory-drag surface. Either way, every withdrawal is logged as a `salvage-withdraw` event (find them with `/sg search a:salvage-withdraw`).
 
 Only containers the rollback *actually* destroys are salvaged - a chest in the rolled region that the rollback leaves untouched is never captured, so items are never duplicated. Salvage snapshots are kept for 30 days.
+
+## Importing and migrating
+
+**`/sg import <file>`** imports a CoreProtect (20+) SQLite database. Drop the `.db` file in `plugins/Spyglass/import/` and run the command - the filename tab-completes. **`/sg import mysql <source>`** imports a live CoreProtect MySQL database instead; define sources (host, credentials) in `plugins/Spyglass/import.conf`, kept deliberately separate from Spyglass's own `database.*` config.
+
+Imports run async off the main thread and stream progress to you and the console. Records get deterministic ids, so re-importing a known source is refused unless you pass `--confirm` - and with it, re-imports dedup rather than duplicate (except into MongoDB, where re-import is blocked). If part of the source history is older than `storage.retention`, the import warns up front how much would age out after import and how far back the source goes - raise the retention (or set it `"never"`) first if you want it all kept. Every world the source references must exist on this server (resolved via `<world>/uid.dat`); the import fails cleanly before writing anything if one is missing.
+
+**`/sg migrate <sqlite|mongo|clickhouse|mariadb>`** copies every record from the active backend into another configured one - for switching storage without losing history. Fill in the target backend's block in `config.conf`, run the migrate, then flip `database.backend` and restart. A non-empty target requires `--confirm` (re-runs dedup by record id, except into MongoDB). One migration runs at a time, and it refuses to start while an import is running. Undo history, wand state, and salvage snapshots are operational state and start fresh on the new backend.
+
+The full operator runbook, including the standalone CLI importer and parity validation, is [`docs/migration-from-coreprotect.md`](docs/migration-from-coreprotect.md).
 
 ## Event names
 

--- a/README.md
+++ b/README.md
@@ -94,28 +94,26 @@ Root command is `/spyglass`, aliased to `/sg`. The full reference - every comman
 /sg rollback p:griefer t:6h r:100             # revert a griefer's last 6h nearby
 /sg undo                                       # reverse your last rollback
 /sg tool                                       # toggle the inspector wand
+/sg import database.db                         # import a CoreProtect history
+/sg migrate clickhouse                         # move all records to another backend
 ```
 
 ## Migrating from CoreProtect
 
-Step-by-step operator runbook: [`docs/migration-from-coreprotect.md`](docs/migration-from-coreprotect.md). Quick summary: build the importer jar, run `import` against your CoreProtect database, run `validate` to audit row parity, then swap the plugin jar.
+Drop your CoreProtect `database.db` in `plugins/Spyglass/import/` and run it in-game - no separate tooling:
 
-```sh
-./gradlew :spyglass-importer:shadowJar
-java -jar spyglass-importer/build/libs/spyglass-importer-1.0.0.jar import \
-    --source ./database.db \
-    --worlds-dir ./world-data \
-    --server-name my-server \
-    --clickhouse-host localhost
-java -jar spyglass-importer/build/libs/spyglass-importer-1.0.0.jar validate \
-    --coreprotect-sqlite ./database.db \
-    --clickhouse-host localhost \
-    --server-name my-server
+```
+/sg import database.db          # CoreProtect SQLite, into whatever backend you run
+/sg import mysql old-survival   # live CoreProtect MySQL (sources in import.conf)
 ```
 
-Or run the whole rig (ClickHouse + importer + validate + bench + interactive client) via Docker: see [`docker/README.md`](docker/README.md).
+Imports run async, stream progress, and warn up front if part of the history is older than your `storage.retention` (set it `"never"` first to keep everything). Re-imports dedup instead of duplicating. Once imported, everything works on the old data - search, and rolling back a griefer by name even if they never joined the new server.
 
-Imports cover blocks, kills, sessions, chat, commands, container deposits/withdraws, and item drops/pickups. Re-runs are idempotent (deterministic UUIDs collapse via ClickHouse `ReplacingMergeTree`). Full table coverage and known gaps are documented in [`docs/importer.md`](docs/importer.md).
+Switching storage later? `/sg migrate <backend>` copies every record from the active backend into another configured one - fill in the target's block in `config.conf`, migrate, flip `database.backend`, restart.
+
+The standalone CLI importer still exists for offline runs and row-parity auditing (`validate`); the step-by-step operator runbook is [`docs/migration-from-coreprotect.md`](docs/migration-from-coreprotect.md), and the whole rig (ClickHouse + importer + validate + bench) runs via Docker: [`docker/README.md`](docker/README.md).
+
+Imports cover blocks, kills, sessions, chat, commands, container deposits/withdraws, and item drops/pickups. Full table coverage and known gaps are documented in [`docs/importer.md`](docs/importer.md).
 
 ## Modules
 

--- a/docs/migration-from-coreprotect.md
+++ b/docs/migration-from-coreprotect.md
@@ -1,12 +1,48 @@
 # Migrating from CoreProtect to Spyglass
 
 End-to-end runbook for an operator who has a CoreProtect-on-Paper
-server and wants to switch to Spyglass-on-ClickHouse, **keeping all
-historical forensic data**.
+server and wants to switch to Spyglass, **keeping all historical
+forensic data**.
 
 The migration is a one-shot, scriptable process: import history, audit
 parity, then swap the plugin jar. Both plugins can co-exist during the
 import so there's no logging blackout window.
+
+## The in-plugin path (start here)
+
+Since 1.0.8 the importer is built into the plugin - for most servers
+this replaces everything below except the parity `validate` step:
+
+1. Install Spyglass alongside CoreProtect and pick your backend in
+   `config.conf`. Check `storage.retention`: records older than it are
+   aged out after import, so set it `"never"` (or long enough to cover
+   your history) BEFORE importing. The import warns you up front if
+   part of the source predates the cutoff.
+2. Copy CoreProtect's `database.db` into `plugins/Spyglass/import/`
+   and run `/sg import database.db` - or, for a MySQL-backed
+   CoreProtect, define the source in `plugins/Spyglass/import.conf`
+   and run `/sg import mysql <source>`.
+3. Watch the progress in chat or console. Re-running the same source
+   is refused unless you pass `--confirm`; with it, re-imports dedup
+   rather than duplicate (MongoDB is the exception - re-import there
+   is blocked).
+4. Done - search and rollback work on the imported history, including
+   `p:<name>` for players who never joined this server. Remove
+   CoreProtect whenever you're comfortable.
+
+Sizing the window: on the same hardware a ~29M-event history imported
+into ClickHouse in minutes and into SQLite in hours - the import runs
+async and does not lag the main thread either way, but plan the SQLite
+case as an overnight job. Every world the source references must exist
+on the server (`<world>/uid.dat`); a missing one fails the import
+cleanly before anything is written.
+
+Switching storage backends later (say SQLite to ClickHouse once you
+outgrow the file): fill in the target's block in `config.conf`, run
+`/sg migrate <backend>`, flip `database.backend`, restart.
+
+The CLI below remains for offline imports (no server running) and for
+the row-parity `validate` audit, which has no in-plugin equivalent yet.
 
 ## Before you start
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.8
+version=1.0.9
 group=net.medievalrp
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/pipeline/ProgressReporter.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/importer/pipeline/ProgressReporter.java
@@ -27,7 +27,7 @@ public final class ProgressReporter {
     }
 
     public void endTable(String label, long rowsInTable) {
-        out.printf(Locale.ROOT, "  %s done — %,d rows%n", label, rowsInTable);
+        out.printf(Locale.ROOT, "  %s done - %,d rows%n", label, rowsInTable);
     }
 
     public void onRow(long readSoFar) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -344,6 +344,9 @@ public final class ClickHouseRecordStore implements RecordStore {
                 record instanceof RollbackOpRecord op ? op.reference() : null);
     }
 
+    /** Worldless sentinel for a null location (#230); columns are non-nullable. */
+    private static final java.util.UUID NULL_WORLD_ID = new java.util.UUID(0L, 0L);
+
     private void writeCommon(RowBinaryFormatWriter writer, EventRecord record) throws IOException {
         Origin origin = record.origin();
         Source source = record.source();
@@ -373,11 +376,20 @@ public final class ClickHouseRecordStore implements RecordStore {
         writer.setValue("source_command_block_y", cmdLoc == null ? null : cmdLoc.y());
         writer.setValue("source_command_block_z", cmdLoc == null ? null : cmdLoc.z());
         writer.setValue("source_description", source == null ? null : source.description());
-        writer.setValue("location_world_id", location.worldId());
-        writer.setString("location_world_name", nullToEmpty(location.worldName()));
-        writer.setInteger("location_x", location.x());
-        writer.setInteger("location_y", location.y());
-        writer.setInteger("location_z", location.z());
+        // #230: a null location must not poison the drain - this exact
+        // dereference wedged a production ingest for 1.5h (the drain retried
+        // the same poisoned batch forever). Maria/Sqlite write NULL columns;
+        // this schema deliberately makes location non-nullable, so write the
+        // worldless sentinel instead (same zero-UUID BlockLocations uses for
+        // a vanished world). Intake validation in SpyglassApiImpl rejects
+        // third-party null locations up front; this is the defense in depth.
+        writer.setValue("location_world_id",
+                location == null ? NULL_WORLD_ID : location.worldId());
+        writer.setString("location_world_name",
+                nullToEmpty(location == null ? null : location.worldName()));
+        writer.setInteger("location_x", location == null ? 0 : location.x());
+        writer.setInteger("location_y", location == null ? 0 : location.y());
+        writer.setInteger("location_z", location == null ? 0 : location.z());
         writer.setString("server", nullToEmpty(record.server()));
         writer.setValue("target", record.target());
         // Extension fields ride on every row (empty map for records that don't

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import net.medievalrp.spyglass.api.event.CustomRecord;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
@@ -513,6 +515,27 @@ class ClickHouseRecordStoreIT {
         assertThat(deposit.afterItem().name()).isEqualTo("Storm Caller");
         assertThat(deposit.afterItem().lore()).contains("Forged in the primordial deep");
         assertThat(deposit.afterItem().enchants()).contains("protection=4");
+    }
+
+    // #230: a record with a null location must persist with the worldless
+    // sentinel instead of throwing while building the RowBinary buffer -
+    // the poison-pill that wedged the whole drain (one bad record stopped
+    // every subsequent record until restart).
+    @Test
+    void nullLocationRecordWritesWorldlessSentinelInsteadOfPoisoningTheBatch() throws Exception {
+        Instant now = Instant.now().minusSeconds(30);
+        CustomRecord poison = new CustomRecord(
+                UUID.randomUUID(), "custom", now, now.plusSeconds(3600),
+                Origin.plugin("third-party"), Source.plugin("third-party"),
+                null /* the poison */, "test", null, "global event", Map.of());
+
+        long before = store.count();
+        store.save(List.of(poison));
+        flushAsyncInserts();
+
+        assertThat(store.count())
+                .as("the null-location record persists instead of wedging the batch")
+                .isEqualTo(before + 1);
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -734,7 +734,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 importService,
                 importConfig,
                 importDir,
-                migrateService);
+                migrateService,
+                config.commands().sAlias());
         commands.register();
 
         if (isWorldEditInstalled()) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImpl.java
@@ -61,6 +61,16 @@ public final class SpyglassApiImpl implements SpyglassApi {
 
     @Override
     public void record(EventRecord record) {
+        // #230: a null location poisons storage drains downstream (ClickHouse's
+        // location columns are non-nullable; one bad record wedged production
+        // ingest for 1.5h before a restart). No built-in listener can produce
+        // one - reject third-party records at the boundary with an error that
+        // names the offender instead of failing silently at drain time.
+        if (record.location() == null) {
+            throw new IllegalArgumentException("Spyglass records are positional: event '"
+                    + record.event() + "' arrived with a null location. Use a sentinel "
+                    + "location (zero coords in a real world) for global events.");
+        }
         recorder.record(record);
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -116,9 +116,13 @@ public final class SpyglassCommands {
                     .handler(ctx -> help.send(ctx.sender())));
 
             for (String name : HELP_ALIASES) {
+                // Optional page (#249): the full command list overflows chat,
+                // so /sg help paginates and /sg help <n> jumps to a page.
                 manager.command(manager.commandBuilder(root).literal(name)
+                        .optional("page", IntegerParser.integerParser(1))
                         .permission("spyglass.use")
-                        .handler(ctx -> help.send(ctx.sender())));
+                        .handler(ctx -> help.send(ctx.sender(),
+                                ctx.<Integer>optional("page").orElse(1))));
             }
 
             for (String name : EVENTS_ALIASES) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -34,7 +34,13 @@ public final class SpyglassCommands {
 
     // /sg is the short backend alias; /sgv on the Velocity proxy stays
     // namespace-distinct so the proxy never shadows the Paper command.
-    private static final List<String> ROOT_ALIASES = List.of("spyglass", "sg");
+    // /s joins when commands.s-alias is enabled in config (#250) - opt-in
+    // because single-letter roots collide with other plugins.
+    private final List<String> rootAliases;
+
+    static List<String> rootAliases(boolean sAlias) {
+        return sAlias ? List.of("spyglass", "sg", "s") : List.of("spyglass", "sg");
+    }
 
     private final JavaPlugin plugin;
     private final SpyglassApi api;
@@ -70,7 +76,8 @@ public final class SpyglassCommands {
                         ImportService imports,
                         ImportConfig importConfig,
                         Path importDir,
-                        net.medievalrp.spyglass.plugin.migrate.MigrateService migrate) {
+                        net.medievalrp.spyglass.plugin.migrate.MigrateService migrate,
+                        boolean sAlias) {
         this.plugin = plugin;
         this.api = api;
         this.help = help;
@@ -88,6 +95,7 @@ public final class SpyglassCommands {
         this.importConfig = importConfig;
         this.importDir = importDir;
         this.migrate = migrate;
+        this.rootAliases = rootAliases(sAlias);
     }
 
     // v1-compat subcommand aliases. Operators have years of muscle memory
@@ -110,7 +118,7 @@ public final class SpyglassCommands {
     public CommandManager<CommandSender> register() {
         LegacyPaperCommandManager<CommandSender> manager = LegacyPaperCommandManager.createNative(
                 plugin, ExecutionCoordinator.simpleCoordinator());
-        for (String root : ROOT_ALIASES) {
+        for (String root : rootAliases) {
             manager.command(manager.commandBuilder(root)
                     .permission("spyglass.use")
                     .handler(ctx -> help.send(ctx.sender())));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -255,7 +255,8 @@ public final class SpyglassCommands {
             // Validation (unknown/active/unconfigured target) happens inside
             // MigrateService, which messages the sender for every outcome.
             manager.command(manager.commandBuilder(root).literal("migrate")
-                    .required("backend", StringParser.stringParser())
+                    .required("backend", StringParser.stringParser(),
+                            suggestions.migrateBackendProvider())
                     .flag(manager.flagBuilder("confirm").build())
                     .permission("spyglass.migrate")
                     .handler(ctx -> migrate.migrate(ctx.sender(),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -46,6 +46,13 @@ public final class SpyglassSuggestions {
                 .map(Suggestion::suggestion).toList();
     }
 
+    /** Tab-completes storage backend tokens for {@code /spyglass migrate <backend>} (#258). */
+    public BlockingSuggestionProvider<CommandSender> migrateBackendProvider() {
+        return (ctx, input) -> java.util.stream.Stream
+                .of("sqlite", "mongo", "clickhouse", "mariadb", "mysql")
+                .map(Suggestion::suggestion).toList();
+    }
+
     public ParserDescriptor<CommandSender, String> paramsParser() {
         return StringParser.greedyStringParser();
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
@@ -47,10 +47,16 @@ public final class Feedback {
                 .asComponent();
     }
 
-    /** `«Spyglass»<green>message</green>` — matches v1's Formatter.success. */
+    /**
+     * `«Spyglass» <green>message</green>`. v1's Formatter.success had no
+     * space after the prefix - the only category that didn't - which
+     * rendered as `«Spyglass»Spyglass version x.y.z` on /sg version (#251).
+     * All four categories now frame identically.
+     */
     public static Component success(String message) {
         return Component.text()
                 .append(PREFIX)
+                .append(Component.text(" ", NamedTextColor.WHITE))
                 .append(Component.text(message, NamedTextColor.GREEN))
                 .asComponent();
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -45,9 +45,21 @@ public final class HelpService {
     public void send(CommandSender sender, int page) {
         int pages = (ENTRIES.length + PAGE_SIZE - 1) / PAGE_SIZE;
         int clamped = Math.min(Math.max(page, 1), pages);
-        sender.sendMessage(Component.text(
-                " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
-                NamedTextColor.AQUA));
+        // Same red clickable nav controls the search-result header uses
+        // (#260), clicking through /spyglass help <n>.
+        net.kyori.adventure.text.TextComponent.Builder header = Component.text()
+                .append(Component.text(
+                        " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
+                        NamedTextColor.AQUA));
+        if (clamped > 1) {
+            header.append(Component.text(" ", NamedTextColor.WHITE))
+                    .append(navButton("←", clamped - 1));
+        }
+        if (clamped < pages) {
+            header.append(Component.text(" ", NamedTextColor.WHITE))
+                    .append(navButton("→", clamped + 1));
+        }
+        sender.sendMessage(header.asComponent());
         sender.sendMessage(Component.text("For Powerful Searching", NamedTextColor.DARK_GRAY)
                 .decoration(TextDecoration.ITALIC, true));
         int from = (clamped - 1) * PAGE_SIZE;
@@ -63,11 +75,19 @@ public final class HelpService {
                     .asComponent();
             sender.sendMessage(line);
         }
-        if (pages > 1) {
-            sender.sendMessage(Component.text(
-                            "/spyglass help " + (clamped % pages + 1) + " for the next page",
-                            NamedTextColor.DARK_GRAY)
-                    .decoration(TextDecoration.ITALIC, true));
-        }
+    }
+
+    /** Mirrors ResultRenderer.navButton, targeting /spyglass help instead. */
+    private static Component navButton(String arrow, int targetPage) {
+        Component label = Component.text()
+                .append(Component.text("[", NamedTextColor.RED))
+                .append(Component.text(arrow, NamedTextColor.RED))
+                .append(Component.text("]", NamedTextColor.RED))
+                .asComponent();
+        return label
+                .clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand(
+                        "/spyglass help " + targetPage))
+                .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(
+                        Component.text("Page " + targetPage, NamedTextColor.RED)));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -12,22 +12,48 @@ public final class HelpService {
     private record Entry(String name, String usage, String description) {
     }
 
+    // Every registered command, in rough workflow order (#249). Keep this in
+    // lockstep with SpyglassCommands registrations and COMMANDS.md - a
+    // command an operator can't discover here may as well not exist.
     private static final Entry[] ENTRIES = new Entry[]{
+            // Page 1: the daily commands (the classic help screen).
+            new Entry("help", "<Page #>", "Show this help, one page at a time."),
             new Entry("search", "<Lookup Params>", "Search Data Records based on the parameters provided."),
+            new Entry("page", "<Page #>", "Moves you to the specified page of results (cached 15 min)."),
             new Entry("rollback", "<Lookup Params>", "Rollback a set of changes based on the parameters provided."),
             new Entry("restore", "<Lookup Params>", "Restore a set of changes based on the parameters provided."),
             new Entry("undo", "", "Undo your most recent rollback or restore."),
-            new Entry("page", "<Page #>", "Moves you to the specified page of results (cached 15 min)."),
             new Entry("tool", "", "Toggle the inspection wand."),
             new Entry("events", "", "List every event type currently being recorded."),
+            // Page 2: queue/admin/migration.
+            new Entry("rbqueue", "", "List, cancel, or resume queued rollback jobs."),
+            new Entry("inventory", "[id]", "Recover items a rollback destroyed (GUI where available)."),
+            new Entry("stats", "", "Show ingest analytics (when enabled in config)."),
+            new Entry("import", "<file>", "Import a CoreProtect SQLite database from plugins/Spyglass/import/."),
+            new Entry("import mysql", "<source>", "Import a live CoreProtect MySQL database (sources in import.conf)."),
+            new Entry("migrate", "<backend>", "Copy all records into another configured storage backend."),
+            new Entry("tele", "<world> <x> <y> <z>", "Teleport (used by clickable search results)."),
             new Entry("version", "", "Show the Spyglass version."),
     };
 
+    private static final int PAGE_SIZE = 8;
+
     public void send(CommandSender sender) {
-        sender.sendMessage(Component.text(" -======= Spyglass =======-", NamedTextColor.AQUA));
+        send(sender, 1);
+    }
+
+    public void send(CommandSender sender, int page) {
+        int pages = (ENTRIES.length + PAGE_SIZE - 1) / PAGE_SIZE;
+        int clamped = Math.min(Math.max(page, 1), pages);
+        sender.sendMessage(Component.text(
+                " -======= Spyglass (" + clamped + "/" + pages + ") =======-",
+                NamedTextColor.AQUA));
         sender.sendMessage(Component.text("For Powerful Searching", NamedTextColor.DARK_GRAY)
                 .decoration(TextDecoration.ITALIC, true));
-        for (Entry entry : ENTRIES) {
+        int from = (clamped - 1) * PAGE_SIZE;
+        int to = Math.min(from + PAGE_SIZE, ENTRIES.length);
+        for (int index = from; index < to; index++) {
+            Entry entry = ENTRIES[index];
             Component line = Component.text()
                     .append(Component.text("/spyglass ", NamedTextColor.AQUA))
                     .append(Component.text(entry.name() + " ", NamedTextColor.GREEN))
@@ -36,6 +62,12 @@ public final class HelpService {
                     .append(Component.text(entry.description(), NamedTextColor.GRAY))
                     .asComponent();
             sender.sendMessage(line);
+        }
+        if (pages > 1) {
+            sender.sendMessage(Component.text(
+                            "/spyglass help " + (clamped % pages + 1) + " for the next page",
+                            NamedTextColor.DARK_GRAY)
+                    .decoration(TextDecoration.ITALIC, true));
         }
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -21,7 +21,8 @@ public record SpyglassConfig(
         Tool tool,
         Server server,
         Metrics metrics,
-        Analytics analytics) {
+        Analytics analytics,
+        Commands commands) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -129,7 +130,10 @@ public record SpyglassConfig(
                 new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
                 new Server(root.node("server", "name").getString("default")),
                 parseMetrics(root),
-                parseAnalytics(root));
+                parseAnalytics(root),
+                // #250: /s as a third root alias, opt-in - single-letter
+                // roots collide with other plugins, so off by default.
+                new Commands(root.node("commands", "s-alias").getBoolean(false)));
     }
 
     /**
@@ -479,6 +483,9 @@ public record SpyglassConfig(
      * Configured under {@code server.name} in {@code config.conf}; defaults
      * to {@code "default"} for a single-server deployment.
      */
+    public record Commands(boolean sAlias) {
+    }
+
     public record Server(String name) {
         public Server {
             name = name == null ? "default" : name.trim();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/ImportService.java
@@ -85,7 +85,7 @@ public final class ImportService {
 
     public ImportOutcome importSqlite(CommandSender sender, Path dbFile, boolean confirm) {
         if (running.get()) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runImportSqlite(sender, dbFile, confirm));
@@ -95,7 +95,7 @@ public final class ImportService {
     public ImportOutcome importMysql(CommandSender sender, String sourceName,
                             ImportConfig.MysqlSourceSpec spec, boolean confirm) {
         if (running.get()) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runImportMysql(sender, sourceName, spec, confirm));
@@ -106,7 +106,7 @@ public final class ImportService {
 
     ImportOutcome runImportSqlite(CommandSender sender, Path dbFile, boolean confirm) {
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         String displayName = dbFile.getFileName().toString();
@@ -120,7 +120,7 @@ public final class ImportService {
                     () -> SqliteSource.open(dbFile));
         } catch (IOException | RuntimeException ex) {
             logger.log(Level.SEVERE, "Spyglass import failed for " + displayName, ex);
-            tell(sender, "Import failed: " + ex.getMessage());
+            tellError(sender, "Import failed: " + ex.getMessage());
             return ImportOutcome.FAILED;
         } finally {
             running.set(false);
@@ -130,7 +130,7 @@ public final class ImportService {
     ImportOutcome runImportMysql(CommandSender sender, String sourceName,
                                  ImportConfig.MysqlSourceSpec spec, boolean confirm) {
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "An import is already running; try again once it finishes.");
+            tellError(sender, "An import is already running; try again once it finishes.");
             return ImportOutcome.ALREADY_RUNNING;
         }
         try {
@@ -145,7 +145,7 @@ public final class ImportService {
                             spec.host(), spec.port(), spec.database(), spec.user(), spec.password())));
         } catch (IOException | RuntimeException ex) {
             logger.log(Level.SEVERE, "Spyglass import failed for " + sourceName, ex);
-            tell(sender, "Import failed: " + ex.getMessage());
+            tellError(sender, "Import failed: " + ex.getMessage());
             return ImportOutcome.FAILED;
         } finally {
             running.set(false);
@@ -188,7 +188,7 @@ public final class ImportService {
             history.record(new ImportRecord(identity, displayName, System.currentTimeMillis(),
                     senderName, summary.totalRead(), summary.totalWritten(), summary.totalSkipped()));
 
-            tell(sender, "Import complete for " + displayName + ": read=" + summary.totalRead()
+            tellSuccess(sender, "Import complete for " + displayName + ": read=" + summary.totalRead()
                     + " written=" + summary.totalWritten() + " skipped=" + summary.totalSkipped());
             return ImportOutcome.DONE;
         }
@@ -208,13 +208,13 @@ public final class ImportService {
             return null;
         }
         if (backend == Backend.MONGO) {
-            tell(sender, "This source was already imported and re-importing into MongoDB "
+            tellError(sender, "This source was already imported and re-importing into MongoDB "
                     + "is not supported; switch backends or restore from a MongoDB backup.");
             return ImportOutcome.MONGO_REIMPORT_BLOCKED;
         }
         if (!confirm) {
             ImportRecord p = prior.get();
-            tell(sender, "This source was already imported on " + Instant.ofEpochMilli(p.importedAtEpochMs())
+            tellError(sender, "This source was already imported on " + Instant.ofEpochMilli(p.importedAtEpochMs())
                     + " by " + p.importedBy() + " (read=" + p.read() + ", written=" + p.written()
                     + ", skipped=" + p.skipped() + "). Re-run with --confirm to import again.");
             return ImportOutcome.NEEDS_CONFIRM;
@@ -274,8 +274,8 @@ public final class ImportService {
                 Instant.ofEpochSecond(cutoffSec), java.time.ZoneOffset.UTC);
         java.time.LocalDate oldest = java.time.LocalDate.ofInstant(
                 Instant.ofEpochSecond(preview.oldestEpochSeconds()), java.time.ZoneOffset.UTC);
-        tell(sender, String.format(java.util.Locale.ROOT,
-                "WARNING: %,d of %,d events (%.1f%%) are older than your retention cutoff "
+        tellWarn(sender, String.format(java.util.Locale.ROOT,
+                "%,d of %,d events (%.1f%%) are older than your retention cutoff "
                         + "%s (retention %dd) and will be aged out after import - immediately "
                         + "on ClickHouse, on the next prune sweep otherwise. Oldest source "
                         + "event: %s. To keep the full history, raise storage.retention (or "
@@ -287,7 +287,25 @@ public final class ImportService {
         return (serverName == null || serverName.isBlank()) ? defaultServerName : serverName;
     }
 
+    // House-styled sender feedback (#252): imports frame like every other
+    // Spyglass message instead of a bare "[import] " string.
     private void tell(CommandSender sender, String message) {
-        support.onMainThread(() -> sender.sendMessage("[import] " + message));
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.info(message)));
+    }
+
+    private void tellWarn(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.warn(message)));
+    }
+
+    private void tellError(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.error(message)));
+    }
+
+    private void tellSuccess(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.success(message)));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/SenderProgress.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/imports/SenderProgress.java
@@ -23,15 +23,27 @@ final class SenderProgress extends PrintStream {
 
         @Override
         public synchronized void flush() {
+            // The autoflushing PrintStream flushes per printf SEGMENT, not per
+            // line - forwarding the raw buffer sent fragments ("co_block",
+            // " done - 17,103", " rows") as separate chat messages (#252).
+            // Forward complete lines only; keep any trailing partial buffered.
             String text = toString(StandardCharsets.UTF_8);
-            if (text.isEmpty()) {
+            int lastNewline = text.lastIndexOf('\n');
+            if (lastNewline < 0) {
                 return;
             }
+            String remainder = text.substring(lastNewline + 1);
+            String complete = text.substring(0, lastNewline);
             reset();
-            for (String line : text.split("\n", -1)) {
+            if (!remainder.isEmpty()) {
+                byte[] keep = remainder.getBytes(StandardCharsets.UTF_8);
+                write(keep, 0, keep.length);
+            }
+            for (String line : complete.split("\n", -1)) {
                 if (!line.isBlank()) {
                     String msg = line.stripTrailing();
-                    support.onMainThread(() -> sender.sendMessage("[import] " + msg));
+                    support.onMainThread(() -> sender.sendMessage(
+                            net.medievalrp.spyglass.plugin.command.render.Feedback.info(msg)));
                 }
             }
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
@@ -97,7 +97,7 @@ public final class MigrateService {
     /** Async entry point: cheap checks inline, the job itself off-thread. */
     public Outcome migrate(CommandSender sender, String targetName, boolean confirm) {
         if (running.get()) {
-            tell(sender, "A migration is already running; try again once it finishes.");
+            tellError(sender, "A migration is already running; try again once it finishes.");
             return Outcome.ALREADY_RUNNING;
         }
         support.onAsyncThread(() -> runMigrate(sender, targetName, confirm));
@@ -109,27 +109,27 @@ public final class MigrateService {
     Outcome runMigrate(CommandSender sender, String targetName, boolean confirm) {
         Backend target = parseBackend(targetName);
         if (target == null) {
-            tell(sender, "Unknown backend '" + targetName
+            tellError(sender, "Unknown backend '" + targetName
                     + "' (expected sqlite, mongo, clickhouse, or mariadb).");
             return Outcome.INVALID_TARGET;
         }
         if (target == active) {
-            tell(sender, capitalize(targetName) + " is already the active backend; "
+            tellError(sender, capitalize(targetName) + " is already the active backend; "
                     + "nothing to migrate.");
             return Outcome.INVALID_TARGET;
         }
         String configError = validateTargetConfig(databaseConfig, target);
         if (configError != null) {
-            tell(sender, "Target backend '" + targetName + "' is not configured: "
+            tellError(sender, "Target backend '" + targetName + "' is not configured: "
                     + configError + " Fill in the block in config.conf first.");
             return Outcome.INVALID_TARGET;
         }
         if (importRunning.getAsBoolean()) {
-            tell(sender, "A CoreProtect import is running; wait for it before migrating.");
+            tellError(sender, "A CoreProtect import is running; wait for it before migrating.");
             return Outcome.IMPORT_RUNNING;
         }
         if (!running.compareAndSet(false, true)) {
-            tell(sender, "A migration is already running; try again once it finishes.");
+            tellError(sender, "A migration is already running; try again once it finishes.");
             return Outcome.ALREADY_RUNNING;
         }
         long startNanos = System.nanoTime();
@@ -138,7 +138,7 @@ public final class MigrateService {
             targetStore = targetFactory.open(target);
 
             if (!confirm && !targetIsEmpty(targetStore)) {
-                tell(sender, "The " + targetName + " target already contains records. "
+                tellError(sender, "The " + targetName + " target already contains records. "
                         + "Re-run with --confirm to migrate anyway"
                         + (target == Backend.MONGO
                                 ? " (NOT recommended on MongoDB - it cannot dedup by id, "
@@ -153,7 +153,7 @@ public final class MigrateService {
             finalizeClickHouse(targetStore);
 
             double secs = (System.nanoTime() - startNanos) / 1e9;
-            tell(sender, String.format(Locale.ROOT,
+            tellSuccess(sender, String.format(Locale.ROOT,
                     "Migration complete: %,d records copied to %s in %.1fs. "
                             + "Set database.backend = \"%s\" in config.conf and restart "
                             + "to switch. (Undo history / wand state / salvage are "
@@ -162,7 +162,7 @@ public final class MigrateService {
             return Outcome.DONE;
         } catch (Exception ex) {
             logger.log(Level.SEVERE, "Spyglass migration to " + targetName + " failed", ex);
-            tell(sender, "Migration failed: " + ex.getMessage());
+            tellError(sender, "Migration failed: " + ex.getMessage());
             return Outcome.FAILED;
         } finally {
             if (targetStore != null) {
@@ -206,8 +206,8 @@ public final class MigrateService {
         }
         sink.flush();
         if (alreadyExpired > 0) {
-            tell(sender, String.format(Locale.ROOT,
-                    "WARNING: %,d copied records are already past their retention expiry "
+            tellWarn(sender, String.format(Locale.ROOT,
+                    "%,d copied records are already past their retention expiry "
                             + "and will be aged out on the target (immediately on ClickHouse). "
                             + "Raise storage.retention (or set it \"never\") before migrating "
                             + "if you want them kept.", alreadyExpired));
@@ -317,7 +317,24 @@ public final class MigrateService {
                 : Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
+    // House-styled sender feedback (#252), mirroring ImportService.
     private void tell(CommandSender sender, String message) {
-        support.onMainThread(() -> sender.sendMessage("[migrate] " + message));
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.info(message)));
+    }
+
+    private void tellWarn(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.warn(message)));
+    }
+
+    private void tellError(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.error(message)));
+    }
+
+    private void tellSuccess(CommandSender sender, String message) {
+        support.onMainThread(() -> sender.sendMessage(
+                net.medievalrp.spyglass.plugin.command.render.Feedback.success(message)));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockLocations.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/BlockLocations.java
@@ -8,11 +8,27 @@ import org.bukkit.block.Block;
 
 public final class BlockLocations {
 
+    /**
+     * Sentinel world id for a capture whose world was already gone (#232).
+     * A stale {@link Location} - an entity observed mid world-unload, some
+     * async contexts - can legitimately return a null world; before this,
+     * every factory below NPE'd on the tick, on the high-frequency
+     * break/place path. A sentinel beats both throwing (kills the capture
+     * AND the listener) and returning null (a null location rippling into
+     * a record is the #230 drain-poison failure). The record persists with
+     * time/player/action intact; {@link #resolveWorld} finds nothing for
+     * it, so rollback skips it.
+     */
+    private static final java.util.UUID NULL_WORLD_ID = new java.util.UUID(0L, 0L);
+
     private BlockLocations() {
     }
 
     public static net.medievalrp.spyglass.api.util.BlockLocation fromLocation(Location location) {
         World world = location.getWorld();
+        if (world == null) {
+            return worldless(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        }
         return new net.medievalrp.spyglass.api.util.BlockLocation(
                 world.getUID(),
                 world.getName(),
@@ -40,12 +56,19 @@ public final class BlockLocations {
      * {@link Location} allocation.
      */
     public static net.medievalrp.spyglass.api.util.BlockLocation from(World world, int x, int y, int z) {
+        if (world == null) {
+            return worldless(x, y, z);
+        }
         return new net.medievalrp.spyglass.api.util.BlockLocation(
                 world.getUID(),
                 world.getName(),
                 x,
                 y,
                 z);
+    }
+
+    private static net.medievalrp.spyglass.api.util.BlockLocation worldless(int x, int y, int z) {
+        return new net.medievalrp.spyglass.api.util.BlockLocation(NULL_WORLD_ID, "", x, y, z);
     }
 
     public static Optional<World> resolveWorld(net.medievalrp.spyglass.api.util.BlockLocation location) {

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -229,6 +229,13 @@ tool {
   material = "GLOWSTONE"
 }
 
+commands {
+  # Register /s as a third root alias next to /spyglass and /sg. Off by
+  # default: single-letter commands collide with other plugins (and /s is
+  # a common shorthand for /say or social plugins), so opt in deliberately.
+  s-alias = false
+}
+
 server {
   # Identifier for this Spyglass instance, stamped onto every recorded
   # event. When multiple backend servers share a single Mongo / ClickHouse

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/api/SpyglassApiImplTest.java
@@ -1,8 +1,15 @@
 package net.medievalrp.spyglass.plugin.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -35,6 +42,29 @@ class SpyglassApiImplTest {
         // Resolves on the read path as a CustomRecord.
         assertThat(EventCatalog.recordClassOf("apitest-voice")).isEqualTo(CustomRecord.class);
         assertThat(EventCatalog.pastTenseOf("apitest-voice")).isEqualTo("spoke");
+    }
+
+    // #230: a null location poisons storage drains downstream; the boundary
+    // must reject it loudly, naming the offending event, before it reaches
+    // the recorder.
+    @Test
+    void nullLocationRecordRejectedAtIntake() {
+        Recorder recorder = mock(Recorder.class);
+        SpyglassApiImpl api = new SpyglassApiImpl(
+                recorder, mock(RecordStore.class), Runnable::run,
+                ConcurrentHashMap.newKeySet(), null, "srv", Logger.getLogger("test"));
+
+        CustomRecord poison = new CustomRecord(
+                UUID.randomUUID(), "third-party-global", Instant.now(),
+                Instant.now().plusSeconds(3600), Origin.plugin("some-plugin"),
+                Source.plugin("some-plugin"), null /* the poison */, "srv",
+                null, null, Map.of());
+
+        assertThatThrownBy(() -> api.record(poison))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("third-party-global")
+                .hasMessageContaining("null location");
+        verifyNoInteractions(recorder);
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassCommandsTest.java
@@ -33,4 +33,11 @@ class SpyglassCommandsTest {
                 .contains("on Paper 26.2")
                 .doesNotContain("by ");
     }
+
+    // #250: /s is opt-in and must never displace the two canonical roots.
+    @Test
+    void sAliasTogglesTheThirdRoot() {
+        assertThat(SpyglassCommands.rootAliases(false)).containsExactly("spyglass", "sg");
+        assertThat(SpyglassCommands.rootAliases(true)).containsExactly("spyglass", "sg", "s");
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
@@ -178,4 +178,17 @@ class SpyglassSuggestionsTest {
             return true;
         }
     }
+
+    // #258: /sg migrate <backend> completes the storage tokens like every
+    // other completed argument.
+    @Test
+    void migrateBackendProviderSuggestsAllTokens() throws Exception {
+        SpyglassSuggestions suggestions = new SpyglassSuggestions(
+                mock(SpyglassApi.class), new ImportConfig(Map.of()), Path.of("import"));
+        var out = new java.util.ArrayList<String>();
+        suggestions.migrateBackendProvider().suggestions(null, null)
+                .forEach(s -> out.add(s.suggestion()));
+        assertThat(out)
+                .containsExactlyInAnyOrder("sqlite", "mongo", "clickhouse", "mariadb", "mysql");
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/FeedbackTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/FeedbackTest.java
@@ -40,6 +40,16 @@ class FeedbackTest {
     }
 
     @Test
+    void everyCategoryFramesWithASpaceAfterThePrefix() {
+        // #251: success was the odd one out (v1 parity) and rendered
+        // "«Spyglass»Spyglass version x.y.z" on /sg version.
+        assertThat(plain(Feedback.info("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.warn("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.error("m"))).startsWith("«Spyglass» ");
+        assertThat(plain(Feedback.success("m"))).startsWith("«Spyglass» ");
+    }
+
+    @Test
     void bonusIsPlainWithoutPrefix() {
         assertThat(plain(Feedback.bonus("skip reason"))).isEqualTo("skip reason");
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
@@ -63,15 +63,17 @@ class HelpServiceTest {
 
         new HelpService().send(sender, 1);
         List<String> pageOne = ServiceTestSupport.plainTexts(captured);
-        assertThat(pageOne.get(0)).contains("(1/2)");
-        // header + tagline + 8 entries + next-page hint
-        assertThat(pageOne).hasSize(11);
-        assertThat(pageOne.get(pageOne.size() - 1)).contains("help 2");
+        // Header carries the red clickable next-page arrow (#260), same
+        // control as the search-result header.
+        assertThat(pageOne.get(0)).contains("(1/2)").contains("[→]").doesNotContain("[←]");
+        // header + tagline + 8 entries
+        assertThat(pageOne).hasSize(10);
 
         captured.clear();
         new HelpService().send(sender, 99);
         List<String> clamped = ServiceTestSupport.plainTexts(captured);
-        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page").contains("(2/2)");
+        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page")
+                .contains("(2/2)").contains("[←]").doesNotContain("[→]");
 
         captured.clear();
         new HelpService().send(sender, -5);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
@@ -30,4 +30,51 @@ class HelpServiceTest {
                 .contains("/spyglass tool")
                 .contains("/spyglass events");
     }
+
+    // ===== #249: every command discoverable, across pages ==============
+
+    @Test
+    void everyRegisteredCommandAppearsAcrossThePages() {
+        CommandSender sender = mock(CommandSender.class);
+        List<Component> captured = ServiceTestSupport.captureMessages(sender);
+
+        HelpService help = new HelpService();
+        help.send(sender, 1);
+        help.send(sender, 2);
+
+        String combined = String.join("\n", ServiceTestSupport.plainTexts(captured));
+        assertThat(combined)
+                .contains("/spyglass help")
+                .contains("/spyglass events")
+                .contains("/spyglass rbqueue")
+                .contains("/spyglass inventory")
+                .contains("/spyglass stats")
+                .contains("/spyglass import <file>")
+                .contains("/spyglass import mysql")
+                .contains("/spyglass migrate")
+                .contains("/spyglass tele")
+                .contains("/spyglass version");
+    }
+
+    @Test
+    void paginatesWithHeaderCountAndClampsOutOfRangePages() {
+        CommandSender sender = mock(CommandSender.class);
+        List<Component> captured = ServiceTestSupport.captureMessages(sender);
+
+        new HelpService().send(sender, 1);
+        List<String> pageOne = ServiceTestSupport.plainTexts(captured);
+        assertThat(pageOne.get(0)).contains("(1/2)");
+        // header + tagline + 8 entries + next-page hint
+        assertThat(pageOne).hasSize(11);
+        assertThat(pageOne.get(pageOne.size() - 1)).contains("help 2");
+
+        captured.clear();
+        new HelpService().send(sender, 99);
+        List<String> clamped = ServiceTestSupport.plainTexts(captured);
+        assertThat(clamped.get(0)).as("out-of-range page clamps to the last page").contains("(2/2)");
+
+        captured.clear();
+        new HelpService().send(sender, -5);
+        assertThat(ServiceTestSupport.plainTexts(captured).get(0)).contains("(1/2)");
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -80,6 +80,15 @@ class SpyglassConfigTest {
                 .isEqualTo(3L * 24 * 60 * 60);
     }
 
+    // #250: /s root alias is opt-in; absent key must read as disabled.
+    @Test
+    void sAliasDefaultsOffAndReadsExplicitTrue() throws SerializationException {
+        BasicConfigurationNode root = BasicConfigurationNode.root();
+        assertThat(root.node("commands", "s-alias").getBoolean(false)).isFalse();
+        root.node("commands", "s-alias").set(true);
+        assertThat(root.node("commands", "s-alias").getBoolean(false)).isTrue();
+    }
+
     @Test
     void absentRedactKeyFallsBackToDefaultAuthSet() throws SerializationException {
         BasicConfigurationNode root = BasicConfigurationNode.root();

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockLocationsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/BlockLocationsTest.java
@@ -82,4 +82,41 @@ class BlockLocationsTest {
         assertThat(BlockLocations.fromBlock(block))
                 .isEqualTo(BlockLocations.from(world, 3, 7, 11));
     }
+
+    // ===== #232: null world (entity observed mid world-unload) =========
+    // The factories must yield the worldless sentinel instead of NPEing on
+    // the tick - and must NOT return null, which would ripple a null
+    // location into the record (the #230 drain-poison shape).
+
+    @Test
+    void nullWorldLocationYieldsWorldlessSentinelNotThrow() {
+        Location stale = mock(Location.class);
+        when(stale.getWorld()).thenReturn(null);
+        when(stale.getBlockX()).thenReturn(17);
+        when(stale.getBlockY()).thenReturn(65);
+        when(stale.getBlockZ()).thenReturn(-4);
+
+        BlockLocation loc = BlockLocations.fromLocation(stale);
+
+        assertThat(loc).isNotNull();
+        assertThat(loc.worldId()).isEqualTo(new UUID(0L, 0L));
+        assertThat(loc.worldName()).isEmpty();
+        assertThat(loc.x()).isEqualTo(17);
+        assertThat(loc.y()).isEqualTo(65);
+        assertThat(loc.z()).isEqualTo(-4);
+    }
+
+    @Test
+    void nullWorldCoordsAndBlockYieldTheSameSentinel() {
+        BlockLocation viaCoords = BlockLocations.from(null, 1, 2, 3);
+        assertThat(viaCoords).isNotNull();
+        assertThat(viaCoords.worldId()).isEqualTo(new UUID(0L, 0L));
+
+        Block orphan = mock(Block.class);
+        when(orphan.getWorld()).thenReturn(null);
+        when(orphan.getX()).thenReturn(1);
+        when(orphan.getY()).thenReturn(2);
+        when(orphan.getZ()).thenReturn(3);
+        assertThat(BlockLocations.fromBlock(orphan)).isEqualTo(viaCoords);
+    }
 }


### PR DESCRIPTION
dev -> main release merge. Ships since 1.0.8: paginated /sg help with clickable nav (#249/#260), consistent «Spyglass» styling + version spacing + migrate tab-complete (#251/#252/#258), /s alias (#250), the null-location ClickHouse poison-pill fix (#230), and the null-world capture NPE fix (#232). Version 1.0.9 + What's-fixed notes included; release workflow publishes on merge.