### PR TITLE
fix(rollback): fluid post-pass re-arms the fluid engine after writes (#270)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -123,6 +123,8 @@ Rollback and restore **force-overwrite**: each matched block is set back to its 
 
 The trade-off: a rollback does not skip a cell just because someone changed it afterward, so a rollback scoped to one player can overwrite a *legitimate* later edit by another player in those exact cells. Scope the query by player, region `r:`, and time `t:` to the grief you mean to revert; review with `/sg search` first if unsure. Items in a container the rollback overwrites are recoverable - see [Container salvage](#container-salvage).
 
+**Water and lava re-flow, they are not replayed.** After the writes land, Spyglass re-arms the fluid engine over the rolled cells and their border, and the water settles to its natural level for the restored terrain. Fluid flow itself is never logged (the volume would rival hopper traffic), so the result is the equilibrium state, which for water is almost always indistinguishable from what stood at the timestamp - but it is a re-simulation, not a replay.
+
 ### Undo and restore
 
 ```

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -40,6 +40,7 @@ import net.medievalrp.spyglass.plugin.pipeline.Recorder;
 import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.ChunkDirectWriter;
 import net.medievalrp.spyglass.plugin.util.ChunkResender;
+import net.medievalrp.spyglass.plugin.util.FluidTickScheduler;
 import net.medievalrp.spyglass.plugin.util.ItemSerialization;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -594,6 +595,13 @@ public final class RollbackEngine {
                     }
                 }
                 ChunkDirectWriter.finishChunk(chunkCtx);
+                // Direct writes never schedule fluid ticks; re-arm the fluid
+                // engine over this chunk's cells and their shell (#270).
+                FluidTickScheduler.Pass fluids = FluidTickScheduler.begin(world);
+                for (int j = i; j < chunkEnd; j++) {
+                    BlockLocation loc = blockReplaceEffects.get(j).location();
+                    fluids.touch(loc.x(), loc.y(), loc.z());
+                }
                 // Direct NMS writes skip the per-block packet queue,
                 // so push the new chunk to viewers ourselves.
                 try {
@@ -927,6 +935,15 @@ public final class RollbackEngine {
                 }
             }
             ChunkDirectWriter.finishChunk(work.ctx);
+            // Direct writes never schedule fluid ticks; re-arm the fluid
+            // engine over this chunk's cells and their shell (#270).
+            if (writes != null) {
+                FluidTickScheduler.Pass fluids = FluidTickScheduler.begin(world);
+                for (int j = 0; j < writes.length; j++) {
+                    BlockLocation loc = blockReplaceEffects.get(from + j).location();
+                    fluids.touch(loc.x(), loc.y(), loc.z());
+                }
+            }
             // Direct NMS writes skip the per-block packet queue, so push
             // the new chunk to viewers ourselves.
             try {
@@ -1166,6 +1183,13 @@ public final class RollbackEngine {
                         writeColumnChunkMain(world, cols, order, cc);
                     } else {
                         ChunkDirectWriter.finishChunk(cc.ctx);
+                    }
+                    // Direct writes never schedule fluid ticks; re-arm the
+                    // fluid engine over this chunk's cells and shell (#270).
+                    FluidTickScheduler.Pass fluids = FluidTickScheduler.begin(world);
+                    for (int k = cc.from; k < cc.rangeEnd; k++) {
+                        int cellIdx = order[k];
+                        fluids.touch(cols.x(cellIdx), cols.y(cellIdx), cols.z(cellIdx));
                     }
                     try {
                         ChunkResender.resend(world, cc.cx, cc.cz);
@@ -1701,6 +1725,10 @@ public final class RollbackEngine {
         // contract as forceWriteCell.
         Block block = world.get().getBlockAt(effect.location().x(), effect.location().y(), effect.location().z());
         applySnapshot(block, effect.replacement());
+        // applySnapshot writes with applyPhysics=false; re-arm the fluid
+        // engine around the cell (#270).
+        FluidTickScheduler.touchSingle(world.get(),
+                effect.location().x(), effect.location().y(), effect.location().z());
         return appliedWithInverse(effect);
     }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FluidTickScheduler.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/util/FluidTickScheduler.java
@@ -1,0 +1,220 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.bukkit.World;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Post-write fluid pass for rollback (#270), the fluid analogue of
+ * {@link ChunkRelighter}. {@link ChunkDirectWriter} deliberately skips
+ * scheduled-tick registration and neighbor updates, and Minecraft fluid
+ * flow is driven entirely by scheduled ticks - so a rolled-back area
+ * was left with orphaned flowing water that never drains and dry
+ * pockets beside sources that never fill, until some unrelated block
+ * update forced a re-evaluation.
+ *
+ * <p>After each chunk's writes land, {@link Pass#touch} is called once
+ * per written cell: the cell and its six orthogonal neighbors (which
+ * includes the one-block shell just outside the rolled area - those
+ * neighbors were never notified either) are checked, and every fluid
+ * found gets a scheduled fluid tick. The fluid engine then re-simulates
+ * the region to its natural equilibrium. Cost is proportional to
+ * fluid-adjacent cells; a dirt-only rollback pays seven cheap fluid
+ * state reads per cell and schedules nothing.
+ *
+ * <p>Deliberately scoped to fluids: blanket neighbor updates over the
+ * area would re-trigger {@code Block.onPlace} for sand, gravel and
+ * concrete powder and reintroduce the falling-block bug
+ * {@link ChunkDirectWriter} exists to avoid. Scheduling a fluid tick
+ * triggers nothing immediately; the re-evaluation runs on later ticks
+ * through the vanilla fluid engine.
+ *
+ * <p>Reflective NMS access, same contract as {@link ChunkDirectWriter}:
+ * built against paper-api only, resolved once, and on lookup failure
+ * every pass is a no-op (the pre-#270 behavior) with one WARN.
+ *
+ * <p>Known limitation, documented in COMMANDS.md: re-simulation drives
+ * water to its natural equilibrium for the restored terrain, which is
+ * not necessarily the exact fluid layout at the rollback timestamp -
+ * flow was never recorded (deliberately: per-cell-per-tick volume, see
+ * HopperTransferListener for the same call).
+ */
+@ApiStatus.Internal
+public final class FluidTickScheduler {
+
+    private static final Logger LOG = Logger.getLogger(FluidTickScheduler.class.getName());
+
+    /** Fallback delay when the fluid's own tick delay is unavailable. */
+    private static final int DEFAULT_DELAY_TICKS = 5;
+
+    private static volatile boolean initialized;
+    private static volatile boolean available;
+
+    private static Method craftWorldGetHandle;
+    private static Constructor<?> blockPosCtor;
+    private static Method levelGetFluidState;
+    private static Method fluidStateIsEmpty;
+    private static Method fluidStateGetType;
+    private static Method levelScheduleTick;
+    private static Method fluidGetTickDelay;
+
+    private FluidTickScheduler() {
+    }
+
+    private static void init(World world) {
+        if (initialized) {
+            return;
+        }
+        synchronized (FluidTickScheduler.class) {
+            if (initialized) {
+                return;
+            }
+            try {
+                // Every class is derived from the live object graph, never
+                // Class.forName: Paper's plugin remapper rewrites reflective
+                // name constants for spigot-mapped plugins, and the spigot
+                // name "material.Fluid" maps to Mojang's FluidState, which
+                // silently corrupts a forName-based lookup. Method scans by
+                // name and shape are immune (same approach as
+                // ChunkDirectWriter's object-graph navigation).
+                craftWorldGetHandle = world.getClass().getMethod("getHandle");
+                Object level = craftWorldGetHandle.invoke(world);
+                // scheduleTick(BlockPos, Fluid, int) - the fluid overload of
+                // ScheduledTickAccess; discriminated from the Block overload
+                // by the parameter's simple name.
+                for (Method m : level.getClass().getMethods()) {
+                    if (!"scheduleTick".equals(m.getName())) {
+                        continue;
+                    }
+                    Class<?>[] p = m.getParameterTypes();
+                    if (p.length == 3 && p[2] == int.class
+                            && p[1].getSimpleName().equals("Fluid")) {
+                        levelScheduleTick = m;
+                        break;
+                    }
+                }
+                if (levelScheduleTick == null) {
+                    throw new NoSuchMethodException("scheduleTick(BlockPos, Fluid, int)");
+                }
+                Class<?> blockPos = levelScheduleTick.getParameterTypes()[0];
+                Class<?> fluid = levelScheduleTick.getParameterTypes()[1];
+                blockPosCtor = blockPos.getConstructor(int.class, int.class, int.class);
+                levelGetFluidState = level.getClass().getMethod("getFluidState", blockPos);
+                Class<?> fluidState = levelGetFluidState.getReturnType();
+                fluidStateIsEmpty = fluidState.getMethod("isEmpty");
+                fluidStateGetType = fluidState.getMethod("getType");
+                // Optional nicety: the fluid's own delay (water 5, lava 30).
+                // Missing lookup falls back to a constant; an early tick only
+                // re-evaluates sooner and the engine re-schedules itself.
+                try {
+                    for (Method m : fluid.getMethods()) {
+                        if ("getTickDelay".equals(m.getName())
+                                && m.getParameterCount() == 1
+                                && m.getParameterTypes()[0].isInstance(level)) {
+                            fluidGetTickDelay = m;
+                            break;
+                        }
+                    }
+                } catch (RuntimeException ignored) {
+                    fluidGetTickDelay = null;
+                }
+                available = true;
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                available = false;
+                LOG.log(Level.WARNING, "FluidTickScheduler unavailable; rolled-back fluids "
+                        + "will not re-flow until an external block update: " + ex);
+            }
+            initialized = true;
+        }
+    }
+
+    /**
+     * Start a pass for one chunk's writes. Call on the MAIN thread, after
+     * the chunk's palette writes finished. Returns a no-op pass when the
+     * reflection handles are unavailable.
+     */
+    public static Pass begin(World world) {
+        init(world);
+        if (!available) {
+            return Pass.NOOP;
+        }
+        try {
+            return new Pass(craftWorldGetHandle.invoke(world));
+        } catch (ReflectiveOperationException | RuntimeException ex) {
+            return Pass.NOOP;
+        }
+    }
+
+    /** Single-cell convenience for the non-batched apply path. */
+    public static void touchSingle(World world, int x, int y, int z) {
+        begin(world).touch(x, y, z);
+    }
+
+    /** One post-write pass; dedupes scheduling within its lifetime. */
+    public static final class Pass {
+
+        static final Pass NOOP = new Pass(null);
+
+        private final Object level;
+        private final Set<Long> visited;
+
+        private Pass(Object level) {
+            this.level = level;
+            this.visited = level == null ? null : new HashSet<>();
+        }
+
+        /**
+         * Consider one written cell: the cell itself plus its six
+         * orthogonal neighbors. Any fluid (including waterlogged
+         * blocks) gets a scheduled fluid tick.
+         */
+        public void touch(int x, int y, int z) {
+            if (level == null) {
+                return;
+            }
+            consider(x, y, z);
+            consider(x + 1, y, z);
+            consider(x - 1, y, z);
+            consider(x, y + 1, z);
+            consider(x, y - 1, z);
+            consider(x, y, z + 1);
+            consider(x, y, z - 1);
+        }
+
+        private void consider(int x, int y, int z) {
+            // Sections span the full build height either way; vanilla
+            // getFluidState returns the empty state out of bounds.
+            long key = (((long) x & 0x3FFFFFFL) << 38) | (((long) z & 0x3FFFFFFL) << 12) | (y & 0xFFFL);
+            if (!visited.add(key)) {
+                return;
+            }
+            try {
+                Object pos = blockPosCtor.newInstance(x, y, z);
+                Object fluidState = levelGetFluidState.invoke(level, pos);
+                if ((boolean) fluidStateIsEmpty.invoke(fluidState)) {
+                    return;
+                }
+                Object fluid = fluidStateGetType.invoke(fluidState);
+                int delay = DEFAULT_DELAY_TICKS;
+                if (fluidGetTickDelay != null) {
+                    try {
+                        delay = (int) fluidGetTickDelay.invoke(fluid, level);
+                    } catch (ReflectiveOperationException | RuntimeException ignored) {
+                        // keep the fallback delay
+                    }
+                }
+                levelScheduleTick.invoke(level, pos, fluid, delay);
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                // Best-effort per cell: a missed tick means that one cell
+                // keeps the pre-#270 behavior (fixed by any block update).
+                LOG.log(Level.FINE, "Fluid tick scheduling failed at "
+                        + x + "," + y + "," + z, ex);
+            }
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FluidTickSchedulerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/util/FluidTickSchedulerTest.java
@@ -1,0 +1,29 @@
+package net.medievalrp.spyglass.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.World;
+import org.junit.jupiter.api.Test;
+
+/**
+ * FluidTickScheduler (#270) is reflective NMS, so its behavior on a live
+ * server is covered by in-game verification; what unit tests can and
+ * must pin is the degradation contract: when the reflection handles are
+ * unavailable (as here, where the World is a mock without getHandle),
+ * every pass is a silent no-op - the pre-#270 behavior - and never
+ * throws into the rollback apply path.
+ */
+class FluidTickSchedulerTest {
+
+    @Test
+    void unavailableReflectionDegradesToNoOpWithoutThrowing() {
+        World world = mock(World.class);
+        assertThatCode(() -> {
+            FluidTickScheduler.Pass pass = FluidTickScheduler.begin(world);
+            pass.touch(0, 64, 0);
+            pass.touch(0, -64, 0);
+            FluidTickScheduler.touchSingle(world, 1, 64, 1);
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Fixes #270.

## What

- New `FluidTickScheduler` (plugin/util), the fluid analogue of `ChunkRelighter`: after each chunk's writes land (sync, parallel, and columnar paths, plus the non-batched `applyBlockReplace`), every written cell and its six orthogonal neighbors are checked and each fluid found gets a scheduled fluid tick. The neighbor check covers the one-block shell just outside the rolled area, which was never notified either.
- Scoped strictly to fluids: scheduling a tick triggers nothing immediately and never touches `Block.onPlace`, so the falling-block suppression `ChunkDirectWriter` exists for is untouched. Cost is seven cheap fluid-state reads per written cell; a dirt-only rollback schedules nothing.
- COMMANDS.md documents the semantics: fluids **re-flow to equilibrium**, they are not replayed (flow was never logged, deliberately).

## The reflection trap this surfaced

Paper's plugin remapper rewrites reflective string constants for spigot-mapped plugins, and spigot's `material.Fluid` maps to Mojang's `FluidState` - a `Class.forName` lookup silently resolves the wrong class and the `scheduleTick(BlockPos, Fluid, int)` lookup fails. The scheduler therefore derives every class from the live object graph (method scans by name and shape), the same philosophy as `ChunkDirectWriter`. Degradation contract: on any lookup failure it no-ops with one WARN (the pre-#270 behavior).

## Verification

- Live, on an isolated throwaway Paper 1.21.8 (per the workflow, not the shared dev server), seeded records + real `/sg rollback`:
  - restored `water[level=2]` with no source **drained to air on its own** within ticks (was: frozen forever),
  - a dam rolled back to air beside a contained source **filled with water on its own** (was: dry forever),
  - the source itself untouched; no scheduler warnings in the log.
- Unit test pins the degradation contract (mock World without `getHandle` -> silent no-op, never throws into the apply path).

`./gradlew check` green.