### PR TITLE
fix(rollback): deaths resurrect only player kills; hostiles never (#284)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EntityDeathRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EntityDeathRecord.java
@@ -41,13 +41,31 @@ public record EntityDeathRecord(
                 target, entityType, entityId, killerType, damageCause, entityNbt);
     }
 
+    /**
+     * Only a player kill is worth resurrecting (#284): environment deaths
+     * (FIRE_TICK, LAVA, SUFFOCATION, ...) resurrected en masse on any
+     * generic area rollback - one fresh-world night left 453 burned
+     * zombies waiting to come back. The Mongo and ClickHouse emitEffect
+     * mirrors apply this same rule from their killer column; keep them in
+     * lockstep with this method.
+     */
+    public boolean resurrectable() {
+        return "player".equalsIgnoreCase(killerType);
+    }
+
     @Override
     public RollbackEffect rollbackEffect() {
+        if (!resurrectable()) {
+            return null;
+        }
         return new RollbackEffect.EntitySpawn(location, entityType, entityNbt);
     }
 
     @Override
     public RollbackEffect restoreEffect() {
+        if (!resurrectable()) {
+            return null;
+        }
         return new RollbackEffect.EntityRemove(location, entityType,
                 entityId == null ? null : entityId.toString());
     }

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/rollback/Rollbackable.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/rollback/Rollbackable.java
@@ -1,8 +1,21 @@
 package net.medievalrp.spyglass.api.rollback;
 
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A record whose effects a rollback or restore can apply.
+ *
+ * <p>Either method may return {@code null}: the record declines to
+ * produce an effect in that direction and the row is skipped (it stays
+ * fully searchable - only the apply is withheld). The first user is
+ * {@link net.medievalrp.spyglass.api.event.EntityDeathRecord}, which
+ * only resurrects player kills (#284): environment deaths (a zombie
+ * burning at dawn, a bat in lava) must not come back on a generic area
+ * rollback.
+ */
 public interface Rollbackable {
 
-    RollbackEffect rollbackEffect();
+    @Nullable RollbackEffect rollbackEffect();
 
-    RollbackEffect restoreEffect();
+    @Nullable RollbackEffect restoreEffect();
 }

