### PR TITLE
fix(audit): rolled entries name the destroyed block and cover containers (#265, #269)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -112,6 +112,10 @@ public final class EventCatalog {
         // recorder queue on big rollbacks).
         m.put("rolled-place", BlockUseRecord.class);
         m.put("rolled-break", BlockUseRecord.class);
+        // Synthesized-only (#265): the rolled audit of a reverted container
+        // transaction. Never persisted or emitted by a listener.
+        m.put("rolled-deposit", BlockUseRecord.class);
+        m.put("rolled-withdraw", BlockUseRecord.class);
         // One per completed rollback/restore/undo operation: the durable
         // identity the per-block rolled-* entries are synthesized from
         // at search time (#22).

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
@@ -45,7 +45,8 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class RolledSynthesis {
 
-    private static final Set<String> ROLLED_EVENTS = Set.of("rolled-place", "rolled-break");
+    private static final Set<String> ROLLED_EVENTS = Set.of(
+            "rolled-place", "rolled-break", "rolled-deposit", "rolled-withdraw");
     // Ops are rare (an operator action each); a search window with more
     // than this many is pathological — log-free clamp, newest first.
     private static final int MAX_OPS_PER_SEARCH = 256;
@@ -222,21 +223,42 @@ public final class RolledSynthesis {
                                                   Source source, Origin origin,
                                                   EventRecord original, Rollbackable rollbackable) {
         var effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
-        if (!(effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace replace)) {
-            // Receipts only ever covered block writes; container/entity
-            // effects never emitted them.
-            return null;
-        }
-        var after = replace.replacement();
-        boolean toAir = after == null
-                || "AIR".equals(after.material() == null ? "AIR" : after.material().name());
-        String event = toAir ? "rolled-break" : "rolled-place";
-        String target = after == null || after.material() == null
-                ? "AIR" : after.material().name();
         // Deterministic id: the same op covering the same record must
         // synthesize the same identity across repeated searches.
         UUID id = UUID.nameUUIDFromBytes(
                 (op.id() + ":" + original.id()).getBytes(StandardCharsets.UTF_8));
+        if (effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite csw) {
+            // A rollback that reverted a container transaction used to leave
+            // NO audit entry in either mode (#265). Synthesize the inverse
+            // transaction: clearing a slot is rolled-withdraw of what sat
+            // there, repopulating one is rolled-deposit of what came back.
+            var placed = csw.replacement();
+            var removed = csw.expectedCurrent();
+            String event = placed == null ? "rolled-withdraw" : "rolled-deposit";
+            String target = placed != null ? placed.material()
+                    : removed != null ? removed.material() : "UNKNOWN";
+            return new BlockUseRecord(id, event, op.occurred(), op.expiresAt(),
+                    origin, source, csw.location(), op.server(), target);
+        }
+        if (!(effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace replace)) {
+            // Entity effects still have no receipt shape.
+            return null;
+        }
+        var after = replace.replacement();
+        var destroyed = replace.expectedCurrent();
+        boolean toAir = after == null
+                || "AIR".equals(after.material() == null ? "AIR" : after.material().name());
+        String event = toAir ? "rolled-break" : "rolled-place";
+        // rolled-break names what was DESTROYED, not the air that replaced
+        // it - "ROLLBACK broke AIR" identified nothing (#269). rolled-place
+        // keeps naming what was placed.
+        String target;
+        if (toAir) {
+            target = destroyed == null || destroyed.material() == null
+                    ? "AIR" : destroyed.material().name();
+        } else {
+            target = after.material() == null ? "AIR" : after.material().name();
+        }
         return new BlockUseRecord(id, event, op.occurred(), op.expiresAt(),
                 origin, source, replace.location(), op.server(), target);
     }

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledAuditRegressionTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledAuditRegressionTest.java
@@ -1,0 +1,181 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
+import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.RollbackOpRecord;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the rolled-audit gaps (#265, #269) in the default
+ * {@code synthesized} mode:
+ *
+ * <ul>
+ * <li>#265 - a rollback that reverted container transactions used to
+ *     synthesize NOTHING; it now yields rolled-withdraw / rolled-deposit
+ *     entries, searchable via {@code a:}.</li>
+ * <li>#269 - {@code rolled-break} used to name AIR (the block written),
+ *     discarding the destroyed block's identity in the same expression
+ *     that decided to call it a break; it now names what was destroyed.</li>
+ * </ul>
+ */
+class RolledAuditRegressionTest {
+
+    private static final UUID WORLD = UUID.fromString("77777777-7777-7777-7777-777777777777");
+    private static final UUID GRIEFER = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final Instant GRIEF_TIME = Instant.parse("2026-06-10T10:00:00Z");
+    private static final Instant OP_TIME = Instant.parse("2026-06-10T11:00:00Z");
+
+    private static final class MemoryStore implements RecordStore {
+        final List<EventRecord> rows = new ArrayList<>();
+
+        @Override
+        public void save(List<EventRecord> records) {
+            rows.addAll(records);
+        }
+
+        @Override
+        public QueryResult query(QueryRequest request) {
+            return new QueryResult(rows.stream()
+                    .filter(r -> PredicateEvaluator.matchesAll(request.predicates(), r))
+                    .limit(request.limit())
+                    .toList(), List.of());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static BlockSnapshot snapshot(Material material) {
+        return new BlockSnapshot(material,
+                "minecraft:" + material.name().toLowerCase(java.util.Locale.ROOT),
+                List.of(), List.of(), List.of(), List.of(), null);
+    }
+
+    private static BlockPlaceRecord placedBarrelOnAir() {
+        return new BlockPlaceRecord(UUID.randomUUID(), "place",
+                GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 2, 64, 0), "test", "BARREL",
+                snapshot(Material.AIR), snapshot(Material.BARREL));
+    }
+
+    private static ContainerDepositRecord deposit() {
+        return new ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 1, 64, 0), "test", "DIAMOND", "CHEST", 3, 64,
+                null, new StoredItem(3, "DIAMOND", "minecraft:diamond"));
+    }
+
+    private static ContainerWithdrawRecord withdraw() {
+        return new ContainerWithdrawRecord(
+                UUID.randomUUID(), "withdraw", GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 4, 64, 0), "test", "GOLD_INGOT", "CHEST", 5, 16,
+                new StoredItem(5, "GOLD_INGOT", "minecraft:gold_ingot"), null);
+    }
+
+    private static RollbackOpRecord op(QueryRequest covered) {
+        String blob = UndoReferenceBson.encodeBase64(covered, "ROLLBACK", OP_TIME,
+                List.of(new UndoReferenceBson.WorldBox(WORLD, 0, 64, 0, 10, 64, 0)), 2, 0);
+        return new RollbackOpRecord(UUID.randomUUID(), "rollback-op",
+                OP_TIME, OP_TIME.plusSeconds(86400),
+                Origin.rollback("Operator"), Source.player(UUID.randomUUID(), "Operator"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 0, 64, 0),
+                "test", "ROLLBACK", blob);
+    }
+
+    private static QueryRequest request(QueryPredicate... predicates) {
+        return new QueryRequest(List.of(predicates), Sort.NEWEST_FIRST,
+                100, EnumSet.of(Flag.NO_GROUP), false);
+    }
+
+    private static QueryRequest coveredBy(String event) {
+        return request(new QueryPredicate.Eq("source.playerId", GRIEFER),
+                new QueryPredicate.Eq("event", event));
+    }
+
+    @Test
+    void rolledBreakNamesTheDestroyedBlock() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(placedBarrelOnAir()));
+        store.save(List.of(op(coveredBy("place"))));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
+        assertThat(rolled.get(0).target())
+                .as("#269: the audit names the BARREL the rollback destroyed, not the AIR it wrote")
+                .isEqualTo("BARREL");
+    }
+
+    @Test
+    void containerRollbackSynthesizesRolledWithdraw() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(deposit()));
+        store.save(List.of(op(coveredBy("deposit"))));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled)
+                .as("#265: a rollback that reverted a deposit leaves an audit entry")
+                .hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-withdraw");
+        assertThat(rolled.get(0).target()).isEqualTo("DIAMOND");
+    }
+
+    @Test
+    void containerRestoreSynthesizesRolledDeposit() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(withdraw()));
+        store.save(List.of(op(coveredBy("withdraw"))));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event())
+                .as("rolling back a withdraw puts the stack back: rolled-deposit")
+                .isEqualTo("rolled-deposit");
+        assertThat(rolled.get(0).target()).isEqualTo("GOLD_INGOT");
+    }
+
+    @Test
+    void rolledContainerEventsAreSearchableByEventFilter() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(deposit()));
+        store.save(List.of(op(coveredBy("deposit"))));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        assertThat(synthesis.synthesize(request(
+                new QueryPredicate.Eq("event", "rolled-withdraw"))))
+                .as("a:rolled-withdraw reaches the synthesized entry")
+                .hasSize(1);
+        assertThat(synthesis.synthesize(request(
+                new QueryPredicate.Eq("event", "rolled-place"))))
+                .isEmpty();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -125,10 +125,12 @@ class RolledSynthesisTest {
         List<EventRecord> rolled = new RolledSynthesis(store)
                 .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
 
-        // Restoring a break re-applies it: the block becomes air.
+        // Restoring a break re-applies it: the block becomes air. The
+        // entry names the STONE that was re-broken, not the air that
+        // replaced it - "ROLLBACK broke AIR" identified nothing (#269).
         assertThat(rolled).hasSize(1);
         assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
-        assertThat(rolled.get(0).target()).isEqualTo("AIR");
+        assertThat(rolled.get(0).target()).isEqualTo("STONE");
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1367,7 +1367,7 @@ public final class RollbackEngine {
                     if (r instanceof RollbackResult.Applied a
                             && a.effect() instanceof RollbackEffect.BlockReplace br) {
                         rolledRecords.add(buildRollbackSourceRecord(
-                                operatorName, br.location(), br.replacement()));
+                                operatorName, br.location(), br.expectedCurrent(), br.replacement()));
                     }
                 }
                 recorder.recordAll(rolledRecords);
