### PR TITLE
feat(commands): /s root alias on by default (opt-out) (#279)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -2,7 +2,7 @@
 
 Full reference for every command, permission, query key, and flag. For the project overview and feature comparison, see the [README](README.md).
 
-Root command is `/spyglass`, aliased to `/sg`. Subcommands take short aliases too, so `/sg s` is `/sg search`. Every permission defaults to `op`; grant them through your permissions plugin to open them up.
+Root command is `/spyglass`, aliased to `/sg` and (on by default) the single-letter `/s`. If another plugin on your server claims `/s`, set `commands.s-alias = false` in `config.conf`; `/spyglass` and `/sg` always work. Subcommands take short aliases too, so `/sg s` is `/sg search`. Every permission defaults to `op`; grant them through your permissions plugin to open them up.
 
 ## Commands
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -34,8 +34,9 @@ public final class SpyglassCommands {
 
     // /sg is the short backend alias; /sgv on the Velocity proxy stays
     // namespace-distinct so the proxy never shadows the Paper command.
-    // /s joins when commands.s-alias is enabled in config (#250) - opt-in
-    // because single-letter roots collide with other plugins.
+    // /s joins unless commands.s-alias is disabled in config (#279, opt-out;
+    // was opt-in under #250) - an operator turns it off when another plugin
+    // on the server claims the single-letter root.
     private final List<String> rootAliases;
 
     static List<String> rootAliases(boolean sAlias) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -131,9 +131,10 @@ public record SpyglassConfig(
                 new Server(root.node("server", "name").getString("default")),
                 parseMetrics(root),
                 parseAnalytics(root),
-                // #250: /s as a third root alias, opt-in - single-letter
-                // roots collide with other plugins, so off by default.
-                new Commands(root.node("commands", "s-alias").getBoolean(false)));
+                // /s as a third root alias next to /spyglass and /sg. On by
+                // default (#279, reversing #250's opt-in); an operator whose
+                // server has another plugin claiming /s sets s-alias = false.
+                new Commands(root.node("commands", "s-alias").getBoolean(true)));
     }
 
     /**

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -230,10 +230,11 @@ tool {
 }
 
 commands {
-  # Register /s as a third root alias next to /spyglass and /sg. Off by
-  # default: single-letter commands collide with other plugins (and /s is
-  # a common shorthand for /say or social plugins), so opt in deliberately.
-  s-alias = false
+  # Register /s as a third root alias next to /spyglass and /sg. On by
+  # default. Set false if another plugin on this server claims /s (it is a
+  # common shorthand for /say or social plugins) - the /spyglass and /sg
+  # roots always work regardless.
+  s-alias = true
 }
 
 server {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/SpyglassConfigTest.java
@@ -80,13 +80,14 @@ class SpyglassConfigTest {
                 .isEqualTo(3L * 24 * 60 * 60);
     }
 
-    // #250: /s root alias is opt-in; absent key must read as disabled.
+    // #279: /s root alias is opt-out; absent key must read as enabled, an
+    // explicit false must disable it (reversing #250's opt-in default).
     @Test
-    void sAliasDefaultsOffAndReadsExplicitTrue() throws SerializationException {
+    void sAliasDefaultsOnAndReadsExplicitFalse() throws SerializationException {
         BasicConfigurationNode root = BasicConfigurationNode.root();
-        assertThat(root.node("commands", "s-alias").getBoolean(false)).isFalse();
-        root.node("commands", "s-alias").set(true);
-        assertThat(root.node("commands", "s-alias").getBoolean(false)).isTrue();
+        assertThat(root.node("commands", "s-alias").getBoolean(true)).isTrue();
+        root.node("commands", "s-alias").set(false);
+        assertThat(root.node("commands", "s-alias").getBoolean(true)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Fixes #279.

Reverses #250: `commands.s-alias` ships `true`, so `/s` is registered alongside `/spyglass` and `/sg` by default. The flag stays - an operator whose server has another plugin claiming `/s` (common for `/say` / social plugins) sets `s-alias = false`; the two longer roots always work.

Touchpoints: the config default in `SpyglassConfig` (missing key -> `true`), `config.conf` value + comment, the stale opt-in comment at the registration site, COMMANDS.md, and the config test now pins default-on + explicit-false.

## Upgrade path (found during live testing)

Existing installs have an on-disk `s-alias = false` written by the old bundled default, and an explicit config value beats the new code default - so this change only affects **fresh installs** by itself. Rolling it out to an existing server means flipping the line in its `config.conf` once (done on both local test servers already); the prod deploy runbook should include the same one-line flip. There is no way to auto-migrate without overriding genuine opt-outs, so this is deliberate.

Trade-off (accepted, per the issue): reintroduces the #250 single-letter collision exposure on multi-plugin servers; the `s-alias = false` escape hatch is the mitigation.

`./gradlew check` green.