### PR TITLE
chore(help): consolidate import entry; drop tele from help (#281)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -19,9 +19,7 @@ Root command is `/spyglass`, aliased to `/sg`. Subcommands take short aliases to
 | `/sg inventory` | `inv`, `salvage` | `spyglass.salvage` | Recover items a rollback destroyed (GUI, or a listing where there is no GUI) |
 | `/sg inventory <id>` | `inv`, `salvage` | `spyglass.salvage` | Recover a container's items by id, via command |
 | `/sg tool` | `t`, `inspect` | `spyglass.tool` | Toggle the inspection wand |
-| `/sg tele <world> <x> <y> <z>` | - | `spyglass.tele` | Teleport (used by clickable search results) |
-| `/sg import <file>` | - | `spyglass.import` | Import a CoreProtect SQLite database from `plugins/Spyglass/import/` |
-| `/sg import mysql <source>` | - | `spyglass.import` | Import a live CoreProtect MySQL database (sources defined in `import.conf`) |
+| `/sg import <file \| mysql <source>>` | - | `spyglass.import` | Import a CoreProtect database: a SQLite file from `plugins/Spyglass/import/`, or a live MySQL source defined in `import.conf` |
 | `/sg migrate <backend>` | - | `spyglass.migrate` | Copy every record from the active backend into another configured backend |
 
 ## Permissions

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/HelpService.java
@@ -29,10 +29,8 @@ public final class HelpService {
             new Entry("rbqueue", "", "List, cancel, or resume queued rollback jobs."),
             new Entry("inventory", "[id]", "Recover items a rollback destroyed (GUI where available)."),
             new Entry("stats", "", "Show ingest analytics (when enabled in config)."),
-            new Entry("import", "<file>", "Import a CoreProtect SQLite database from plugins/Spyglass/import/."),
-            new Entry("import mysql", "<source>", "Import a live CoreProtect MySQL database (sources in import.conf)."),
+            new Entry("import", "<file | mysql <source>>", "Import a CoreProtect database: a SQLite file from plugins/Spyglass/import/, or a live MySQL source from import.conf."),
             new Entry("migrate", "<backend>", "Copy all records into another configured storage backend."),
-            new Entry("tele", "<world> <x> <y> <z>", "Teleport (used by clickable search results)."),
             new Entry("version", "", "Show the Spyglass version."),
     };
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/HelpServiceTest.java
@@ -31,7 +31,7 @@ class HelpServiceTest {
                 .contains("/spyglass events");
     }
 
-    // ===== #249: every command discoverable, across pages ==============
+    // ===== #249/#281: every operator command discoverable, across pages ===
 
     @Test
     void everyRegisteredCommandAppearsAcrossThePages() {
@@ -49,11 +49,19 @@ class HelpServiceTest {
                 .contains("/spyglass rbqueue")
                 .contains("/spyglass inventory")
                 .contains("/spyglass stats")
-                .contains("/spyglass import <file>")
-                .contains("/spyglass import mysql")
+                .contains("/spyglass import")
                 .contains("/spyglass migrate")
-                .contains("/spyglass tele")
                 .contains("/spyglass version");
+        // #281: mysql is an option on the single import entry, not its own
+        // command; tele is internal (backs clickable rows) and stays out of
+        // the operator-facing help.
+        assertThat(combined)
+                .as("mysql shown as an import mode")
+                .contains("mysql <source>");
+        assertThat(combined)
+                .as("no standalone import-mysql entry, no tele entry")
+                .doesNotContain("/spyglass import mysql")
+                .doesNotContain("/spyglass tele");
     }
 
     @Test


### PR DESCRIPTION
Fixes #281.

Three help-menu cleanups (HelpService + COMMANDS.md, kept in lockstep per the HelpService header note):

- `import` and `import mysql` collapse into **one** entry showing both forms: `/spyglass import <file | mysql <source>>`.
- `tele` is dropped from the help listing - it exists only to back clickable search-result rows, operators never type it.
- `spyglass.tele` stays in the permissions table (an admin still needs to grant it for clickable teleport to work).

No behavioral change: `import mysql` and `tele` work exactly as before; only the listing changes. HelpServiceTest updated to assert the consolidated entry, that mysql shows as an import mode, and that neither a standalone import-mysql nor a tele entry appears.

`./gradlew check` green.