### PR TITLE
fix(query): container-aware block: filter (#263)

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseFieldMapper.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseFieldMapper.java
@@ -56,7 +56,13 @@ final class ClickHouseFieldMapper {
             // JoinRecord IP — a flat column on the events table; previously
             // omitted so ip:1.2.3.4 raised UnsupportedPredicateException
             // with a misleading "BSON blob" message.
-            Map.entry("address", "address"));
+            Map.entry("address", "address"),
+            // Container transaction's own material (#263): a nullable
+            // LowCardinality column, written since the schema's first
+            // container support but unreachable by any filter until the
+            // container-aware b: predicate. NULL on non-container rows,
+            // which the predicate's Exists guards key on.
+            Map.entry("containerType", "container_type"));
 
     private ClickHouseFieldMapper() {
     }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -614,12 +614,17 @@ public final class MariaDbRecordStore implements RecordStore {
         return runQuery(request, false);
     }
 
-    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
-        List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
-        String where;
-        List<QueryPredicate> residual = List.of();
+    /** SQL for the pushable predicates plus the in-memory residual rest. */
+    private record SqlSplit(String where, List<QueryPredicate> residual) {
+    }
+
+    // Push what translates, post-filter the rest through PredicateEvaluator.
+    // Shared by the query, page, and rollback-stream paths so an unpushable
+    // predicate (e.g. the container-aware b: filter, #263) degrades to a
+    // slower scan everywhere instead of throwing on some paths.
+    private SqlSplit splitTranslate(List<QueryPredicate> predicates) {
         try {
-            where = predicateToSql.translate(predicates);
+            return new SqlSplit(predicateToSql.translate(predicates), List.of());
         } catch (MariaDbPredicateToSql.UnsupportedPredicateException unsupported) {
             List<QueryPredicate> pushable = new ArrayList<>();
             List<QueryPredicate> inMemory = new ArrayList<>();
@@ -631,9 +636,14 @@ public final class MariaDbRecordStore implements RecordStore {
                     inMemory.add(predicate);
                 }
             }
-            residual = inMemory;
-            where = predicateToSql.translate(pushable);
+            return new SqlSplit(predicateToSql.translate(pushable), inMemory);
         }
+    }
+
+    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        String where = split.where();
+        List<QueryPredicate> residual = split.residual();
         boolean postFilter = !residual.isEmpty();
         boolean hydrate = includeHeavy || postFilter;
         where = appendNoChat(where, request);
