### PR TITLE
fix(undo): tombstone unusable references instead of leaving them poppable (#266)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -132,6 +132,14 @@ The trade-off: a rollback does not skip a cell just because someone changed it a
 
 `/sg undo` reverses your most recent operation. Run it again to keep walking back, newest first. Undo references the last 24 hours.
 
+Undo's limits, spelled out:
+
+- **Per player, player only.** It walks *your* operations; console-run rollbacks never enter the ledger and console cannot invoke undo.
+- **24 hour window.** Older operations age out of the ledger (the records themselves keep `storage.retention`).
+- **No redo.** An undo cannot itself be undone; to re-apply, run `/sg restore` with the original query.
+- **It replays the query, not the world.** Undo re-runs the stored query in the opposite direction. Container items the rollback destroyed come back only via [Container salvage](#container-salvage), and a cell someone legitimately edited *after* the original window replays to its recorded state, not to that later edit.
+- An unreadable ledger entry is discarded on contact; run `/sg undo` again to reach the operation beneath it.
+
 ## Queue
 
 Rollbacks run one at a time and the rest wait in line. Manage them with `/sg rbqueue`:

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/UndoService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/UndoService.java
@@ -83,18 +83,23 @@ public final class UndoService {
         try {
             decoded = UndoReferenceBson.decodeBase64(ref.referenceBase64());
         } catch (RuntimeException ex) {
-            ref.close();
-            support.onMainThread(() -> player.sendMessage(
-                    Feedback.error("Undo reference unreadable: " + ex.getMessage())));
+            // Consume the reference: openLatest always returns the newest
+            // row, so a poison blob left in place blocks every older valid
+            // entry until the TTL ages it out (#266). Unlike a failed
+            // replay (transient, worth retrying), an unreadable blob can
+            // never succeed.
+            discardUnusable(player, ref,
+                    "Undo reference unreadable (" + ex.getMessage()
+                            + "); discarded it - run /sg undo again for the previous operation");
             return;
         }
         RollbackMode original;
         try {
             original = RollbackMode.valueOf(decoded.mode());
         } catch (IllegalArgumentException ex) {
-            ref.close();
-            support.onMainThread(() -> player.sendMessage(
-                    Feedback.error("Undo reference has unknown mode " + decoded.mode())));
+            discardUnusable(player, ref,
+                    "Undo reference has unknown mode " + decoded.mode()
+                            + "; discarded it - run /sg undo again for the previous operation");
             return;
         }
         RollbackMode inverse = original == RollbackMode.ROLLBACK
@@ -122,6 +127,21 @@ public final class UndoService {
                         ref.close();
                     }
                 })));
