### PR TITLE
fix(tool): configurable, visible wand lookback + mo duration unit (#271)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -106,7 +106,9 @@ Player-lit TNT records the igniter as the actor, so `p:<griefer>` searches and r
 /sg tool
 ```
 
-Toggles inspection mode. Left-click a block to see its full history, including blocks a previous rollback restored. Right-click to preview what is about to happen near it. Toggle off the same way.
+Toggles inspection mode. Left-click a block to see its history, including blocks a previous rollback restored. Right-click to preview what is about to happen near it. Toggle off the same way.
+
+The wand looks back `tool.lookback` (default `26w`), and the inspect header always names the window, e.g. `STONE at 100 64 200 (last 26w)`. An empty inspect means nothing happened *inside that window*; for anything older, or for more results than the cap shows, run `/sg search t:... trg:x,y,z` at the block.
 
 ## Rollback
 

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/util/Duration.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/util/Duration.java
@@ -6,7 +6,9 @@ import java.util.regex.Pattern;
 
 public record Duration(long seconds) {
 
-    private static final Pattern TOKEN_PATTERN = Pattern.compile("(\\d+)([smhdw])");
+    // "mo" must precede the single-char class or "1mo" would match as
+    // "1m" (one minute) and then fail the trailing-character check (#271).
+    private static final Pattern TOKEN_PATTERN = Pattern.compile("(\\d+)(mo|[smhdw])");
 
     public static Duration parse(String input) {
         if (input == null || input.isBlank()) {
@@ -27,6 +29,7 @@ public record Duration(long seconds) {
                 case "h" -> 60L * 60L;
                 case "d" -> 60L * 60L * 24L;
                 case "w" -> 60L * 60L * 24L * 7L;
+                case "mo" -> 60L * 60L * 24L * 30L;
                 default -> throw new IllegalArgumentException("Unsupported duration unit.");
             };
             total = Math.addExact(total, Math.multiplyExact(value, multiplier));
@@ -46,5 +49,28 @@ public record Duration(long seconds) {
 
     public Instant after(Instant base) {
         return base.plusSeconds(seconds);
+    }
+
+    /**
+     * Shortest {@code w/d/h/m/s} rendering, e.g. {@code 26w}, {@code 4h30m}.
+     * Operator-facing (the wand's inspect header shows its window with it).
+     * Months are an input convenience only and render as weeks/days.
+     */
+    public String compact() {
+        if (seconds <= 0) {
+            return "0s";
+        }
+        StringBuilder out = new StringBuilder();
+        long rest = seconds;
+        long[] sizes = {60L * 60L * 24L * 7L, 60L * 60L * 24L, 60L * 60L, 60L, 1L};
+        String[] units = {"w", "d", "h", "m", "s"};
+        for (int i = 0; i < sizes.length; i++) {
+            long count = rest / sizes[i];
+            if (count > 0) {
+                out.append(count).append(units[i]);
+                rest -= count * sizes[i];
+            }
+        }
+        return out.toString();
     }
 }

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/util/DurationTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/util/DurationTest.java
@@ -14,11 +14,32 @@ class DurationTest {
         assertThat(Duration.parse("1h").seconds()).isEqualTo(3_600L);
         assertThat(Duration.parse("1d").seconds()).isEqualTo(86_400L);
         assertThat(Duration.parse("1w").seconds()).isEqualTo(604_800L);
+        assertThat(Duration.parse("1mo").seconds()).isEqualTo(30L * 86_400L);
     }
 
     @Test
     void parsesCompositeDurations() {
         assertThat(Duration.parse("4w3d").seconds()).isEqualTo((4L * 7L + 3L) * 86_400L);
+    }
+
+    @Test
+    void monthDoesNotShadowMinute() {
+        // "mo" is ordered before the single-char class (#271): 1mo is a
+        // month, 1m stays a minute, and a bare trailing "o" still fails.
+        assertThat(Duration.parse("2mo").seconds()).isEqualTo(60L * 86_400L);
+        assertThat(Duration.parse("1mo30m").seconds())
+                .isEqualTo(30L * 86_400L + 30L * 60L);
+        assertThatThrownBy(() -> Duration.parse("1month"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void compactRendersShortestForm() {
+        assertThat(Duration.parse("26w").compact()).isEqualTo("26w");
+        assertThat(Duration.parse("7d").compact()).isEqualTo("1w");
+        assertThat(Duration.parse("4h30m").compact()).isEqualTo("4h30m");
+        assertThat(Duration.parse("1mo").compact()).isEqualTo("4w2d");
+        assertThat(new Duration(0L).compact()).isEqualTo("0s");
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/Feedback.java
@@ -76,8 +76,14 @@ public final class Feedback {
         return Component.text(message, NamedTextColor.GREEN);
     }
 
-    /** `«Spyglass» --- TARGET at x y z ---` — used by the wand before a lookup. */
-    public static Component inspectHeader(String target, BlockLocation location) {
+    /**
+     * {@code «Spyglass» --- TARGET at x y z (last 26w) ---}, used by the
+     * wand before a lookup. The window is always shown so an empty result
+     * reads as "nothing inside the window", never "no history exists"
+     * (#271).
+     */
+    public static Component inspectHeader(String target, BlockLocation location,
+                                          net.medievalrp.spyglass.api.util.Duration window) {
         return Component.text()
                 .append(PREFIX)
                 .append(Component.text(" --- ", NamedTextColor.GREEN))
@@ -86,6 +92,8 @@ public final class Feedback {
                 .append(Component.text(
                         location.x() + " " + location.y() + " " + location.z(),
                         NamedTextColor.GREEN))
+                .append(Component.text(" (last " + window.compact() + ")",
+                        NamedTextColor.GRAY))
                 .append(Component.text(" ---", NamedTextColor.GREEN))
                 .asComponent();
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/WandInteractListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/tool/WandInteractListener.java
@@ -44,7 +44,9 @@ public final class WandInteractListener implements Listener {
         this.tool = tool;
         this.search = search;
         this.config = config;
-        this.lookbackWindow = Duration.parse("7d");
+        // tool.lookback, default 26w. The old hardcoded 7d silently hid
+        // older history and read as "Spyglass cannot roll this back" (#271).
+        this.lookbackWindow = config.tool().lookback();
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
@@ -130,7 +132,7 @@ public final class WandInteractListener implements Listener {
     private void queryAt(Player player, Location location) {
         BlockLocation anchor = BlockLocations.fromLocation(location);
         String target = location.getBlock().getType().name();
-        player.sendMessage(Feedback.inspectHeader(target, anchor));
+        player.sendMessage(Feedback.inspectHeader(target, anchor, lookbackWindow));
         List<QueryPredicate> predicates = new ArrayList<>();
         predicates.add(RadiusParam.groupAround(anchor, 0));
         predicates.add(new QueryPredicate.Range(

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -127,7 +127,11 @@ public record SpyglassConfig(
                         root.node("limits", "rollback-tick-budget-ms").getLong(15L)),
                 Map.copyOf(events),
                 commandRedact,
-                new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false)),
+                new Tool(Material.matchMaterial(root.node("tool", "material").getString("REDSTONE_LAMP"), false),
+                        // How far back the wand's inspect looks. A point query
+                        // on one block, already capped by limits.search-result,
+                        // so a long default is cheap (#271).
+                        Duration.parse(root.node("tool", "lookback").getString("26w"))),
                 new Server(root.node("server", "name").getString("default")),
                 parseMetrics(root),
                 parseAnalytics(root),
@@ -471,9 +475,10 @@ public record SpyglassConfig(
     public record EventSettings(boolean enabled, String pastTense, Long retentionSeconds) {
     }
 
-    public record Tool(Material material) {
+    public record Tool(Material material, Duration lookback) {
         public Tool {
             material = material == null ? Material.REDSTONE_LAMP : material;
+            lookback = lookback == null ? Duration.parse("26w") : lookback;
         }
     }
 

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -227,6 +227,13 @@ tool {
   # material; clicking a block while holding it shows that block's recent
   # history inline instead of placing or breaking. Any Bukkit Material name.
   material = "GLOWSTONE"
+
+  # How far back a wand inspect looks. The inspect header always shows
+  # this window. It is a point query on a single block, already capped
+  # by limits.search-result, so a long window costs little; match it to
+  # storage.retention if you want the wand to see everything Spyglass
+  # still holds. Use /sg search t:... at the block for anything past it.
+  lookback = "26w"
 }
 
 commands {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/tool/WandLookbackTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/tool/WandLookbackTest.java
@@ -1,0 +1,105 @@
+package net.medievalrp.spyglass.plugin.command.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.command.service.SearchService;
+import net.medievalrp.spyglass.plugin.command.service.ToolService;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Regression tests for #271: the wand's lookback comes from
+ * {@code tool.lookback} (it was a hardcoded, invisible 7d), and the
+ * inspect header always names the window so an empty result reads as
+ * "nothing inside the window" rather than "no history exists".
+ */
+class WandLookbackTest {
+
+    @Test
+    void wandQueriesTheConfiguredWindowAndHeaderNamesIt() throws Exception {
+        SpyglassConfig config = mock(SpyglassConfig.class);
+        when(config.limits()).thenReturn(new SpyglassConfig.Limits(
+                250, 1_000, 50, 4_000, Duration.parse("30s"), 40L));
+        when(config.tool()).thenReturn(new SpyglassConfig.Tool(
+                Material.GLOWSTONE, Duration.parse("3w")));
+
+        SearchService search = mock(SearchService.class);
+        WandInteractListener listener = new WandInteractListener(
+                mock(ToolService.class), search, config);
+
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(UUID.randomUUID());
+        when(world.getName()).thenReturn("world");
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.STONE);
+        when(world.getBlockAt(any(Location.class))).thenReturn(block);
+        Location location = new Location(world, 1, 64, 2);
+
+        Player player = mock(Player.class);
+        List<Component> messages = new ArrayList<>();
+        doAnswer(invocation -> {
+            messages.add(invocation.getArgument(0));
+            return null;
+        }).when(player).sendMessage(any(Component.class));
+
+        // Drive the single query path both wand handlers share; the wand
+        // item/PDC gate is not under test.
+        Instant before = Instant.now();
+        Method queryAt = WandInteractListener.class
+                .getDeclaredMethod("queryAt", Player.class, Location.class);
+        queryAt.setAccessible(true);
+        queryAt.invoke(listener, player, location);
+        Instant after = Instant.now();
+
+        ArgumentCaptor<QueryRequest> request = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(search).executeRequest(any(Player.class), request.capture());
+        Instant floor = request.getValue().predicates().stream()
+                .filter(p -> p instanceof QueryPredicate.Range r && "occurred".equals(r.field()))
+                .map(p -> (Instant) ((QueryPredicate.Range) p).lowerInclusive())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("wand query has no occurred floor"));
+
+        assertThat(floor)
+                .as("the wand honors tool.lookback, not a hardcoded constant")
+                .isBetween(before.minus(21, ChronoUnit.DAYS).minusSeconds(60),
+                        after.minus(21, ChronoUnit.DAYS).plusSeconds(60));
+
+        String header = messages.stream()
+                .map(c -> PlainTextComponentSerializer.plainText().serialize(c))
+                .reduce("", (a, b) -> a + "\n" + b);
+        assertThat(header).contains("STONE");
+        assertThat(header)
+                .as("the inspect header must name the window")
+                .contains("last 3w");
+    }
+
+    @Test
+    void defaultLookbackIsLongNotSevenDays() {
+        // The unexamined 7d constant is gone: an absent tool.lookback
+        // resolves to 26w.
+        assertThat(new SpyglassConfig.Tool(Material.GLOWSTONE, null).lookback())
+                .isEqualTo(Duration.parse("26w"));
+    }
+}


### PR DESCRIPTION
Fixes #271.

## What

- `tool.lookback` config key (default `26w`), read by `WandInteractListener` instead of the hardcoded, invisible `7d`. The wand inspect is a radius-0 point query already capped by `limits.search-result`, so a long window is cheap.
- `Feedback.inspectHeader` now always names the window: `STONE at 100 64 200 (last 26w)`. An empty inspect reads as nothing-in-window, never no-history-exists - the misread that produced the staff report.
- `Duration` gains the `mo` unit (30d) that COMMANDS.md has advertised all along; `mo` is ordered before the single-char class so `1m` stays one minute and `1month` still rejects. Also adds `Duration.compact()` for the header rendering.
- COMMANDS.md documents the window and the `/sg search t:... trg:x,y,z` escape hatch.

## Tests

- `WandLookbackTest`: the query floor honors a configured `3w` window (was pinned at now-7d regardless of config), the header names the window, and the default resolves to 26w.
- `DurationTest`: `mo` parsing, no shadowing of `m`, `compact()` rendering.

`./gradlew check` green, including the store ITs (note: they only pass on top of dev 0cafc56, the parity-IT expiry fix).