@@ -678,7 +688,8 @@ public final class MariaDbRecordStore implements RecordStore {
         // Generic keyset page over seq - all event types, full decode. The
         // lean, rollbackable-filtered path is streamRollbackEffects below.
         boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
-        String where = appendNoChat(predicateToSql.translate(new ArrayList<>(request.predicates())), request);
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        String where = appendNoChat(split.where(), request);
         where = appendKeyset(where, cursor, newestFirst);
 
         String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
@@ -686,14 +697,25 @@ public final class MariaDbRecordStore implements RecordStore {
                 + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
                 + " LIMIT " + pageSize;
 
+        // Under a residual filter a page may come back short; the cursor
+        // still advances over every SCANNED row, so paging terminates.
+        int scanned = 0;
+        EventRecord lastScanned = null;
         List<EventRecord> records = new ArrayList<>(Math.min(pageSize, 4096));
         Connection conn = borrow();
         try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
             while (rs.next()) {
                 EventRecord record = decodeRow(rs, true);
-                if (record != null) {
-                    records.add(record);
+                if (record == null) {
+                    continue;
                 }
+                scanned++;
+                lastScanned = record;
+                if (!split.residual().isEmpty()
+                        && !PredicateEvaluator.matchesAll(split.residual(), record)) {
+                    continue;
+                }
+                records.add(record);
             }
         } catch (SQLException ex) {
             throw new RuntimeException("MariaDB paged query failed: " + ex.getMessage(), ex);
@@ -701,8 +723,8 @@ public final class MariaDbRecordStore implements RecordStore {
             giveBack(conn);
         }
         QueryPage.Cursor next = null;
-        if (records.size() == pageSize) {
-            EventRecord last = records.get(records.size() - 1);
+        if (scanned == pageSize && lastScanned != null) {
+            EventRecord last = lastScanned;
             if (last.occurred() != null && last.id() != null) {
                 next = new QueryPage.Cursor(last.occurred(), last.id());
             }
@@ -723,8 +745,16 @@ public final class MariaDbRecordStore implements RecordStore {
         // block) decodes.
         String blockColumn = rollback ? "orig_block" : "new_block";
         boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
-        String where = predicateToSql.translate(new ArrayList<>(request.predicates()));
-        where = appendAnd(where, rollbackableFilter());
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        if (!split.residual().isEmpty()) {
+            // Unpushable predicate (e.g. the container-aware b: filter,
+            // #263): fall back to a full-decode scan so the residual can be
+            // evaluated. Slower than the lean path, but only queries that
+            // carry such a filter pay for it.
+            return streamRollbackEffectsDecoded(split, cursor, windowLimit,
+                    rollback, newestFirst, sink);
+        }
+        String where = appendAnd(split.where(), rollbackableFilter());
         where = appendKeyset(where, cursor, newestFirst);
 
         String sql = "SELECT seq, occurred, world, x, y, z, "
@@ -757,6 +787,48 @@ public final class MariaDbRecordStore implements RecordStore {
                 : null;
     }
 
+    // Residual-filtered rollback stream: full row decode so the residual
+    // evaluates against real records; rows the residual rejects are simply
+    // omitted (they are query non-matches, not skips). The cursor advances
+    // over every scanned row, so windowing terminates as usual.
+    private QueryPage.Cursor streamRollbackEffectsDecoded(SqlSplit split, QueryPage.Cursor cursor,
+                                                          int windowLimit, boolean rollback,
+                                                          boolean newestFirst, RollbackEffectSink sink) {
+        String where = appendAnd(split.where(), rollbackableFilter());
+        where = appendKeyset(where, cursor, newestFirst);
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + windowLimit;
+
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int count = 0;
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                count++;
+                UUID id = EventIds.uuidOf(rs.getLong("seq"));
+                Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+                lastOccurred = occurred;
+                lastId = id;
+                EventRecord record = decodeRow(rs, true);
+                if (record == null
+                        || !PredicateEvaluator.matchesAll(split.residual(), record)) {
+                    continue;
+                }
+                emitEffectFromRecord(record, rollback, occurred, id, sink);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("MariaDB rollback stream failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        return (count == windowLimit && lastOccurred != null && lastId != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
     private void emitEffect(ResultSet rs, boolean rollback, Instant occurred, UUID id,
                             RollbackEffectSink sink) throws SQLException {
         byte[] blob = rs.getBytes("payload");
@@ -775,7 +847,11 @@ public final class MariaDbRecordStore implements RecordStore {
                     dictValue(blockRef), null, occurred, id);
             return;
         }
-        EventRecord record = decodeBlob(blob);
+        emitEffectFromRecord(decodeBlob(blob), rollback, occurred, id, sink);
+    }
+
+    private void emitEffectFromRecord(EventRecord record, boolean rollback, Instant occurred,
+                                      UUID id, RollbackEffectSink sink) {
         if (!(record instanceof Rollbackable rollbackable)) {
             sink.skip(occurred, id);
             return;

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateEvaluator.java
@@ -148,6 +148,17 @@ final class PredicateEvaluator {
             case "message" -> messageOf(record);
             case "commandLine" -> record instanceof CommandRecord c ? c.commandLine() : null;
             case "recipients" -> record instanceof ChatRecord c ? c.recipients() : null;
+            // The container's own material (#263). ClickHouse pushes this to
+            // its container_type column and Mongo to the BSON field; SQLite
+            // and MariaDB fold it into the blob, so the container-aware b:
+            // predicate lands here as a residual filter. Null on everything
+            // that is not a container transaction, which is what the b:
+            // predicate's Exists guard keys on.
+            case "containerType" -> switch (record) {
+                case ContainerDepositRecord c -> c.containerType();
+                case ContainerWithdrawRecord w -> w.containerType();
+                default -> null;
+            };
             default -> itemPathValue(record, field);
         };
     }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToBson.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/PredicateToBson.java
@@ -25,7 +25,12 @@ final class PredicateToBson {
             case QueryPredicate.In in -> Filters.in(in.field(), new ArrayList<>(in.values()));
             case QueryPredicate.Range range -> translateRange(range);
             case QueryPredicate.Exists exists -> Filters.exists(exists.field(), exists.expected());
-            case QueryPredicate.Not not -> Filters.not(translate(not.predicate()));
+            // $nor, not Filters.not: a top-level $not is rejected by the
+            // server for compound children ("unknown top level operator:
+            // $not") - first hit by the container-aware b: exclude (#263),
+            // whose Not wraps an Or. A single-clause $nor is NOT for every
+            // shape, simple or compound.
+            case QueryPredicate.Not not -> Filters.nor(translate(not.predicate()));
             case QueryPredicate.And and -> Filters.and(and.predicates().stream().map(this::translate).toList());
             case QueryPredicate.Or or -> Filters.or(or.predicates().stream().map(this::translate).toList());
         };

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -543,12 +543,17 @@ public final class SqliteRecordStore implements RecordStore {
         return runQuery(request, false);
     }
 
-    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
-        List<QueryPredicate> predicates = new ArrayList<>(request.predicates());
-        String where;
-        List<QueryPredicate> residual = List.of();
+    /** SQL for the pushable predicates plus the in-memory residual rest. */
+    private record SqlSplit(String where, List<QueryPredicate> residual) {
+    }
+
+    // Push what translates, post-filter the rest through PredicateEvaluator.
+    // Shared by the query, page, and rollback-stream paths so an unpushable
+    // predicate (e.g. the container-aware b: filter, #263) degrades to a
+    // slower scan everywhere instead of throwing on some paths.
+    private SqlSplit splitTranslate(List<QueryPredicate> predicates) {
         try {
-            where = predicateToSql.translate(predicates);
+            return new SqlSplit(predicateToSql.translate(predicates), List.of());
         } catch (SqlitePredicateToSql.UnsupportedPredicateException unsupported) {
             List<QueryPredicate> pushable = new ArrayList<>();
             List<QueryPredicate> inMemory = new ArrayList<>();
@@ -560,9 +565,14 @@ public final class SqliteRecordStore implements RecordStore {
                     inMemory.add(predicate);
                 }
             }
-            residual = inMemory;
-            where = predicateToSql.translate(pushable);
+            return new SqlSplit(predicateToSql.translate(pushable), inMemory);
         }
+    }
+
+    private QueryResult runQuery(QueryRequest request, boolean includeHeavy) {
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        String where = split.where();
+        List<QueryPredicate> residual = split.residual();
         boolean postFilter = !residual.isEmpty();
         boolean hydrate = includeHeavy || postFilter;
         where = appendNoChat(where, request);
@@ -607,7 +617,8 @@ public final class SqliteRecordStore implements RecordStore {
         // Generic keyset page over seq - all event types, full decode. The
         // lean, rollbackable-filtered path is streamRollbackEffects below.
         boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
-        String where = appendNoChat(predicateToSql.translate(new ArrayList<>(request.predicates())), request);
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        String where = appendNoChat(split.where(), request);
         where = appendKeyset(where, cursor, newestFirst);
 
         String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
@@ -615,14 +626,25 @@ public final class SqliteRecordStore implements RecordStore {
                 + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
                 + " LIMIT " + pageSize;
 
+        // Under a residual filter a page may come back short; the cursor
+        // still advances over every SCANNED row, so paging terminates.
+        int scanned = 0;
+        EventRecord lastScanned = null;
         List<EventRecord> records = new ArrayList<>(Math.min(pageSize, 4096));
         Connection conn = borrow();
         try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
             while (rs.next()) {
                 EventRecord record = decodeRow(rs, true);
-                if (record != null) {
-                    records.add(record);
+                if (record == null) {
+                    continue;
                 }
+                scanned++;
+                lastScanned = record;
+                if (!split.residual().isEmpty()
+                        && !PredicateEvaluator.matchesAll(split.residual(), record)) {
+                    continue;
+                }
+                records.add(record);
             }
         } catch (SQLException ex) {
             throw new RuntimeException("SQLite paged query failed: " + ex.getMessage(), ex);
@@ -630,8 +652,8 @@ public final class SqliteRecordStore implements RecordStore {
             giveBack(conn);
         }
         QueryPage.Cursor next = null;
-        if (records.size() == pageSize) {
-            EventRecord last = records.get(records.size() - 1);
+        if (scanned == pageSize && lastScanned != null) {
+            EventRecord last = lastScanned;
             if (last.occurred() != null && last.id() != null) {
                 next = new QueryPage.Cursor(last.occurred(), last.id());
             }
@@ -651,8 +673,16 @@ public final class SqliteRecordStore implements RecordStore {
         // (container / entity / complex block) decodes.
         String blockColumn = rollback ? "orig_block" : "new_block";
         boolean newestFirst = request.sort() != Sort.OLDEST_FIRST;
-        String where = predicateToSql.translate(new ArrayList<>(request.predicates()));
-        where = appendAnd(where, rollbackableFilter());
+        SqlSplit split = splitTranslate(new ArrayList<>(request.predicates()));
+        if (!split.residual().isEmpty()) {
+            // Unpushable predicate (e.g. the container-aware b: filter,
+            // #263): fall back to a full-decode scan so the residual can be
+            // evaluated. Slower than the lean path, but only queries that
+            // carry such a filter pay for it.
+            return streamRollbackEffectsDecoded(split, cursor, windowLimit,
+                    rollback, newestFirst, sink);
+        }
+        String where = appendAnd(split.where(), rollbackableFilter());
         where = appendKeyset(where, cursor, newestFirst);
 
         String sql = "SELECT seq, occurred, world, x, y, z, "
@@ -685,6 +715,48 @@ public final class SqliteRecordStore implements RecordStore {
                 : null;
     }
 
+    // Residual-filtered rollback stream: full row decode so the residual
+    // evaluates against real records; rows the residual rejects are simply
+    // omitted (they are query non-matches, not skips). The cursor advances
+    // over every scanned row, so windowing terminates as usual.
+    private QueryPage.Cursor streamRollbackEffectsDecoded(SqlSplit split, QueryPage.Cursor cursor,
+                                                          int windowLimit, boolean rollback,
+                                                          boolean newestFirst, RollbackEffectSink sink) {
+        String where = appendAnd(split.where(), rollbackableFilter());
+        where = appendKeyset(where, cursor, newestFirst);
+        String sql = "SELECT " + DECODE_COLUMNS + " FROM records"
+                + (where.isEmpty() ? "" : " WHERE " + where)
+                + " ORDER BY seq " + (newestFirst ? "DESC" : "ASC")
+                + " LIMIT " + windowLimit;
+
+        Instant lastOccurred = null;
+        UUID lastId = null;
+        int count = 0;
+        Connection conn = borrow();
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                count++;
+                UUID id = EventIds.uuidOf(rs.getLong("seq"));
+                Instant occurred = Instant.ofEpochSecond(rs.getLong("occurred"));
+                lastOccurred = occurred;
+                lastId = id;
+                EventRecord record = decodeRow(rs, true);
+                if (record == null
+                        || !PredicateEvaluator.matchesAll(split.residual(), record)) {
+                    continue;
+                }
+                emitEffectFromRecord(record, rollback, occurred, id, sink);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("SQLite rollback stream failed: " + ex.getMessage(), ex);
+        } finally {
+            giveBack(conn);
+        }
+        return (count == windowLimit && lastOccurred != null && lastId != null)
+                ? new QueryPage.Cursor(lastOccurred, lastId)
+                : null;
+    }
+
     private void emitEffect(ResultSet rs, boolean rollback, Instant occurred, UUID id,
                             RollbackEffectSink sink) throws SQLException {
         byte[] blob = rs.getBytes("blob");
@@ -703,7 +775,11 @@ public final class SqliteRecordStore implements RecordStore {
                     dictValue(blockRef), null, occurred, id);
             return;
         }
-        EventRecord record = decodeBlob(blob);
+        emitEffectFromRecord(decodeBlob(blob), rollback, occurred, id, sink);
+    }
+
+    private void emitEffectFromRecord(EventRecord record, boolean rollback, Instant occurred,
+                                      UUID id, RollbackEffectSink sink) {
         if (!(record instanceof Rollbackable rollbackable)) {
             sink.skip(occurred, id);
             return;

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ContainerAwareBlockFilterTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ContainerAwareBlockFilterTest.java
@@ -1,0 +1,117 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for #263: {@code block:X} means the BLOCK. On container
+ * transactions the record's {@code target} is the moved item; the container's
+ * own material lives in {@code containerType}. Before the fix, {@code b:} was
+ * a target-only filter - identical to {@code i:} - so {@code block:!chest}
+ * still rolled back every deposit inside a chest, and {@code block:chest}
+ * matched a chest ITEM inside a barrel while missing the chest's own
+ * transactions. These tests pin the container-aware predicate's semantics in
+ * the evaluator, which is also the SQLite/MariaDB residual path.
+ */
+class ContainerAwareBlockFilterTest {
+
+    private static final UUID WORLD = UUID.fromString("77777777-7777-7777-7777-777777777777");
+    private static final UUID GRIEFER = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    // Relative, never a wall-clock date: ClickHouse enforces expiry
+    // eagerly, so a hardcoded expiry turns rows born-expired once the
+    // calendar passes it (the ClickHouseSynthesisParityIT lesson).
+    private static final Instant WHEN = Instant.now().minusSeconds(3600);
+
+    /** Mirrors BlockParam.membership (#263) - the shape b:X compiles to. */
+    static QueryPredicate blockShape(String name) {
+        return new QueryPredicate.Or(List.of(
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", true),
+                        new QueryPredicate.Eq("containerType", name))),
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", false),
+                        new QueryPredicate.Eq("target", name)))));
+    }
+
+    static ContainerDepositRecord deposit(String itemTarget, String containerType, int x) {
+        return new ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", WHEN, WHEN.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", itemTarget, containerType, 3, 64,
+                null, new StoredItem(3, itemTarget, "minecraft:" + itemTarget.toLowerCase()));
+    }
+
+    static BlockPlaceRecord place(Material material, int x) {
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot placed = new BlockSnapshot(material,
+                "minecraft:" + material.name().toLowerCase(java.util.Locale.ROOT),
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockPlaceRecord(UUID.randomUUID(), "place",
+                WHEN, WHEN.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", material.name(), air, placed);
+    }
+
+    private static boolean matches(QueryPredicate predicate, EventRecord record) {
+        return PredicateEvaluator.matchesAll(List.of(predicate), record);
+    }
+
+    @Test
+    void blockChestFindsTheChestsOwnTransactionsAndBlocks() {
+        QueryPredicate chest = blockShape("CHEST");
+        assertThat(matches(chest, deposit("DIAMOND", "CHEST", 1)))
+                .as("a deposit INTO a chest is a chest event")
+                .isTrue();
+        assertThat(matches(chest, place(Material.CHEST, 3)))
+                .as("a placed chest block is a chest event")
+                .isTrue();
+    }
+
+    @Test
+    void blockChestDoesNotMatchAChestItemInsideABarrel() {
+        assertThat(matches(blockShape("CHEST"), deposit("CHEST", "BARREL", 2)))
+                .as("the moved ITEM being a chest does not make it a chest event")
+                .isFalse();
+    }
+
+    @Test
+    void blockNotChestExcludesTheChestsTransactionsAndKeepsEverythingElse() {
+        QueryPredicate notChest = new QueryPredicate.Not(blockShape("CHEST"));
+        assertThat(matches(notChest, deposit("DIAMOND", "CHEST", 1)))
+                .as("block:!chest excludes deposits into chests - the #263 report")
+                .isFalse();
+        assertThat(matches(notChest, place(Material.CHEST, 3))).isFalse();
+        assertThat(matches(notChest, deposit("CHEST", "BARREL", 2)))
+                .as("a chest ITEM in a barrel is not a chest event")
+                .isTrue();
+        assertThat(matches(notChest, place(Material.DIRT, 4)))
+                .as("plain block rows survive the exclusion")
+                .isTrue();
+    }
+
+    @Test
+    void itemFilterStaysOnTarget() {
+        // i:chest keeps its item semantics: it finds the chest ITEM moving,
+        // wherever it moved to - b: no longer shadows it.
+        QueryPredicate itemChest = new QueryPredicate.Eq("target", "CHEST");
+        assertThat(matches(itemChest, deposit("CHEST", "BARREL", 2))).isTrue();
+        assertThat(matches(itemChest, deposit("DIAMOND", "CHEST", 1))).isFalse();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ContainerFilterPushdownIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ContainerFilterPushdownIT.java
@@ -1,0 +1,124 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * #263 pushdown parity: the container-aware b: predicate compiles fully to
+ * SQL on ClickHouse (containerType -> container_type, a nullable column)
+ * and to BSON on Mongo. The exclude direction is the three-valued-logic
+ * trap: without the Exists guards, {@code NOT(...)} evaluates to NULL for
+ * every plain block row (container_type IS NULL) and silently drops them
+ * all - the guarded shape must keep them.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ContainerFilterPushdownIT {
+
+    private ClickHouseContainer clickhouse;
+    private ClickHouseRecordStore chStore;
+    private MongoDBContainer mongo;
+    private MongoClient mongoClient;
+    private MongoRecordStore mongoStore;
+
+    @BeforeAll
+    void setup() throws Exception {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        clickhouse = new ClickHouseContainer("clickhouse/clickhouse-server:24.8-alpine");
+        clickhouse.start();
+        chStore = new ClickHouseRecordStore(
+                clickhouse.getHost(), clickhouse.getMappedPort(8123),
+                "container_filter", "event_records",
+                clickhouse.getUsername(), clickhouse.getPassword(), false);
+        mongo = new MongoDBContainer("mongo:7.0");
+        mongo.start();
+        String uri = mongo.getReplicaSetUrl();
+        mongoClient = MongoClients.create(uri);
+        mongoStore = new MongoRecordStore(uri, "IT", "EventRecords", new IndexManager());
+
+        List<EventRecord> fixtures = List.of(
+                ContainerAwareBlockFilterTest.deposit("DIAMOND", "CHEST", 1),
+                ContainerAwareBlockFilterTest.deposit("CHEST", "BARREL", 2),
+                ContainerAwareBlockFilterTest.place(Material.CHEST, 3),
+                ContainerAwareBlockFilterTest.place(Material.DIRT, 4));
+        chStore.save(fixtures);
+        mongoStore.save(fixtures);
+        // ClickHouse inserts are async; make them visible to the queries
+        // below (same as ClickHouseSynthesisParityIT).
+        chStore.client().execute("SYSTEM FLUSH ASYNC INSERT QUEUE")
+                .get(30, java.util.concurrent.TimeUnit.SECONDS).close();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (chStore != null) {
+            chStore.close();
+        }
+        if (clickhouse != null) {
+            clickhouse.stop();
+        }
+        if (mongoStore != null) {
+            mongoStore.close();
+        }
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
+    private static QueryRequest request(QueryPredicate predicate) {
+        return new QueryRequest(List.of(predicate), Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+    }
+
+    private static List<Integer> xsOf(List<EventRecord> records) {
+        return records.stream().map(r -> r.location().x()).sorted().toList();
+    }
+
+    @Test
+    void clickHousePushesTheIncludeAndExcludeDown() {
+        assertThat(chStore.query(new QueryRequest(List.of(), Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false)).records())
+                .as("all four fixtures persisted and readable")
+                .hasSize(4);
+        assertThat(xsOf(chStore.query(request(
+                ContainerAwareBlockFilterTest.blockShape("CHEST"))).records()))
+                .containsExactly(1, 3);
+        assertThat(xsOf(chStore.query(request(new QueryPredicate.Not(
+                ContainerAwareBlockFilterTest.blockShape("CHEST")))).records()))
+                .as("the NULL-guarded exclude keeps plain block rows under SQL three-valued logic")
+                .containsExactly(2, 4);
+    }
+
+    @Test
+    void mongoPushesTheIncludeAndExcludeDown() {
+        assertThat(xsOf(mongoStore.query(request(
+                ContainerAwareBlockFilterTest.blockShape("CHEST"))).records()))
+                .containsExactly(1, 3);
+        assertThat(xsOf(mongoStore.query(request(new QueryPredicate.Not(
+                ContainerAwareBlockFilterTest.blockShape("CHEST")))).records()))
+                .containsExactly(2, 4);
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateToBsonTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/PredicateToBsonTest.java
@@ -91,8 +91,18 @@ class PredicateToBsonTest {
 
     @Test
     void translatesNotWrapping() {
+        // Not renders as a single-clause $nor, never a top-level $not: the
+        // server rejects $not around compound children ("unknown top level
+        // operator"), first hit by the container-aware b: exclude (#263)
+        // whose Not wraps an Or. $nor has identical semantics for simple
+        // shapes too.
         BsonDocument doc = asBson(translator.translate(new QueryPredicate.Not(new QueryPredicate.Eq("event", "break"))));
-        assertThat(doc.toJson()).contains("$not");
+        assertThat(doc.toJson()).contains("$nor");
+        BsonDocument compound = asBson(translator.translate(new QueryPredicate.Not(
+                new QueryPredicate.Or(List.of(
+                        new QueryPredicate.Eq("event", "break"),
+                        new QueryPredicate.Eq("event", "place"))))));
+        assertThat(compound.toJson()).contains("$nor").doesNotContain("$not");
     }
 
     @Test

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteContainerFilterTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/SqliteContainerFilterTest.java
@@ -1,0 +1,110 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * #263 on the real SQLite store: the container-aware b: predicate cannot
+ * push down (containerType lives in the blob), so it must land in the
+ * residual filter on the query path AND on the rollback stream - the
+ * stream previously threw on any unpushable predicate, which would have
+ * made a b: rollback fail outright on SQLite.
+ */
+class SqliteContainerFilterTest {
+
+    @TempDir
+    Path dir;
+    private SqliteRecordStore store;
+
+    @BeforeEach
+    void open() {
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"));
+        store.save(List.of(
+                ContainerAwareBlockFilterTest.deposit("DIAMOND", "CHEST", 1),
+                ContainerAwareBlockFilterTest.deposit("CHEST", "BARREL", 2),
+                ContainerAwareBlockFilterTest.place(Material.CHEST, 3),
+                ContainerAwareBlockFilterTest.place(Material.DIRT, 4)));
+    }
+
+    @AfterEach
+    void close() {
+        store.close();
+    }
+
+    private static QueryRequest request(QueryPredicate predicate) {
+        return new QueryRequest(List.of(predicate), Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+    }
+
+    private List<Integer> xsOf(List<EventRecord> records) {
+        return records.stream().map(r -> r.location().x()).sorted().toList();
+    }
+
+    @Test
+    void queryPathResolvesTheResidualContainerFilter() {
+        List<EventRecord> chest = store.query(
+                request(ContainerAwareBlockFilterTest.blockShape("CHEST"))).records();
+        assertThat(xsOf(chest))
+                .as("b:chest = the deposit into the chest + the placed chest block")
+                .containsExactly(1, 3);
+
+        List<EventRecord> notChest = store.query(
+                request(new QueryPredicate.Not(ContainerAwareBlockFilterTest.blockShape("CHEST")))).records();
+        assertThat(xsOf(notChest))
+                .as("b:!chest = the barrel transaction + the plain dirt block")
+                .containsExactly(2, 4);
+    }
+
+    @Test
+    void rollbackStreamFallsBackToDecodedScanInsteadOfThrowing() {
+        List<Integer> emittedXs = new ArrayList<>();
+        RecordStore.RollbackEffectSink sink = new RecordStore.RollbackEffectSink() {
+            @Override
+            public void block(UUID world, int x, int y, int z, String blockData,
+                              String expectedCurrent, Instant occurred, UUID id) {
+                emittedXs.add(x);
+            }
+
+            @Override
+            public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+                emittedXs.add(switch (effect) {
+                    case RollbackEffect.BlockReplace br -> br.location().x();
+                    case RollbackEffect.ContainerSlotWrite csw -> csw.location().x();
+                    case RollbackEffect.EntitySpawn es -> es.location().x();
+                    case RollbackEffect.EntityRemove er -> er.location().x();
+                    case RollbackEffect.Custom c -> c.location() == null ? -999 : c.location().x();
+                });
+            }
+
+            @Override
+            public void skip(Instant occurred, UUID id) {
+            }
+        };
+
+        store.streamRollbackEffects(
+                request(new QueryPredicate.Not(ContainerAwareBlockFilterTest.blockShape("CHEST"))),
+                null, 1000, true, sink);
+
+        assertThat(emittedXs.stream().sorted().toList())
+                .as("the b:!chest rollback touches ONLY the barrel deposit and the dirt block; "
+                        + "the chest's deposit and the chest block never reach the sink")
+                .containsExactly(2, 4);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BlockParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/BlockParam.java
@@ -52,11 +52,32 @@ public final class BlockParam implements QueryParamHandler {
         return clauses.size() == 1 ? clauses.getFirst() : new QueryPredicate.And(clauses);
     }
 
-    private static QueryPredicate membership(List<String> names) {
-        if (names.size() == 1) {
-            return new QueryPredicate.Eq("target", names.getFirst());
-        }
-        return new QueryPredicate.In("target", names);
+    /**
+     * {@code block:X} means the BLOCK (#263). On container transactions the
+     * record's {@code target} is the moved ITEM and the container's own
+     * material lives in {@code containerType}, so a bare target match made
+     * {@code b:} an item filter (identical to {@code i:}) that could neither
+     * find nor exclude a chest's transactions - and {@code block:!chest}
+     * silently emptied the "protected" chest. Match {@code containerType}
+     * where the record has one, {@code target} otherwise.
+     *
+     * <p>Both branches carry an {@link QueryPredicate.Exists} guard: on the
+     * SQL backends {@code containerType} is a nullable column, and an
+     * unguarded {@code Not(Or(...))} evaluates to NULL for every plain block
+     * row under three-valued logic, silently dropping them from an exclude.
+     */
+    static QueryPredicate membership(List<String> names) {
+        QueryPredicate onContainer = names.size() == 1
+                ? new QueryPredicate.Eq("containerType", names.getFirst())
+                : new QueryPredicate.In("containerType", names);
+        QueryPredicate onTarget = names.size() == 1
+                ? new QueryPredicate.Eq("target", names.getFirst())
+                : new QueryPredicate.In("target", names);
+        return new QueryPredicate.Or(List.of(
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", true), onContainer)),
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", false), onTarget))));
     }
 
     @Override

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/BlockParamShapeTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/BlockParamShapeTest.java
@@ -1,0 +1,42 @@
+package net.medievalrp.spyglass.plugin.command.param;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the container-aware predicate shape b: compiles to (#263). The full
+ * parse path needs a live registry (see BlockParamTest's coverage note);
+ * membership() is pure and carries the semantics: containerType where the
+ * record has one, target otherwise, with Exists guards on BOTH branches so
+ * a Not() of the shape survives SQL three-valued logic over the nullable
+ * containerType column.
+ */
+class BlockParamShapeTest {
+
+    @Test
+    void singleMaterialCompilesToGuardedContainerAwareOr() {
+        QueryPredicate shape = BlockParam.membership(List.of("CHEST"));
+        assertThat(shape).isEqualTo(new QueryPredicate.Or(List.of(
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", true),
+                        new QueryPredicate.Eq("containerType", "CHEST"))),
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", false),
+                        new QueryPredicate.Eq("target", "CHEST"))))));
+    }
+
+    @Test
+    void multipleMaterialsUseInOnBothBranches() {
+        QueryPredicate shape = BlockParam.membership(List.of("CHEST", "BARREL"));
+        assertThat(shape).isEqualTo(new QueryPredicate.Or(List.of(
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", true),
+                        new QueryPredicate.In("containerType", List.of("CHEST", "BARREL")))),
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", false),
+                        new QueryPredicate.In("target", List.of("CHEST", "BARREL")))))));
+    }
+}


### PR DESCRIPTION
Fixes #263.

## What

`block:X` now means the BLOCK. On container transactions the record's `target` is the moved item and the container's own material lives in `containerType`, so `b:` was literally the same predicate as `i:` - `block:!chest` still reverted every deposit inside the chest it was supposed to protect, and `block:chest` matched chest ITEMS in barrels while missing the chest's own transactions.

`b:` compiles to: `Or(And(Exists(containerType), Eq(containerType,X)), And(NotExists(containerType), Eq(target,X)))`. The Exists guards on BOTH branches are load-bearing: `containerType` is a nullable column on the SQL backends, and an unguarded `Not(Or(...))` evaluates to NULL for every plain block row under three-valued logic, silently dropping them all from an exclude - the exact trap flagged in the issue. `i:` is untouched.

## Per backend

- **ClickHouse**: `containerType -> container_type` added to the field mapper; the whole shape pushes down as SQL, streams included. IT proves the 3VL exclude keeps plain block rows.
- **Mongo**: pushes natively - but this shape was the first to Not-wrap a compound, exposing that `Filters.not` renders a server-rejected top-level `$not`. `Not` now renders as single-clause `$nor` (identical semantics for all shapes).
- **SQLite / MariaDB**: `containerType` lives in the blob, so the shape lands in the residual (in-memory) filter. The rollback stream and page paths previously THREW on any unpushable predicate; both stores now share the query path's pushable/residual split, and the stream falls back to a full-decode scan - only queries carrying such a filter pay for it.

## Tests

- `ContainerAwareBlockFilterTest` (evaluator semantics: include, exclude, chest-item-in-barrel non-match, plain-row survival, i: separation)
- `SqliteContainerFilterTest` (real store: residual query + the rollback-stream fallback that used to throw)
- `ContainerFilterPushdownIT` (ClickHouse + Mongo pushdown, incl. the 3VL exclude)
- `BlockParamShapeTest` (the compiled shape; the parse path needs a live registry per BlockParamTest's standing note)

`./gradlew check` green with the store ITs running (Docker up).