+    }
+
+    // A reference that can never replay (corrupt blob, unknown mode) is
+    // removed from the ledger so the next /undo reaches the operation
+    // beneath it. Tombstone failure is tolerable: the row then survives
+    // only until its TTL, which is the pre-#266 behavior.
+    private void discardUnusable(Player player, UndoStack.ReplayReference ref, String message) {
+        try {
+            ref.tombstone();
+        } catch (RuntimeException ignored) {
+            // Best effort; see above.
+        } finally {
+            ref.close();
+        }
+        support.onMainThread(() -> player.sendMessage(Feedback.error(message)));
     }
 
     // Pre-reference operation: stream the stored inverse effects chunk

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/UndoServiceCorruptReferenceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/UndoServiceCorruptReferenceTest.java
@@ -1,0 +1,140 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.rollback.RollbackEngine;
+import net.medievalrp.spyglass.plugin.rollback.SqliteUndoStack;
+import net.medievalrp.spyglass.plugin.rollback.UndoStack;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import net.medievalrp.spyglass.plugin.storage.UndoReferenceBson;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Regression tests for #266: a reference that can never replay (corrupt
+ * blob, unknown mode) must be tombstoned, not merely closed. Before the
+ * fix the poison row stayed newest in the ledger and every subsequent
+ * /undo re-popped it, soft-locking the player's whole undo history for
+ * the 24h TTL. Runs against the real SQLite stack.
+ */
+class UndoServiceCorruptReferenceTest {
+
+    @TempDir
+    Path dir;
+    private SqliteRecordStore store;
+
+    @BeforeEach
+    void open() {
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"));
+    }
+
+    @AfterEach
+    void close() {
+        store.close();
+    }
+
+    private static SpyglassConfig fakeConfig() {
+        SpyglassConfig.Limits limits = new SpyglassConfig.Limits(
+                250, 1_000, 50, 4_000, Duration.parse("30s"), 40L);
+        return mock(SpyglassConfig.class, invocation -> {
+            if ("limits".equals(invocation.getMethod().getName())) {
+                return limits;
+            }
+            return null;
+        });
+    }
+
+    private static String validBlob(UUID playerId) {
+        QueryRequest valid = new QueryRequest(
+                List.of(new QueryPredicate.Eq("source.playerId", playerId)),
+                Sort.NEWEST_FIRST, 50, EnumSet.of(Flag.NO_GROUP), false);
+        return UndoReferenceBson.encodeBase64(valid, "ROLLBACK",
+                Instant.parse("2026-06-10T02:00:00Z"));
+    }
+
+    private void assertPoisonRowIsConsumedAndOlderRefIsReachable(
+            SqliteUndoStack stack, UUID playerId, Player player,
+            List<Component> messages, String expectedFragment) {
+        RollbackService rollbacks = mock(RollbackService.class);
+        UndoService undo = new UndoService(mock(RollbackEngine.class), stack,
+                ServiceSupport.synchronous(), fakeConfig(), rollbacks);
+
+        // First /undo hits the unusable newest reference: it is reported
+        // AND removed from the ledger.
+        undo.execute(player);
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains(expectedFragment)
+                        && line.contains("run /sg undo again"));
+        verify(rollbacks, never()).executeReplay(any(), any(), any(), any(), any());
+        UndoStack.Popped next = stack.openLatest(playerId).orElseThrow();
+        assertThat(((UndoStack.ReplayReference) next).referenceBase64())
+                .as("the poison row must be tombstoned so the older valid reference surfaces")
+                .isEqualTo(validBlob(playerId));
+        next.close();
+
+        // Second /undo reaches the valid reference and queues the replay.
+        undo.execute(player);
+        ArgumentCaptor<RollbackMode> mode = ArgumentCaptor.forClass(RollbackMode.class);
+        verify(rollbacks).executeReplay(eq(player), any(QueryRequest.class),
+                mode.capture(), any(String.class), any(Runnable.class));
+        assertThat(mode.getValue()).isEqualTo(RollbackMode.RESTORE);
+    }
+
+    @Test
+    void corruptReferenceIsTombstonedAndDoesNotBlockOlderEntries() throws Exception {
+        SqliteUndoStack stack = new SqliteUndoStack(store);
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        List<Component> messages = ServiceTestSupport.captureMessages(player);
+
+        stack.pushReference(playerId, "ROLLBACK", validBlob(playerId));
+        Thread.sleep(20); // distinct created_at so the poison row is strictly newer
+        stack.pushReference(playerId, "ROLLBACK", "%%%not-base64-bson%%%");
+
+        assertPoisonRowIsConsumedAndOlderRefIsReachable(
+                stack, playerId, player, messages, "Undo reference unreadable");
+    }
+
+    @Test
+    void unknownModeReferenceIsTombstonedAndDoesNotBlockOlderEntries() throws Exception {
+        SqliteUndoStack stack = new SqliteUndoStack(store);
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        List<Component> messages = ServiceTestSupport.captureMessages(player);
+
+        stack.pushReference(playerId, "ROLLBACK", validBlob(playerId));
+        Thread.sleep(20);
+        QueryRequest request = new QueryRequest(
+                List.of(new QueryPredicate.Eq("source.playerId", playerId)),
+                Sort.NEWEST_FIRST, 50, EnumSet.of(Flag.NO_GROUP), false);
+        stack.pushReference(playerId, "TELEPORT", UndoReferenceBson.encodeBase64(
+                request, "TELEPORT", Instant.parse("2026-06-10T02:00:00Z")));
+
+        assertPoisonRowIsConsumedAndOlderRefIsReachable(
+                stack, playerId, player, messages, "unknown mode TELEPORT");
+    }
+}


### PR DESCRIPTION
Fixes the soft-lock half of #266.

## What

- `UndoService.replayReference`: an unreadable reference blob or unknown mode now **tombstones** the row (best effort) instead of only `close()`-ing the in-memory handle. Before, the poison row stayed newest in the ledger and every subsequent `/undo` re-popped it, blocking all older valid entries for the full 24h TTL.
- The error message now says the reference was discarded and points the operator at the retry: `run /sg undo again for the previous operation`.
- COMMANDS.md documents undo's designed limits (per-player, player-only, 24h, no redo, query-replay semantics, salvage pointer) - the other half of the staff confusion in #266.

## Why tombstone, not leave-poppable

Leave-poppable is correct for *transient* replay failures (retry-safe, see the legacy path). A corrupt blob can never succeed, so retrying it is a guaranteed loop.

## Tests

`UndoServiceCorruptReferenceTest` runs against the real SQLite stack: pushes an older valid reference shadowed by a newer corrupt one (and an unknown-mode one), asserts the first `/undo` discards the poison row, and the second reaches the valid reference and queues the RESTORE replay. Before this fix both tests fail with the same unreadable-reference error on every attempt.

`./gradlew check` green.

Out of scope, still open on #266: distinguishing the six silent no-op cases needs UndoStack interface additions across all four backends; `/sg undo <op-id>` / `undo list` are feature asks.