--- a/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EntityDeathRecordTest.java
+++ b/spyglass-api/src/test/java/net/medievalrp/spyglass/api/event/EntityDeathRecordTest.java
@@ -1,0 +1,43 @@
+package net.medievalrp.spyglass.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #284: only a player kill is resurrectable. Environment deaths (a zombie
+ * burning at dawn) decline both effect directions - they stay searchable
+ * but never come back on a rollback, and never re-remove on a restore.
+ */
+class EntityDeathRecordTest {
+
+    private static EntityDeathRecord death(String killerType) {
+        Instant now = Instant.now();
+        return new EntityDeathRecord(UUID.randomUUID(), "death", now, now.plusSeconds(60),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(UUID.randomUUID(), "world", 1, 64, 2),
+                "srv", "SHEEP", "sheep", UUID.randomUUID(), killerType, "ENTITY_ATTACK", null);
+    }
+
+    @Test
+    void playerKillsProduceEffectsInBothDirections() {
+        EntityDeathRecord record = death("player");
+        assertThat(record.resurrectable()).isTrue();
+        assertThat(record.rollbackEffect()).isInstanceOf(RollbackEffect.EntitySpawn.class);
+        assertThat(record.restoreEffect()).isInstanceOf(RollbackEffect.EntityRemove.class);
+    }
+
+    @Test
+    void environmentDeathsDeclineBothDirections() {
+        for (String killer : new String[]{"FIRE_TICK", "LAVA", "SUFFOCATION", null}) {
+            EntityDeathRecord record = death(killer);
+            assertThat(record.resurrectable()).as("killer=" + killer).isFalse();
+            assertThat(record.rollbackEffect()).as("killer=" + killer).isNull();
+            assertThat(record.restoreEffect()).as("killer=" + killer).isNull();
+        }
+    }
+}

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -209,7 +209,9 @@ public final class ClickHouseRecordStore implements RecordStore {
             "location_world_id", "location_world_name",
             "location_x", "location_y", "location_z",
             "slot", "before_item", "after_item",
-            "entity_type", "entity_id", "entity_nbt");
+            // killer_type gates death resurrection (#284): only player
+            // kills produce effects, so the stream now reads it.
+            "entity_type", "entity_id", "entity_nbt", "entity_killer_type");
     private static final List<String> LEAN_ROLLBACK_BLOCK = List.of(
             "before_material", "before_blockdata", "before_extras");
     private static final List<String> LEAN_RESTORE_BLOCK = List.of(
@@ -805,6 +807,14 @@ public final class ClickHouseRecordStore implements RecordStore {
             return;
         }
         if (clazz == EntityDeathRecord.class) {
+            // Lockstep with EntityDeathRecord.resurrectable() (#284): only a
+            // player kill produces an effect in either direction; environment
+            // deaths stay searchable but never resurrect (or re-remove).
+            String killer = row.getString("entity_killer_type");
+            if (!"player".equalsIgnoreCase(killer)) {
+                sink.skip(occurred, id);
+                return;
+            }
             BlockLocation location = readLocation(row);
             String entityType = row.getString("entity_type");
             if (rollback) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MariaDbRecordStore.java
@@ -781,6 +781,12 @@ public final class MariaDbRecordStore implements RecordStore {
             return;
         }
         RollbackEffect effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+        if (effect == null) {
+            // The record declined this direction (e.g. an environment
+            // death is never resurrected, #284) - cursor past it.
+            sink.skip(occurred, id);
+            return;
+        }
         if (effect instanceof RollbackEffect.BlockReplace br
                 && br.replacement() != null && br.replacement().simple()) {
             BlockLocation loc = br.location();

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoRecordStore.java
@@ -377,7 +377,8 @@ public final class MongoRecordStore implements RecordStore {
                 Projections.include(RecordFields.ID, RecordFields.EVENT, RecordFields.OCCURRED,
                         RecordFields.LOCATION, replacementSide,
                         RecordFields.SLOT, RecordFields.BEFORE_ITEM, RecordFields.AFTER_ITEM,
-                        RecordFields.ENTITY_TYPE, RecordFields.ENTITY_ID, RecordFields.ENTITY_NBT),
+                        RecordFields.ENTITY_TYPE, RecordFields.ENTITY_ID, RecordFields.ENTITY_NBT,
+                        RecordFields.KILLER_TYPE),
                 Projections.excludeId());
 
         Instant lastOccurred = null;
@@ -464,6 +465,16 @@ public final class MongoRecordStore implements RecordStore {
         }
 
         if (clazz == EntityDeathRecord.class) {
+            // Lockstep with EntityDeathRecord.resurrectable() (#284): only a
+            // player kill produces an effect in either direction; environment
+            // deaths stay searchable but never resurrect (or re-remove).
+            String killer = doc.containsKey(RecordFields.KILLER_TYPE)
+                    && doc.get(RecordFields.KILLER_TYPE).isString()
+                    ? doc.getString(RecordFields.KILLER_TYPE).getValue() : null;
+            if (!"player".equalsIgnoreCase(killer)) {
+                sink.skip(occurred, id);
+                return;
+            }
             BlockLocation location = readLocation(doc);
             String entityType = doc.containsKey(RecordFields.ENTITY_TYPE)
                     && doc.get(RecordFields.ENTITY_TYPE).isString()

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordFields.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordFields.java
@@ -47,6 +47,7 @@ final class RecordFields {
     static final String ENTITY_TYPE = "entityType";
     static final String ENTITY_ID = "entityId";
     static final String ENTITY_NBT = "entityNbt";
+    static final String KILLER_TYPE = "killerType";
 
     private RecordFields() {
     }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RecordStore.java
@@ -160,6 +160,12 @@ public interface RecordStore extends AutoCloseable {
             RollbackEffect effect = rollback
                     ? rollbackable.rollbackEffect()
                     : rollbackable.restoreEffect();
+            if (effect == null) {
+                // The record declined this direction (e.g. an environment
+                // death is never resurrected, #284) - cursor past it.
+                sink.skip(record.occurred(), record.id());
+                return;
+            }
             if (effect instanceof RollbackEffect.BlockReplace br
                     && br.replacement() != null && br.replacement().simple()) {
                 net.medievalrp.spyglass.api.util.BlockLocation loc = br.location();

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SqliteRecordStore.java
@@ -709,6 +709,12 @@ public final class SqliteRecordStore implements RecordStore {
             return;
         }
         RollbackEffect effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+        if (effect == null) {
+            // The record declined this direction (e.g. an environment
+            // death is never resurrected, #284) - cursor past it.
+            sink.skip(occurred, id);
+            return;
+        }
         if (effect instanceof RollbackEffect.BlockReplace br
                 && br.replacement() != null && br.replacement().simple()) {
             BlockLocation loc = br.location();

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/DeathResurrectionPushdownIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/DeathResurrectionPushdownIT.java
@@ -1,0 +1,131 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EntityDeathRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * #284 on the two stores that MIRROR the record-to-effect logic instead of
+ * calling it (their emitEffect lockstep comments): an environment death
+ * must stream as a skip, a player kill as an EntitySpawn - same rule as
+ * EntityDeathRecord.resurrectable().
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DeathResurrectionPushdownIT {
+
+    private static final UUID WORLD = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private ClickHouseContainer clickhouse;
+    private ClickHouseRecordStore chStore;
+    private MongoDBContainer mongo;
+    private MongoRecordStore mongoStore;
+
+    @BeforeAll
+    void setup() throws Exception {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        clickhouse = new ClickHouseContainer("clickhouse/clickhouse-server:24.8-alpine");
+        clickhouse.start();
+        chStore = new ClickHouseRecordStore(
+                clickhouse.getHost(), clickhouse.getMappedPort(8123),
+                "death_stream", "event_records",
+                clickhouse.getUsername(), clickhouse.getPassword(), false);
+        mongo = new MongoDBContainer("mongo:7.0");
+        mongo.start();
+        mongoStore = new MongoRecordStore(mongo.getReplicaSetUrl(), "IT", "EventRecords",
+                new IndexManager());
+
+        List<net.medievalrp.spyglass.api.event.EventRecord> fixtures = List.of(
+                death("zombie", "FIRE_TICK", 1),
+                death("sheep", "player", 2));
+        chStore.save(fixtures);
+        mongoStore.save(fixtures);
+        chStore.client().execute("SYSTEM FLUSH ASYNC INSERT QUEUE")
+                .get(30, java.util.concurrent.TimeUnit.SECONDS).close();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (chStore != null) {
+            chStore.close();
+        }
+        if (clickhouse != null) {
+            clickhouse.stop();
+        }
+        if (mongoStore != null) {
+            mongoStore.close();
+        }
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
+    private static EntityDeathRecord death(String entityType, String killer, int x) {
+        Instant now = Instant.now();
+        return new EntityDeathRecord(UUID.randomUUID(), "death", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", x, 64, 0),
+                "srv", entityType.toUpperCase(java.util.Locale.ROOT), entityType,
+                UUID.randomUUID(), killer, "ENTITY_ATTACK", null);
+    }
+
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        final List<RollbackEffect> complex = new ArrayList<>();
+        int skips;
+
+        @Override
+        public void block(UUID world, int x, int y, int z, String blockData,
+                          String expectedCurrent, Instant occurred, UUID id) {
+        }
+
+        @Override
+        public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+            complex.add(effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skips++;
+        }
+    }
+
+    private static void assertOnlyThePlayerKillEmits(RecordStore store) {
+        CapturingSink sink = new CapturingSink();
+        store.streamRollbackEffects(new QueryRequest(List.of(), Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false), null, 100, true, sink);
+        assertThat(sink.skips).as("environment death declines").isEqualTo(1);
+        assertThat(sink.complex).hasSize(1);
+        assertThat(((RollbackEffect.EntitySpawn) sink.complex.get(0)).entityType())
+                .isEqualTo("sheep");
+    }
+
+    @Test
+    void clickHouseMirrorAppliesTheKillerRule() {
+        assertOnlyThePlayerKillEmits(chStore);
+    }
+
+    @Test
+    void mongoMirrorAppliesTheKillerRule() {
+        assertOnlyThePlayerKillEmits(mongoStore);
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/DeathResurrectionStreamTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/DeathResurrectionStreamTest.java
@@ -1,0 +1,118 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.EntityDeathRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * #284 across the record-to-effect emitters: an environment death (killer
+ * FIRE_TICK) must stream as a cursor-advancing skip, never as an
+ * EntitySpawn; a player kill still resurrects. Covers the default
+ * interface stream and the real SQLite store (whose lean path decodes the
+ * blob and calls the api the same way MariaDB does).
+ */
+class DeathResurrectionStreamTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+
+    @TempDir
+    Path dir;
+
+    private static EntityDeathRecord death(String entityType, String killer, int x) {
+        Instant now = Instant.now();
+        return new EntityDeathRecord(UUID.randomUUID(), "death", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "srv", entityType.toUpperCase(java.util.Locale.ROOT), entityType,
+                UUID.randomUUID(), killer, "ENTITY_ATTACK", null);
+    }
+
+    private static QueryRequest all() {
+        return new QueryRequest(List.of(), Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+    }
+
+    private static final class CapturingSink implements RecordStore.RollbackEffectSink {
+        final List<RollbackEffect> complex = new ArrayList<>();
+        int skips;
+
+        @Override
+        public void block(UUID world, int x, int y, int z, String blockData,
+                          String expectedCurrent, Instant occurred, UUID id) {
+        }
+
+        @Override
+        public void complex(RollbackEffect effect, Instant occurred, UUID id) {
+            complex.add(effect);
+        }
+
+        @Override
+        public void skip(Instant occurred, UUID id) {
+            skips++;
+        }
+    }
+
+    @Test
+    void defaultStreamSkipsEnvironmentDeathsAndEmitsPlayerKills() {
+        List<EventRecord> rows = List.of(
+                death("zombie", "FIRE_TICK", 1),
+                death("sheep", "player", 2));
+        RecordStore store = new RecordStore() {
+            @Override
+            public void save(List<EventRecord> records) {
+            }
+
+            @Override
+            public QueryResult query(QueryRequest request) {
+                return new QueryResult(rows, List.of());
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        CapturingSink sink = new CapturingSink();
+
+        store.streamRollbackEffects(all(), null, 100, true, sink);
+
+        assertThat(sink.skips).as("the fire-tick zombie declines").isEqualTo(1);
+        assertThat(sink.complex).hasSize(1);
+        assertThat(sink.complex.get(0)).isInstanceOf(RollbackEffect.EntitySpawn.class);
+        assertThat(((RollbackEffect.EntitySpawn) sink.complex.get(0)).entityType())
+                .isEqualTo("sheep");
+    }
+
+    @Test
+    void sqliteStreamSkipsEnvironmentDeathsAndEmitsPlayerKills() {
+        try (SqliteRecordStore store = new SqliteRecordStore(dir.resolve("spyglass.db"))) {
+            store.save(List.of(
+                    death("zombie", "FIRE_TICK", 1),
+                    death("sheep", "player", 2)));
+            CapturingSink sink = new CapturingSink();
+
+            store.streamRollbackEffects(all(), null, 100, true, sink);
+
+            assertThat(sink.skips).isEqualTo(1);
+            assertThat(sink.complex).hasSize(1);
+            assertThat(((RollbackEffect.EntitySpawn) sink.complex.get(0)).entityType())
+                    .isEqualTo("sheep");
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1623,6 +1623,14 @@ public final class RollbackEngine {
         }
         Location location = new Location(world.get(),
                 effect.location().x() + 0.5, effect.location().y(), effect.location().z() + 0.5);
+        // Hostile mobs are never resurrected (#284), NBT snapshot or not:
+        // nobody rolls back a slain zombie horde on purpose, and the killer
+        // filter upstream still lets player-killed passives (pets, villagers,
+        // livestock) come back.
+        if (isHostile(effect.entityType())) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(
+                    "Hostile mobs are not resurrected."));
+        }
         // Full-NBT resurrection when a snapshot exists. In practice it
         // rarely does: Paper's serializeEntity rejects dying entities,
         // so death records ship with null NBT — hence the
@@ -1643,6 +1651,25 @@ public final class RollbackEngine {
             }
         }
         return spawnByType(effect, world.get(), location);
+    }
+
+    // Best-effort hostility check via the entity type's API class. Any
+    // lookup failure (unknown type, registry not ready) resolves to NOT
+    // hostile so the killer filter upstream remains the deciding gate.
+    private static boolean isHostile(String entityTypeName) {
+        if (entityTypeName == null || entityTypeName.isBlank()) {
+            return false;
+        }
+        try {
+            EntityType type = org.bukkit.Registry.ENTITY_TYPE.get(
+                    org.bukkit.NamespacedKey.minecraft(
+                            entityTypeName.toLowerCase(Locale.ROOT)));
+            return type != null && type.getEntityClass() != null
+                    && (org.bukkit.entity.Monster.class.isAssignableFrom(type.getEntityClass())
+                        || org.bukkit.entity.Boss.class.isAssignableFrom(type.getEntityClass()));
+        } catch (Throwable ignored) {
+            return false;
+        }
     }
 
     // Resurrection without a snapshot: a fresh entity of the recorded


### PR DESCRIPTION
Fixes #284, reported from in-game testing: a generic rollback spawned ~100 zombies (453 FIRE_TICK death records in the session window).

## What

- **Canonical policy on `EntityDeathRecord`**: `resurrectable()` = the killer was a player. `rollbackEffect()`/`restoreEffect()` return null otherwise - environment deaths (fire, lava, suffocation) stay recorded and searchable but never produce effects in either direction.
- **`Rollbackable` contract**: both methods documented `@Nullable` (a record may decline a direction); the api-calling emitters (default interface stream, SQLite, MariaDB) skip null effects with a cursor-advancing `sink.skip`.
- **Mongo + ClickHouse mirrors**: their `emitEffect` re-implements per-type logic, so the same killer rule is applied there from the projected column (their lockstep comments demand parity). ClickHouse's lean stream projection now includes `entity_killer_type` (the old comment said the effect constructors ignore it - true until today); Mongo's projection gains `killerType`.
- **Engine belt**: `applyEntitySpawn` skips `Monster`/`Boss` entity types with a benign NotSupported even on player kills - nobody rolls back a slain zombie horde on purpose. Player-killed passives (pets, villagers, livestock) keep resurrecting. Hostility check is best-effort via the type's API class and fails open (not hostile) so the killer filter stays the deciding gate.

## Tests

- `EntityDeathRecordTest` (api): player kill -> both effects; FIRE_TICK/LAVA/SUFFOCATION/null -> both null.
- `DeathResurrectionStreamTest` (core): default stream + real SQLite - the zombie skips, the player-killed sheep emits.
- `DeathResurrectionPushdownIT`: the Mongo and ClickHouse mirrors apply the rule (this caught the missing lean-projection column).
- Engine hostile gate: exercised in live verification on the 1.21.11 server (needs the real entity registry).

## Left open (on the issue)

True idempotency for legitimate resurrections (re-running a rollback duplicates a restored sheep) needs the record id carried into the spawn effect for entity tagging - follow-up; these two rules shrink the exposure to player-killed passives on re-run.

`./gradlew check` green (one unrelated AsyncRecorderTest timing flake observed and confirmed passing on re-run and on clean dev).