### PR TITLE
fix(listener): per-slot shift-click deposit records (#268)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -398,7 +398,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 // hopper listener since one listener carries both toggles.
                 new BucketListener(recorder, support, deferredSerializer, enabledEvents),
                 new FallingBlockLandListener(recorder, support),
-                new ContainerTransactionListener(recorder, support, deferredSerializer),
+                new ContainerTransactionListener(recorder, support, deferredSerializer,
+                        task -> getServer().getScheduler().runTask(this, task)),
                 new ContainerDragListener(recorder, support),
                 new ContainerInteractListener(recorder, support),
                 new BlockUseListener(recorder, support),

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
@@ -53,12 +53,16 @@ public final class ContainerTransactionListener implements RecordingListener {
     private final Recorder recorder;
     private final RecordingSupport support;
     private final Executor serializer;
+    private final Executor nextTick;
 
     public ContainerTransactionListener(Recorder recorder, RecordingSupport support,
-                                        Executor serializer) {
+                                        Executor serializer, Executor nextTick) {
         this.recorder = recorder;
         this.support = support;
         this.serializer = serializer;
+        // Main-thread, next-tick. Shift-click deposits are diffed after the
+        // click applies (#268); everything else records at event time.
+        this.nextTick = nextTick;
     }
 
     @Override
@@ -184,42 +188,77 @@ public final class ContainerTransactionListener implements RecordingListener {
         if (topHolder instanceof ShulkerBox) {
             return;
         }
-        // Withdraw shift-clicks index the container (top) inventory, so the
-        // clicked slot is a container slot to translate. Deposit shift-clicks
-        // index the player (bottom) inventory and record slot -1, so resolve
-        // with -1 to pin a stable half and never mistranslate a player slot.
-        int containerSlot = clickedIsTop ? event.getSlot() : -1;
-        SlotTarget resolved = resolveSlotTarget(topHolder, containerSlot);
-        if (resolved == null) {
-            return;
-        }
-        ContainerTarget containerTarget = resolved.target();
 
         ItemStack moved = clicked.getItem(event.getSlot());
         if (moved == null || moved.getType() == Material.AIR) {
             return;
         }
-        int amount = moved.getAmount();
-        BlockLocation location = containerTarget.location();
-        String containerType = containerTarget.type();
 
-        ItemStack movedSnapshot = moved.clone(); // pre-click; serialized off-thread
-        String target = moved.getType().name();
         if (clickedIsTop) {
             // Shift-click from container to player inventory -> withdraw.
+            // The clicked slot IS a container slot to translate.
+            SlotTarget resolved = resolveSlotTarget(topHolder, event.getSlot());
+            if (resolved == null) {
+                return;
+            }
             int recordSlot = resolved.slot();
-            deferWithdraw(player, location, containerType, recordSlot, amount, target,
-                    occurred, recordSlot, movedSnapshot, null);
+            deferWithdraw(player, resolved.target().location(), resolved.target().type(),
+                    recordSlot, moved.getAmount(), moved.getType().name(),
+                    occurred, recordSlot, moved.clone(), null);
             return;
         }
         if (!clicked.equals(bottom)) {
             return;
         }
-        // Shift-click from player inventory to container -> deposit. Slot is
-        // -1 (no specific container slot); the after-item carries the source
-        // player-inventory slot, matching the single-chest behavior.
-        deferDeposit(player, location, containerType, -1, amount, target,
-                occurred, event.getSlot(), null, movedSnapshot);
+        // Trackable destination only: a Container/minecart, or a DoubleChest
+        // (which resolveTarget alone drops but resolveSlotTarget handles
+        // per-slot). Anvils, brewing stands etc. bail before the snapshot.
+        if (!(topHolder instanceof DoubleChest) && resolveTarget(topHolder) == null) {
+            return;
+        }
+        // Shift-click from player inventory to container -> deposit. The
+        // event names no destination: vanilla merges into partial stacks
+        // first, then empty slots, so ONE click can touch SEVERAL container
+        // slots, and nothing in the event says which. Snapshot the top
+        // inventory now (MONITOR fires before the click applies) and diff
+        // it one tick later, emitting one per-slot record - the same
+        // granularity ContainerDragListener gets from getNewItems() (#268).
+        // The old single record carried slot -1, which every rollback path
+        // rejects, so shift-click deposits were never rolled back; it also
+        // recorded the full stack even when a full container took nothing.
+        int topSize = top.getSize();
+        ItemStack[] beforeTop = new ItemStack[topSize];
+        for (int i = 0; i < topSize; i++) {
+            beforeTop[i] = cloneOrNull(top.getItem(i));
+        }
+        Material movedType = moved.getType();
+        nextTick.execute(() -> {
+            for (int rawSlot = 0; rawSlot < topSize; rawSlot++) {
+                ItemStack now = top.getItem(rawSlot);
+                if (now == null || now.getType() != movedType) {
+                    continue;
+                }
+                ItemStack was = beforeTop[rawSlot];
+                boolean wasEmpty = was == null || was.getType() == Material.AIR;
+                if (!wasEmpty && was.getType() != movedType) {
+                    // A different material sat here before the click; vanilla
+                    // never merges into it, so this change is not ours.
+                    continue;
+                }
+                int delta = now.getAmount() - (wasEmpty ? 0 : was.getAmount());
+                if (delta <= 0) {
+                    continue;
+                }
+                SlotTarget slotTarget = resolveSlotTarget(topHolder, rawSlot);
+                if (slotTarget == null) {
+                    continue;
+                }
+                int recordSlot = slotTarget.slot();
+                deferDeposit(player, slotTarget.target().location(), slotTarget.target().type(),
+                        recordSlot, delta, movedType.name(),
+                        occurred, recordSlot, wasEmpty ? null : was, now.clone());
+            }
+        });
     }
 
     private void handleHotbarSwap(InventoryClickEvent event, ContainerTarget containerTarget, Player player,

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1714,10 +1714,13 @@ public final class RollbackEngine {
             return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported("Target is no longer a container."));
         }
 
-        // Some Bukkit inventory events fire with slot = -1 (drag /
-        // auto-stack) and the recorded container may be wider than
-        // the live one (chest -> hopper downgrade). Range-check
-        // before getItem to avoid IndexOutOfBoundsException.
+        // slot = -1 rows exist and stay benign skips: cursor-held bundle
+        // transactions record -1 by design (there is no container slot),
+        // and shift-click deposits recorded -1 before #268 - those legacy
+        // rows live in every store until retention ages them out. The
+        // recorded container may also be wider than the live one (chest ->
+        // hopper downgrade). Range-check before getItem to avoid
+        // IndexOutOfBoundsException.
         int slot = effect.slot();
         int size = container.getInventory().getSize();
         if (slot < 0 || slot >= size) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
@@ -40,11 +40,15 @@ class ContainerTransactionListenerTest {
 
     private final CapturingRecorder recorder = new CapturingRecorder();
     private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    // Queued next-tick executor: shift-click deposits diff the container
+    // one tick after the click applies (#268), so tests re-stub the top
+    // inventory to its post-click state and then drain this queue.
+    private final List<Runnable> nextTick = new java.util.ArrayList<>();
     // Same-thread serializer so the deferred build (#98) runs inline and the
     // (before, after) assertions below see the records immediately. A
     // separate test exercises the actual deferral handoff.
     private final ContainerTransactionListener listener =
-            new ContainerTransactionListener(recorder, support, Runnable::run);
+            new ContainerTransactionListener(recorder, support, Runnable::run, nextTick::add);
 
     // Strong refs so Location's weak World reference can't be collected
     // mid-test (see ChatListenerTest.mockPlayer).
@@ -164,7 +168,7 @@ class ContainerTransactionListenerTest {
         // record exists until the deferred task runs.
         List<Runnable> deferred = new java.util.ArrayList<>();
         ContainerTransactionListener deferredListener =
-                new ContainerTransactionListener(recorder, support, deferred::add);
+                new ContainerTransactionListener(recorder, support, deferred::add, nextTick::add);
         InventoryClickEvent event = clickEvent(InventoryAction.PLACE_ALL, 0, null, ironStack(64));
 
         deferredListener.onInventoryClick(event);
@@ -179,6 +183,128 @@ class ContainerTransactionListenerTest {
         assertThat(record.amount()).isEqualTo(64);
         assertThat(record.afterItem()).isNotNull();
         assertThat(record.afterItem().material()).isEqualTo("IRON_INGOT");
+    }
+
+    // ── shift-click deposits (#268) ──────────────────────────────
+
+    @Test
+    void shiftClickDepositEmitsOnePerSlotRecordAcrossPartialAndEmptySlots() {
+        // Chest slot 3 holds 40 iron; the player shift-clicks 64 iron from
+        // player-inventory slot 30. Vanilla tops the partial stack up to 64
+        // (+24) and drops the remaining 40 into the first empty slot. The
+        // record shape carries one slot, so this MUST be two records; the
+        // pre-#268 code emitted a single slot=-1 record no rollback path
+        // could apply.
+        ItemStack partialBefore = ironStack(40);
+        Inventory top = mock(Inventory.class);
+        when(top.getSize()).thenReturn(27);
+        when(top.getItem(3)).thenReturn(partialBefore);
+        InventoryClickEvent event = shiftClickFromPlayer(top, 30, ironStack(64));
+
+        listener.onInventoryClick(event);
+        assertThat(recorder.records).as("nothing recorded until the click applies").isEmpty();
+        assertThat(nextTick).hasSize(1);
+
+        // The click has applied: slot 3 topped up to 64, overflow of 40 in slot 0.
+        ItemStack overflow = ironStack(40);
+        ItemStack toppedUp = ironStack(64);
+        when(top.getItem(0)).thenReturn(overflow);
+        when(top.getItem(3)).thenReturn(toppedUp);
+        nextTick.forEach(Runnable::run);
+
+        assertThat(recorder.records).hasSize(2);
+        ContainerDepositRecord intoEmpty = (ContainerDepositRecord) recorder.records.get(0);
+        assertThat(intoEmpty.slot()).isEqualTo(0);
+        assertThat(intoEmpty.amount()).isEqualTo(40);
+        assertThat(intoEmpty.beforeItem()).isNull();
+        assertThat(intoEmpty.afterItem().material()).isEqualTo("IRON_INGOT");
+        ContainerDepositRecord intoPartial = (ContainerDepositRecord) recorder.records.get(1);
+        assertThat(intoPartial.slot()).isEqualTo(3);
+        assertThat(intoPartial.amount()).isEqualTo(24);
+        assertThat(intoPartial.beforeItem()).isNotNull();
+        // No record anywhere carries the old -1 sentinel.
+        assertThat(recorder.records)
+                .allSatisfy(r -> assertThat(((ContainerDepositRecord) r).slot()).isNotNegative());
+    }
+
+    @Test
+    void shiftClickIntoFullContainerRecordsNothing() {
+        // Nothing fits, nothing moves. The old code recorded a full-stack
+        // deposit that never happened.
+        ItemStack full = ironStack(64);
+        Inventory top = mock(Inventory.class);
+        when(top.getSize()).thenReturn(27);
+        for (int i = 0; i < 27; i++) {
+            when(top.getItem(i)).thenReturn(full);
+        }
+        InventoryClickEvent event = shiftClickFromPlayer(top, 30, ironStack(64));
+
+        listener.onInventoryClick(event);
+        nextTick.forEach(Runnable::run);
+
+        assertThat(recorder.records).isEmpty();
+    }
+
+    @Test
+    void shiftClickDepositIgnoresForeignMaterialChanges() {
+        // A slot that held a different material cannot be a merge target;
+        // a same-tick change there (hopper, another player) is not ours.
+        Inventory top = mock(Inventory.class);
+        when(top.getSize()).thenReturn(27);
+        ItemStack gold = mockStack(Material.GOLD_INGOT, 10);
+        when(top.getItem(5)).thenReturn(gold);
+        InventoryClickEvent event = shiftClickFromPlayer(top, 30, ironStack(16));
+
+        listener.onInventoryClick(event);
+        ItemStack foreignSwap = ironStack(16);
+        ItemStack deposit = ironStack(16);
+        when(top.getItem(5)).thenReturn(foreignSwap); // foreign swap mid-tick
+        when(top.getItem(0)).thenReturn(deposit); // the actual deposit
+        nextTick.forEach(Runnable::run);
+
+        assertThat(recorder.records).hasSize(1);
+        assertThat(((ContainerDepositRecord) recorder.records.get(0)).slot()).isEqualTo(0);
+    }
+
+    @Test
+    void shiftClickWithdrawStillRecordsTheRealContainerSlot() {
+        // The withdraw direction indexed real container slots all along and
+        // must keep doing so, without waiting a tick.
+        Inventory top = mock(Inventory.class);
+        when(top.getSize()).thenReturn(27);
+        ItemStack held = ironStack(16);
+        when(top.getItem(3)).thenReturn(held);
+        InventoryClickEvent event = shiftClickEvent(top, top, 3, InventoryAction.MOVE_TO_OTHER_INVENTORY);
+
+        listener.onInventoryClick(event);
+
+        assertThat(nextTick).isEmpty();
+        assertThat(recorder.records).hasSize(1);
+        ContainerWithdrawRecord record = (ContainerWithdrawRecord) recorder.records.get(0);
+        assertThat(record.slot()).isEqualTo(3);
+        assertThat(record.amount()).isEqualTo(16);
+    }
+
+    @Test
+    void shiftClickDepositIntoDoubleChestRebasesToTheOwningHalf() {
+        // Raw slot 30 of a double chest lives in the right half: the record
+        // must attribute to the right block at its local slot 3, exactly as
+        // direct clicks do.
+        Inventory top = mock(Inventory.class);
+        when(top.getSize()).thenReturn(54);
+        DoubleChest holder = doubleChestHolder();
+        when(top.getHolder(false)).thenReturn(holder);
+        InventoryClickEvent event = shiftClickFromPlayer(top, 12, ironStack(8));
+
+        listener.onInventoryClick(event);
+        ItemStack landed = ironStack(8);
+        when(top.getItem(30)).thenReturn(landed);
+        nextTick.forEach(Runnable::run);
+
+        assertThat(recorder.records).hasSize(1);
+        ContainerDepositRecord record = (ContainerDepositRecord) recorder.records.get(0);
+        assertThat(record.location().x()).isEqualTo(2);
+        assertThat(record.slot()).isEqualTo(3);
     }
 
     // ── fixtures ─────────────────────────────────────────────────
@@ -242,6 +368,62 @@ class ContainerTransactionListenerTest {
         when(event.getSlot()).thenReturn(rawSlot);
         when(event.getCursor()).thenReturn(cursor);
         return event;
+    }
+
+    /**
+     * A MOVE_TO_OTHER_INVENTORY click from the player (bottom) inventory
+     * into {@code top}. The moved stack sits in player-inventory
+     * {@code playerSlot}; {@code top} gets a single-chest holder at
+     * (1,64,2) unless the test stubbed one already.
+     */
+    private InventoryClickEvent shiftClickFromPlayer(Inventory top, int playerSlot, ItemStack moved) {
+        Inventory bottom = mock(Inventory.class);
+        when(bottom.getItem(playerSlot)).thenReturn(moved);
+        return shiftClickEvent(top, bottom, playerSlot, InventoryAction.MOVE_TO_OTHER_INVENTORY);
+    }
+
+    private InventoryClickEvent shiftClickEvent(Inventory top, Inventory clicked, int slot,
+                                                InventoryAction action) {
+        ensureChestHolder(top);
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+        Inventory bottom = clicked.equals(top) ? mock(Inventory.class) : clicked;
+        org.bukkit.inventory.InventoryView view = mock(org.bukkit.inventory.InventoryView.class);
+        when(view.getTopInventory()).thenReturn(top);
+        when(view.getBottomInventory()).thenReturn(bottom);
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getWhoClicked()).thenReturn(player);
+        when(event.getClickedInventory()).thenReturn(clicked);
+        when(event.getAction()).thenReturn(action);
+        when(event.getView()).thenReturn(view);
+        when(event.getSlot()).thenReturn(slot);
+        return event;
+    }
+
+    private void ensureChestHolder(Inventory top) {
+        if (top.getHolder(false) != null) {
+            return;
+        }
+        when(world.getUID()).thenReturn(UUID.fromString("77777777-7777-7777-7777-777777777777"));
+        when(world.getName()).thenReturn("world");
+        Block block = mock(Block.class);
+        when(block.getLocation()).thenReturn(new Location(world, 1, 64, 2));
+        when(block.getType()).thenReturn(Material.CHEST);
+        Chest holder = mock(Chest.class);
+        when(holder.getBlock()).thenReturn(block);
+        when(top.getHolder(false)).thenReturn(holder);
+    }
+
+    private DoubleChest doubleChestHolder() {
+        when(world.getUID()).thenReturn(UUID.fromString("77777777-7777-7777-7777-777777777777"));
+        when(world.getName()).thenReturn("world");
+        Chest left = chestHalf(1);
+        Chest right = chestHalf(2);
+        DoubleChest doubleChest = mock(DoubleChest.class);
+        when(doubleChest.getLeftSide()).thenReturn(left);
+        when(doubleChest.getRightSide()).thenReturn(right);
+        return doubleChest;
     }
 
     /** A 27-slot chest block at the given x, used as one half of a double chest. */

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ShiftClickDepositRoundTripTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ShiftClickDepositRoundTripTest.java
@@ -1,0 +1,103 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.RollbackResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Regression test for #268 (engine side): the per-slot records the
+ * shift-click deposit path now emits round-trip through
+ * {@link RollbackEngine} and actually clear the deposited items. The
+ * pre-fix slot=-1 shape was rejected by every container apply path as a
+ * benign NotSupported skip.
+ */
+class ShiftClickDepositRoundTripTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    @Test
+    void perSlotDepositRecordAppliesAndClearsTheSlot() {
+        // The record the fixed listener emits for a deposit into an empty
+        // slot: real container slot, before=null, after=the merged stack.
+        ItemStack deposited = ironStack(40);
+        StoredItem after = ItemSerialization.storedItem(0, deposited);
+        Instant now = Instant.now();
+        ContainerDepositRecord record = new ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD_ID, "world", 1, 64, 2),
+                "test", "IRON_INGOT", "CHEST", 0, 40, null, after);
+        RollbackEffect effect = record.rollbackEffect();
+        assertThat(((RollbackEffect.ContainerSlotWrite) effect).slot()).isEqualTo(0);
+
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        Inventory inventory = mock(Inventory.class);
+        when(inventory.getSize()).thenReturn(27);
+        // Live slot still holds exactly what the record said the deposit
+        // left behind, so the expected-state guard passes.
+        ItemStack live = ironStack(40);
+        when(inventory.getItem(0)).thenReturn(live);
+        Container container = mock(Container.class);
+        when(container.getInventory()).thenReturn(inventory);
+        when(container.getSnapshotInventory()).thenReturn(inventory);
+        Block block = mock(Block.class);
+        when(block.getState()).thenReturn(container);
+        when(world.getBlockAt(1, 64, 2)).thenReturn(block);
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+            bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+
+            RollbackEngine engine = new RollbackEngine();
+            RollbackResult result = engine.applyAll(List.of(effect), mock(CommandSender.class)).get(0);
+
+            assertThat(result)
+                    .as("a real-slot deposit record must apply, not skip")
+                    .isInstanceOf(RollbackResult.Applied.class);
+            verify(inventory).setItem(0, null);
+        }
+    }
+
+    private static ItemStack ironStack(int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.IRON_INGOT);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.getMaxStackSize()).thenReturn(64);
+        when(stack.getItemMeta()).thenReturn(null);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{9, 9, 9});
+        return stack;
+    }
+}