@@ -1567,7 +1567,8 @@ public final class RollbackEngine {
     // carrying the before/after snapshot blobs that BlockPlaceRecord
     // would, which mattered: at 150 blocks the snapshot pairs combined
     // with FAWE's write buffer were enough to tip the heap into OOM.
-    private EventRecord buildRollbackSourceRecord(String operatorName, BlockLocation location, BlockSnapshot after) {
+    private EventRecord buildRollbackSourceRecord(String operatorName, BlockLocation location,
+                                                   BlockSnapshot destroyed, BlockSnapshot after) {
         Instant occurred = support.now();
         Source source = Source.environment("ROLLBACK");
         Origin origin = Origin.rollback(operatorName);
@@ -1582,7 +1583,12 @@ public final class RollbackEngine {
         // Lowercase-hyphenated form matches shulker-open etc. and
         // dodges the case-sensitivity quirk in EventCatalog.recordClassOf.
         String event = toAir ? "rolled-break" : "rolled-place";
-        String target = (after == null ? Material.AIR : after.material()).name();
+        // rolled-break names what was DESTROYED, not the air that replaced
+        // it (#269); rolled-place keeps naming what was placed.
+        String target = toAir
+                ? (destroyed == null || destroyed.material() == null
+                        ? Material.AIR : destroyed.material()).name()
+                : after.material().name();
         return new BlockUseRecord(
                 ctx.id(), event, ctx.occurred(), ctx.expiresAt(),
                 ctx.origin(), ctx.source(), ctx.location(), ctx.server(), target);

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -369,6 +369,12 @@ events {
   # visibility; with "receipts" they are persisted rows again.
   rolled-place = { enabled = true, past-tense = "placed" }
   rolled-break = { enabled = true, past-tense = "broke" }
+  # The rolled audit of a reverted container transaction (#265):
+  # clearing a deposited stack back out is rolled-withdraw, repopulating
+  # a withdrawn one is rolled-deposit. Synthesized on read like the two
+  # above.
+  rolled-deposit = { enabled = true, past-tense = "deposited" }
+  rolled-withdraw = { enabled = true, past-tense = "withdrew" }
   # One record per completed rollback / restore / undo operation: the
   # operator, mode, and the operation's resolved query + bounding box.
   # This is what the per-block entries above are synthesized from —


### PR DESCRIPTION
Fixes the two rolled-audit gaps; closes #265 and the core of #269.

## What

- **#269**: `rolled-break` names what the rollback DESTROYED. `buildRollbackSourceRecord` (receipts mode) now receives `expectedCurrent`, and `RolledSynthesis.toRolled` (the default mode) reads it off the effect it already had. Destroying a barrel now logs `ROLLBACK broke BARREL`, not `broke AIR`.
- **#265**: container slot writes synthesize `rolled-withdraw` / `rolled-deposit` entries in the default mode - clearing a deposited stack is a withdraw, repopulating a withdrawn one is a deposit. Searchable via `a:rolled-withdraw` etc. Zero write cost (synthesized on read). EventCatalog + config.conf entries added; these names are never persisted or listener-emitted, so no codec/schema touchpoints.
- Updated `RolledSynthesisTest`'s restore expectation with justification: re-breaking STONE now names STONE (the old assertion pinned the AIR bug).

## Verified live (isolated throwaway Paper 1.21.8)

- Rollback destroying a placed barrel: `/sg search a:rolled-break` shows `= ROLLBACK broke BARREL` (was `broke AIR`).
- Rollback covering a chest deposit: `/sg search a:rolled-withdraw` shows `= ROLLBACK withdrew DIAMOND` (was empty).

## Deliberately left open on the issues

- **rolled-place over a destroyed non-air block** still names only the placed block: naming both needs a two-snapshot record shape, which is the #267-adjacent design (the OOM constraint at `buildRollbackSourceRecord` is why the lean single-target shape exists).
- **Rollbackable rolled records** (reversing a rollback via `/sg rollback a:rolled-*`): synthesized entries never enter the store, so the rollback stream cannot see them - making this work is architectural, not a record-shape tweak.
- **Receipts mode's columnar blind spot** (it logs almost nothing today) is unchanged, pending the keep-or-retire decision flagged in #265.

`./gradlew check` green.