### PR TITLE
fix(rollback): live-state guard for operator-excluded materials (#264)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -530,6 +530,10 @@ public final class RollbackService {
                 // effects via the object path. Both run their writes off-main
                 // and yield by tick, so TPS stays at ~20.
                 long tApply = System.nanoTime();
+                // Materials the operator excluded with block:!x - the live-
+                // state guard skips any cell whose live block is one (#264).
+                java.util.Set<String> protectedMaterials =
+                        net.medievalrp.spyglass.plugin.rollback.ExcludedMaterials.of(request.predicates());
                 RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
                 List<RollbackResult> complexResults = List.of();
                 try {
@@ -541,24 +545,28 @@ public final class RollbackService {
                         UUID worldId = worldCols.getKey();
                         java.util.concurrent.CompletableFuture<RollbackEngine.ApplyCounts> fut =
                                 new java.util.concurrent.CompletableFuture<>();
-                        support.onMainThread(() ->
+                        support.onMainThread(() -> {
+                                engine.protectMaterials(protectedMaterials);
                                 engine.applyColumnsChunked(worldId, cols, sender, support, batchSize, cancelFlag)
                                         .whenComplete((c, err) -> {
                                             if (err != null) fut.completeExceptionally(err);
                                             else fut.complete(c);
-                                        }));
+                                        });
+                        });
                         counts.add(fut.join());
                     }
                     if (!window.complex().isEmpty()) {
                         java.util.concurrent.CompletableFuture<List<RollbackResult>> fut =
                                 new java.util.concurrent.CompletableFuture<>();
                         List<RollbackEffect> complex = window.complex();
-                        support.onMainThread(() ->
+                        support.onMainThread(() -> {
+                                engine.protectMaterials(protectedMaterials);
                                 engine.applyAllChunked(complex, sender, support, batchSize, cancelFlag)
                                         .whenComplete((r, err) -> {
                                             if (err != null) fut.completeExceptionally(err);
                                             else fut.complete(r);
-                                        }));
+                                        });
+                        });
                         complexResults = fut.join();
                     }
                 } catch (java.util.concurrent.CompletionException ex) {
@@ -578,6 +586,7 @@ public final class RollbackService {
                 mergeSkip(skipCounts, "Unparseable blockdata", counts.unparseable);
                 mergeSkip(skipCounts, "invalid location", counts.invalidLocation);
                 mergeSkip(skipCounts, "Cancelled by operator", counts.cancelled);
+                mergeSkip(skipCounts, RollbackEngine.PROTECTED_SKIP, counts.protectedCells);
                 // The rare complex effects' per-cell results.
                 for (RollbackResult r : complexResults) {
                     if (r instanceof RollbackResult.Applied) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/ExcludedMaterials.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/ExcludedMaterials.java
@@ -1,0 +1,67 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Extracts the materials an operator explicitly excluded with
+ * {@code block:!x}, for the live-state guard (#264).
+ *
+ * <p>Walks the request's predicate tree: inside every {@link
+ * QueryPredicate.Not}, any {@code Eq}/{@code In} over the {@code target}
+ * or {@code containerType} fields names such a material. This covers
+ * both the historical b: shape ({@code Not(Eq(target, X))}) and the
+ * container-aware one ({@code Not(Or(And(Exists, Eq(containerType, X)),
+ * And(Exists, Eq(target, X))))}, #263) without the parser having to
+ * side-channel anything. Other params' excludes are unaffected: a:, p:,
+ * c: and e: negate different fields.
+ */
+@ApiStatus.Internal
+public final class ExcludedMaterials {
+
+    private ExcludedMaterials() {
+    }
+
+    public static Set<String> of(List<QueryPredicate> predicates) {
+        Set<String> out = new HashSet<>();
+        for (QueryPredicate predicate : predicates) {
+            collect(predicate, false, out);
+        }
+        return Set.copyOf(out);
+    }
+
+    private static void collect(QueryPredicate predicate, boolean negated, Set<String> out) {
+        switch (predicate) {
+            case QueryPredicate.Not not -> collect(not.predicate(), !negated, out);
+            case QueryPredicate.And and -> and.predicates().forEach(p -> collect(p, negated, out));
+            case QueryPredicate.Or or -> or.predicates().forEach(p -> collect(p, negated, out));
+            case QueryPredicate.Eq eq -> {
+                if (negated && isMaterialField(eq.field()) && eq.value() instanceof String s) {
+                    out.add(s);
+                }
+            }
+            case QueryPredicate.In in -> {
+                if (negated && isMaterialField(in.field())) {
+                    for (Object value : in.values()) {
+                        if (value instanceof String s) {
+                            out.add(s);
+                        }
+                    }
+                }
+            }
+            case QueryPredicate.Range range -> {
+                // ranges never name materials
+            }
+            case QueryPredicate.Exists exists -> {
+                // existence guards carry no material
+            }
+        }
+    }
+
+    private static boolean isMaterialField(String field) {
+        return "target".equals(field) || "containerType".equals(field);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.BitSet;
+import java.util.Set;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -247,10 +248,40 @@ public final class RollbackEngine {
         this.chunkTicketHolder = plugin;
     }
 
+    /** Skip message for cells the live-state guard left untouched (#264). */
+    public static final String PROTECTED_SKIP = "Live block is excluded by the query";
+
+    // Materials the operator explicitly excluded (block:!x), per job. A cell
+    // whose LIVE block is one of these is never overwritten: excluding the
+    // chest's record used to leave older same-coordinate history free to
+    // force-write the live chest back to the window's start state (#264).
+    // This is deliberately NOT the general expected-state guard that #69
+    // removed - that one skipped cells where unlogged drift (water/lava/
+    // fire) moved in after the grief, which broke grief recovery. Guarding
+    // only the operator's own exclusions cannot break that: unlogged drift
+    // is never in the set, and an operator who names a material has said
+    // "leave that material alone" in so many words. Do not widen this into
+    // a general live-state comparison; the reasoning above is why the last
+    // one was deleted.
+    //
+    // Per-job engine state, same contract as the apply-phase counters
+    // above: jobs are queue-serialized, set at the public entry points.
+    private volatile Set<String> protectedMaterials = Set.of();
+
     // Synchronous entry point for tests. Production uses applyAllChunked
     // directly so the apply loop can yield between ticks.
     public List<RollbackResult> applyAll(List<RollbackEffect> effects, CommandSender sender) {
         return applyAllChunked(effects, sender, ServiceSupport.synchronous(), Integer.MAX_VALUE).join();
+    }
+
+    /** Sets the operator's excluded materials for the next job (#264). */
+    public void protectMaterials(Set<String> materials) {
+        this.protectedMaterials = materials == null ? Set.of() : Set.copyOf(materials);
+    }
+
+    private boolean isProtectedLive(World world, int x, int y, int z) {
+        return !protectedMaterials.isEmpty()
+                && protectedMaterials.contains(world.getBlockAt(x, y, z).getType().name());
     }
 
     // -- apply-phase failsafe (#127) ------------------------------
@@ -293,6 +324,7 @@ public final class RollbackEngine {
             throw new IllegalStateException("RollbackEngine.applyAllChunked must run on the main thread.");
         }
         CompletableFuture<List<RollbackResult>> done = new CompletableFuture<>();
+        done.whenComplete((r, t) -> protectedMaterials = Set.of());
         if (effects.isEmpty()) {
             done.complete(List.of());
             return done;
@@ -580,6 +612,11 @@ public final class RollbackEngine {
                     BlockSnapshot replacement = effect.replacement();
                     BlockLocation loc = effect.location();
                     try {
+                        if (isProtectedLive(world, loc.x(), loc.y(), loc.z())) {
+                            resultArray[targetIndex] = new RollbackResult.Skipped(effect,
+                                    new RollbackReason.NotSupported(PROTECTED_SKIP));
+                            continue;
+                        }
                         BlockData bd =
                                 blockDataFor(replacement.blockData());
                         forceWriteCell(chunkCtx, world, loc.x(), loc.y(), loc.z(), bd);
@@ -730,7 +767,20 @@ public final class RollbackEngine {
                 if (salvageHook != null) {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
-                batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded));
+                // Live-state reads are main-thread only; the worker half
+                // consults the mask instead of the world (#264).
+                BitSet protectedMask = null;
+                if (!protectedMaterials.isEmpty()) {
+                    protectedMask = new BitSet(chunkEnd - cursor);
+                    for (int j = cursor; j < chunkEnd; j++) {
+                        BlockLocation loc = blockReplaceEffects.get(j).location();
+                        if (isProtectedLive(world, loc.x(), loc.y(), loc.z())) {
+                            protectedMask.set(j - cursor);
+                        }
+                    }
+                }
+                batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded,
+                        protectedMask));
                 if (!chunkLoaded) {
                     loadsThisHop++;
                 }
@@ -856,6 +906,11 @@ public final class RollbackEngine {
         for (int j = 0; j < chunkSize; j++) {
             int targetIndex = blockReplaceIndices.get(from + j);
             RollbackEffect.BlockReplace effect = blockReplaceEffects.get(from + j);
+            if (work.protectedMask != null && work.protectedMask.get(j)) {
+                resultArray[targetIndex] = new RollbackResult.Skipped(effect,
+                        new RollbackReason.NotSupported(PROTECTED_SKIP));
+                continue;
+            }
             BlockData bd;
             try {
                 bd = blockDataFor(effect.replacement().blockData());
@@ -963,11 +1018,13 @@ public final class RollbackEngine {
         final int chunkEnd;
         final ChunkDirectWriter.ChunkContext ctx;
         final boolean ticketAdded;
+        final BitSet protectedMask;
         volatile BlockData[] writes;
         volatile BitSet nonSimpleMask;
 
         ChunkWork(World world, int cx, int cz, int from, int chunkEnd,
-                  ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded) {
+                  ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded,
+                  BitSet protectedMask) {
             this.world = world;
             this.cx = cx;
             this.cz = cz;
@@ -975,6 +1032,7 @@ public final class RollbackEngine {
             this.chunkEnd = chunkEnd;
             this.ctx = ctx;
             this.ticketAdded = ticketAdded;
+            this.protectedMask = protectedMask;
         }
     }
 
@@ -999,10 +1057,12 @@ public final class RollbackEngine {
         public long unparseable;
         public long invalidLocation;
         public long cancelled;
+        /** Cells the live-state guard left untouched (#264). Benign. */
+        public long protectedCells;
 
         /** Total skipped across every benign and error reason. */
         public long skipped() {
-            return blockChanged + unparseable + invalidLocation + cancelled;
+            return blockChanged + unparseable + invalidLocation + cancelled + protectedCells;
         }
 
         /** Skips that are real failures (parity with RollbackReason.Error). */
@@ -1016,6 +1076,7 @@ public final class RollbackEngine {
             unparseable += other.unparseable;
             invalidLocation += other.invalidLocation;
             cancelled += other.cancelled;
+            protectedCells += other.protectedCells;
         }
     }
 
@@ -1027,6 +1088,7 @@ public final class RollbackEngine {
             throw new IllegalStateException("RollbackEngine.applyColumnsChunked must run on the main thread.");
         }
         CompletableFuture<ApplyCounts> done = new CompletableFuture<>();
+        done.whenComplete((r, t) -> protectedMaterials = Set.of());
         ApplyCounts counts = new ApplyCounts();
         int total = cols.count();
         if (total == 0) {
@@ -1118,7 +1180,19 @@ public final class RollbackEngine {
                 if (salvageHook != null) {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
-                batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded));
+                // Live-state reads are main-thread only; the worker half
+                // consults the mask instead of the world (#264).
+                BitSet protectedMask = null;
+                if (!protectedMaterials.isEmpty()) {
+                    protectedMask = new BitSet(rangeEnd - cursor);
+                    for (int k = cursor; k < rangeEnd; k++) {
+                        int cellIdx = order[k];
+                        if (isProtectedLive(world, cols.x(cellIdx), cols.y(cellIdx), cols.z(cellIdx))) {
+                            protectedMask.set(k - cursor);
+                        }
+                    }
+                }
+                batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded, protectedMask));
                 if (!chunkLoaded) {
                     loadsThisHop++;
                 }
@@ -1179,6 +1253,7 @@ public final class RollbackEngine {
                     counts.applied += cc.applied;
                     counts.blockChanged += cc.blockChanged;
                     counts.unparseable += cc.unparseable;
+                    counts.protectedCells += cc.protectedCells;
                 } catch (Throwable t) {
                     // finishChunk / onChunkWritten threw; record the failure and
                     // keep cleaning up the rest of the batch (#127).
@@ -1255,7 +1330,12 @@ public final class RollbackEngine {
         long applied = 0;
         long changed = 0;
         long unparse = 0;
+        long protectedCount = 0;
         for (int k = cc.from; k < cc.rangeEnd; k++) {
+            if (cc.protectedMask != null && cc.protectedMask.get(k - cc.from)) {
+                protectedCount++;
+                continue;
+            }
             int idx = order[k];
             int x = cols.x(idx);
             int y = cols.y(idx);
@@ -1276,6 +1356,7 @@ public final class RollbackEngine {
         cc.applied = applied;
         cc.blockChanged = changed;
         cc.unparseable = unparse;
+        cc.protectedCells = protectedCount;
     }
 
     // Main-thread fallback for a chunk whose prepareChunk failed: single
@@ -1283,7 +1364,12 @@ public final class RollbackEngine {
     private void writeColumnChunkMain(World world, BlockColumns cols, int[] order, ColChunk cc) {
         long applied = 0;
         long unparse = 0;
+        long protectedCount = 0;
         for (int k = cc.from; k < cc.rangeEnd; k++) {
+            if (cc.protectedMask != null && cc.protectedMask.get(k - cc.from)) {
+                protectedCount++;
+                continue;
+            }
             int idx = order[k];
             int x = cols.x(idx);
             int y = cols.y(idx);
@@ -1303,6 +1389,7 @@ public final class RollbackEngine {
         }
         cc.applied = applied;
         cc.unparseable = unparse;
+        cc.protectedCells = protectedCount;
     }
 
     // One chunk's columnar work unit: the [from, rangeEnd) slice of the
@@ -1315,16 +1402,20 @@ public final class RollbackEngine {
         final int rangeEnd;
         final ChunkDirectWriter.ChunkContext ctx;
         final boolean ticketAdded;
+        final BitSet protectedMask;
         volatile long applied;
         volatile long blockChanged;
         volatile long unparseable;
+        volatile long protectedCells;
 
         ColChunk(int cx, int cz, int from, int rangeEnd,
-                 ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded) {
+                 ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded,
+                 BitSet protectedMask) {
             this.cx = cx;
             this.cz = cz;
             this.from = from;
             this.rangeEnd = rangeEnd;
+            this.protectedMask = protectedMask;
             this.ctx = ctx;
             this.ticketAdded = ticketAdded;
         }
@@ -1697,6 +1788,9 @@ public final class RollbackEngine {
             return new RollbackResult.Skipped(effect, new RollbackReason.InvalidLocation(effect.location()));
         }
 
+        if (isProtectedLive(world.get(), effect.location().x(), effect.location().y(), effect.location().z())) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(PROTECTED_SKIP));
+        }
         // Force-overwrite via applySnapshot (the Bukkit slow path) — same
         // contract as forceWriteCell.
         Block block = world.get().getBlockAt(effect.location().x(), effect.location().y(), effect.location().z());

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ExcludedMaterialsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ExcludedMaterialsTest.java
@@ -1,0 +1,58 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #264: the live-state guard needs the materials the operator excluded
+ * with block:!x. The extraction walks Not subtrees for Eq/In over the
+ * target/containerType fields, so it reads both the historical b: shape
+ * and the container-aware #263 shape, and ignores every other param's
+ * negations.
+ */
+class ExcludedMaterialsTest {
+
+    @Test
+    void readsTheHistoricalTargetOnlyShape() {
+        assertThat(ExcludedMaterials.of(List.of(
+                new QueryPredicate.Not(new QueryPredicate.Eq("target", "CHEST")))))
+                .containsExactly("CHEST");
+        assertThat(ExcludedMaterials.of(List.of(
+                new QueryPredicate.Not(new QueryPredicate.In("target", List.of("CHEST", "BARREL"))))))
+                .containsExactlyInAnyOrder("CHEST", "BARREL");
+    }
+
+    @Test
+    void readsTheContainerAwareShape() {
+        QueryPredicate shape = new QueryPredicate.Not(new QueryPredicate.Or(List.of(
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", true),
+                        new QueryPredicate.Eq("containerType", "CHEST"))),
+                new QueryPredicate.And(List.of(
+                        new QueryPredicate.Exists("containerType", false),
+                        new QueryPredicate.Eq("target", "CHEST"))))));
+        assertThat(ExcludedMaterials.of(List.of(shape))).containsExactly("CHEST");
+    }
+
+    @Test
+    void ignoresIncludesAndOtherParamsNegations() {
+        assertThat(ExcludedMaterials.of(List.of(
+                new QueryPredicate.Eq("target", "CHEST"),
+                new QueryPredicate.Not(new QueryPredicate.Eq("event", "PLACE")),
+                new QueryPredicate.Not(new QueryPredicate.Eq("source.playerId", "someone")),
+                new QueryPredicate.Range("occurred", 1L, 2L))))
+                .isEmpty();
+    }
+
+    @Test
+    void mixedIncludeExcludeOnlyYieldsTheExcludes() {
+        // b:dirt,!chest compiles to And(include(dirt), Not(exclude(chest))).
+        assertThat(ExcludedMaterials.of(List.of(new QueryPredicate.And(List.of(
+                new QueryPredicate.Eq("target", "DIRT"),
+                new QueryPredicate.Not(new QueryPredicate.Eq("target", "CHEST")))))))
+                .containsExactly("CHEST");
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ProtectedLiveGuardTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ProtectedLiveGuardTest.java
@@ -1,0 +1,108 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.RollbackReason;
+import net.medievalrp.spyglass.api.rollback.RollbackResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Regression tests for #264: a cell whose LIVE block is one of the
+ * operator's excluded materials is never force-overwritten. Before the
+ * fix, block:!chest only dropped the chest's RECORD; older records at
+ * the same coordinate still dragged the coordinate back to the window's
+ * start state, deleting the live chest with no drops. This is the
+ * scoped guard - the general expected-state guard #69 removed stays
+ * removed (see the comment at RollbackEngine.protectedMaterials).
+ */
+class ProtectedLiveGuardTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private static RollbackEffect.BlockReplace replaceAt(int x, Material replacement) {
+        BlockLocation loc = new BlockLocation(WORLD_ID, "world", x, 64, 0);
+        BlockSnapshot replacementSnap = new BlockSnapshot(replacement,
+                "minecraft:" + replacement.name().toLowerCase(java.util.Locale.ROOT),
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new RollbackEffect.BlockReplace(loc, null, replacementSnap);
+    }
+
+    private static World mockWorldWithLive(Material... liveByX) {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        for (int x = 0; x < liveByX.length; x++) {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(liveByX[x]);
+            BlockData data = mock(BlockData.class);
+            when(data.getAsString()).thenReturn("minecraft:" + liveByX[x].name().toLowerCase(java.util.Locale.ROOT));
+            when(block.getBlockData()).thenReturn(data);
+            when(world.getBlockAt(x, 64, 0)).thenReturn(block);
+        }
+        return world;
+    }
+
+    @Test
+    void liveExcludedMaterialIsSkippedOthersStillApply() {
+        // Coordinate 0 holds a live CHEST (excluded); coordinate 1 holds
+        // GRASS_BLOCK. Both cells have surviving history that would
+        // force-write AIR over them.
+        World world = mockWorldWithLive(Material.CHEST, Material.GRASS_BLOCK);
+        List<RollbackEffect> effects = List.of(
+                replaceAt(0, Material.AIR), replaceAt(1, Material.AIR));
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+            bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            BlockData replacementData = mock(BlockData.class);
+            bukkit.when(() -> Bukkit.createBlockData(org.mockito.ArgumentMatchers.anyString()))
+                    .thenReturn(replacementData);
+
+            RollbackEngine engine = new RollbackEngine();
+            engine.protectMaterials(Set.of("CHEST"));
+            List<RollbackResult> results = engine.applyAll(effects, mock(CommandSender.class));
+
+            assertThat(results.get(0))
+                    .as("the live excluded chest must not be overwritten")
+                    .isInstanceOf(RollbackResult.Skipped.class);
+            RollbackResult.Skipped skipped = (RollbackResult.Skipped) results.get(0);
+            assertThat(skipped.reason()).isInstanceOf(RollbackReason.NotSupported.class);
+            assertThat(((RollbackReason.NotSupported) skipped.reason()).detail())
+                    .isEqualTo(RollbackEngine.PROTECTED_SKIP);
+            assertThat(results.get(1))
+                    .as("cells whose live block is not excluded still apply")
+                    .isInstanceOf(RollbackResult.Applied.class);
+
+            // The guard is per job: the completed run reset it, so the same
+            // engine without a new protectMaterials call overwrites freely.
+            List<RollbackResult> unguarded = engine.applyAll(
+                    List.of(replaceAt(0, Material.AIR)), mock(CommandSender.class));
+            assertThat(unguarded.get(0))
+                    .as("protection never leaks into the next job")
+                    .isInstanceOf(RollbackResult.Applied.class);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #264.

## What

An exclusion now protects the COORDINATE, not just the record. `block:!chest` used to drop the chest's record while older same-coordinate history rolled the cell back to the window's start state - force-deleting the live chest (no drops, contents only in salvage). The engine now skips any cell whose **live** block is one of the operator's explicitly excluded materials.

- Extraction: `ExcludedMaterials.of(predicates)` walks Not subtrees for Eq/In over `target`/`containerType` - reads both the historical b: shape and #263's container-aware shape, with no parser side-channel and no conflict with the #263 PR.
- Guard on every apply path: sync loop (direct), parallel + columnar (a main-thread resolve mask, since live-state reads are main-only; workers consult the mask), and the object-path leftovers. Per-job engine state with the same serialized-jobs contract as the existing apply-phase counters, reset on job completion.
- Skipped cells surface in the operator summary under `Live block is excluded by the query` and count as benign skips (reusing `NotSupported` - no API change).

## Why this does not resurrect #69

The general expected-state guard was removed because unlogged drift (water/lava/fire) into a griefed area made cells skip and broke grief recovery. This guard is scoped to materials the operator NAMED in an exclusion - drift is never in that set. The field comment documents the distinction so the next reader does not delete it for the old reason.

## Verification

- `ExcludedMaterialsTest` (both predicate shapes, other params' negations ignored)
- `ProtectedLiveGuardTest` (engine: excluded live chest skips with the message, unexcluded cell applies, protection resets between jobs)
- **Live, isolated throwaway Paper 1.21.8**: seeded the issue's exact three-record history under a real chest with contents, ran `/sg rollback t:1h b:!chest` - the chest and its diamonds survive, and an unprotected control dirt column still rolls back (`1 applied`).

`./gradlew check` green.