### PR DESCRIPTION
Fixes #268.

## What

- `ContainerTransactionListener.handleMoveToOther` deposit branch: snapshot the top inventory at MONITOR (the click has not applied yet), re-read it one tick later via a new `nextTick` executor, and emit **one `ContainerDepositRecord` per changed slot** with real container slots - the same granularity `ContainerDragListener` gets from `getNewItems()`. Merge targets are only empty slots or same-material stacks, so foreign same-tick changes (hoppers, other players) are not attributed to the click.
- Fixes a second lie for free: a shift-click into a **full** container used to record a full-stack deposit that never happened; the diff records nothing.
- Double chests work (the deposit gate now admits `DoubleChest`, and per-slot `resolveSlotTarget` rebases each touched slot to its owning half).
- `RollbackEngine`: stale "drag / auto-stack" comment replaced with the real -1 producers.

## Deliberately NOT changed

`slot < 0` stays a benign `NotSupported` skip rather than an `Error`: cursor-held bundle transactions record -1 by design (there is no container slot), and pre-fix -1 rows persist in every store until retention ages them out - reclassifying would make old-data rollbacks report phantom errors.

## Tests

- Listener: merge across partial+empty emits two records with real slots and correct deltas/state pairs; full container emits nothing; foreign-material changes ignored; withdraw direction unchanged (no tick delay); double-chest raw slot 30 rebases to the right half local 3.
- Engine round-trip: the new record shape applies through `RollbackEngine` and clears the slot (the old -1 shape skips).

`./gradlew check` green.