### PR TITLE
feat(rollback): opt-in containers and entities via --containers / --entities (#287)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -91,6 +91,8 @@ Flags start with `-` and take no value unless noted.
 | `-nc` | `-nochat` | Don't echo the summary line to chat (action-bar only) |
 | `-ex` | `-extended` | Include extra detail columns in the result list |
 | `-nod:<keys>` | `-nodefault:` | Drop defaults. `-nod:r,t` runs with no radius or time bound |
+| `--containers` | `-containers` | Rollback/restore also touches containers. Without it, a rollback never places a container block, never overwrites a live one, and never reverts deposits/withdrawals |
+| `--entities` | `-entities` | Rollback/restore also spawns/removes entities. Without it, death records are left alone |
 
 ### Time formats
 

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/query/Flag.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/query/Flag.java
@@ -4,5 +4,16 @@ public enum Flag {
     NO_GROUP,
     GLOBAL,
     NO_CHAT,
-    EXTENDED
+    EXTENDED,
+    /**
+     * Rollback/restore also touches container blocks and contents (#287).
+     * Absent (the default), a rollback never places a container, never
+     * overwrites a live one, and never reverts container transactions.
+     */
+    INCLUDE_CONTAINERS,
+    /**
+     * Rollback/restore also spawns/removes entities (#287). Absent (the
+     * default), death records produce no resurrections or removals.
+     */
+    INCLUDE_ENTITIES
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
@@ -92,7 +92,10 @@ public final class QueryStringParser {
                     continue;
                 }
                 if (token.startsWith("-")) {
-                    String name = token.substring(1).toLowerCase(java.util.Locale.ROOT);
+                    // Accept GNU-style double dashes too: --containers and
+                    // -containers are the same flag (#287).
+                    String name = token.substring(token.startsWith("--") ? 2 : 1)
+                            .toLowerCase(java.util.Locale.ROOT);
                     String flagValue = null;
                     int eq = name.indexOf('=');
                     if (eq >= 0) {
@@ -257,7 +260,8 @@ public final class QueryStringParser {
                  "ex", "extended",
                  "we", "worldedit",
                  "ord", "order",
-                 "nod", "nodefault" -> true;
+                 "nod", "nodefault",
+                 "containers", "entities" -> true;
             default -> false;
         };
     }
@@ -288,6 +292,9 @@ public final class QueryStringParser {
                 state.defaultRadiusSuppressed = true;
             }
             case "nc", "nochat" -> state.flags.add(Flag.NO_CHAT);
+            // #287: rollbacks skip containers and entities unless asked.
+            case "containers" -> state.flags.add(Flag.INCLUDE_CONTAINERS);
+            case "entities" -> state.flags.add(Flag.INCLUDE_ENTITIES);
             case "ex", "extended" -> state.flags.add(Flag.EXTENDED);
             case "we", "worldedit" -> {
                 if (!(sender instanceof Player player)) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -534,6 +534,13 @@ public final class RollbackService {
                 // state guard skips any cell whose live block is one (#264).
                 java.util.Set<String> protectedMaterials =
                         net.medievalrp.spyglass.plugin.rollback.ExcludedMaterials.of(request.predicates());
+                // #287: containers and entities are opt-in. Flags ride the
+                // stored request, so an /sg undo replays with identical
+                // inclusion semantics.
+                boolean includeContainers = request.flags().contains(
+                        net.medievalrp.spyglass.api.query.Flag.INCLUDE_CONTAINERS);
+                boolean includeEntities = request.flags().contains(
+                        net.medievalrp.spyglass.api.query.Flag.INCLUDE_ENTITIES);
                 RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
                 List<RollbackResult> complexResults = List.of();
                 try {
@@ -547,6 +554,7 @@ public final class RollbackService {
                                 new java.util.concurrent.CompletableFuture<>();
                         support.onMainThread(() -> {
                                 engine.protectMaterials(protectedMaterials);
+                                engine.includeInRollback(includeContainers, includeEntities);
                                 engine.applyColumnsChunked(worldId, cols, sender, support, batchSize, cancelFlag)
                                         .whenComplete((c, err) -> {
                                             if (err != null) fut.completeExceptionally(err);
@@ -561,6 +569,7 @@ public final class RollbackService {
                         List<RollbackEffect> complex = window.complex();
                         support.onMainThread(() -> {
                                 engine.protectMaterials(protectedMaterials);
+                                engine.includeInRollback(includeContainers, includeEntities);
                                 engine.applyAllChunked(complex, sender, support, batchSize, cancelFlag)
                                         .whenComplete((r, err) -> {
                                             if (err != null) fut.completeExceptionally(err);
@@ -587,6 +596,7 @@ public final class RollbackService {
                 mergeSkip(skipCounts, "invalid location", counts.invalidLocation);
                 mergeSkip(skipCounts, "Cancelled by operator", counts.cancelled);
                 mergeSkip(skipCounts, RollbackEngine.PROTECTED_SKIP, counts.protectedCells);
+                mergeSkip(skipCounts, RollbackEngine.CONTAINERS_SKIP, counts.containerCells);
                 // The rare complex effects' per-cell results.
                 for (RollbackResult r : complexResults) {
                     if (r instanceof RollbackResult.Applied) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -251,6 +251,14 @@ public final class RollbackEngine {
     /** Skip message for cells the live-state guard left untouched (#264). */
     public static final String PROTECTED_SKIP = "Live block is excluded by the query";
 
+    /** Skip message for container work withheld by default (#287). */
+    public static final String CONTAINERS_SKIP =
+            "Containers are skipped by default (pass --containers to include them)";
+
+    /** Skip message for entity work withheld by default (#287). */
+    public static final String ENTITIES_SKIP =
+            "Entities are skipped by default (pass --entities to include them)";
+
     // Materials the operator explicitly excluded (block:!x), per job. A cell
     // whose LIVE block is one of these is never overwritten: excluding the
     // chest's record used to leave older same-coordinate history free to
@@ -268,6 +276,44 @@ public final class RollbackEngine {
     // above: jobs are queue-serialized, set at the public entry points.
     private volatile Set<String> protectedMaterials = Set.of();
 
+    // #287: containers and entities are opt-in per job. Default TRUE so
+    // direct engine callers (tests, the legacy undo replay, the api) keep
+    // their behavior; RollbackService sets both from the query flags.
+    private volatile boolean includeContainers = true;
+    private volatile boolean includeEntities = true;
+
+    // Materials whose block state is a Bukkit Container - the same set
+    // SalvageCapturer keys on. Resolved once from the live registry; on any
+    // failure (unit tests without a server) the set stays empty and the
+    // container-block gate is inert, which the flag-independent gates on
+    // the container-slot and entity paths do not depend on.
+    private static volatile Set<Material> containerMaterials;
+
+    private static Set<Material> containerMaterials() {
+        Set<Material> resolved = containerMaterials;
+        if (resolved != null) {
+            return resolved;
+        }
+        Set<Material> out = new java.util.HashSet<>();
+        try {
+            for (Material material : Material.values()) {
+                try {
+                    if (material.isBlock() && !material.isLegacy()
+                            && material.createBlockData().createBlockState()
+                                    instanceof org.bukkit.block.Container) {
+                        out.add(material);
+                    }
+                } catch (Throwable ignored) {
+                    // Material without a resolvable state; not a container.
+                }
+            }
+        } catch (Throwable ignored) {
+            out.clear();
+        }
+        containerMaterials = Set.copyOf(out);
+        return containerMaterials;
+    }
+
     // Synchronous entry point for tests. Production uses applyAllChunked
     // directly so the apply loop can yield between ticks.
     public List<RollbackResult> applyAll(List<RollbackEffect> effects, CommandSender sender) {
@@ -279,9 +325,35 @@ public final class RollbackEngine {
         this.protectedMaterials = materials == null ? Set.of() : Set.copyOf(materials);
     }
 
+    /** Sets what the next job may touch beyond plain blocks (#287). */
+    public void includeInRollback(boolean containers, boolean entities) {
+        this.includeContainers = containers;
+        this.includeEntities = entities;
+    }
+
     private boolean isProtectedLive(World world, int x, int y, int z) {
         return !protectedMaterials.isEmpty()
                 && protectedMaterials.contains(world.getBlockAt(x, y, z).getType().name());
+    }
+
+    /**
+     * Skip reason for a block cell, or null to write it. Two gates (#264,
+     * #287): the operator's excluded materials, and - unless --containers -
+     * any cell that would place a container or overwrite a live one. Main
+     * thread only (live block reads).
+     */
+    private String blockCellSkip(World world, int x, int y, int z, Material replacement) {
+        if (isProtectedLive(world, x, y, z)) {
+            return PROTECTED_SKIP;
+        }
+        if (!includeContainers) {
+            Set<Material> containers = containerMaterials();
+            if ((replacement != null && containers.contains(replacement))
+                    || containers.contains(world.getBlockAt(x, y, z).getType())) {
+                return CONTAINERS_SKIP;
+            }
+        }
+        return null;
     }
 
     // -- apply-phase failsafe (#127) ------------------------------
@@ -324,7 +396,11 @@ public final class RollbackEngine {
             throw new IllegalStateException("RollbackEngine.applyAllChunked must run on the main thread.");
         }
         CompletableFuture<List<RollbackResult>> done = new CompletableFuture<>();
-        done.whenComplete((r, t) -> protectedMaterials = Set.of());
+        done.whenComplete((r, t) -> {
+            protectedMaterials = Set.of();
+            includeContainers = true;
+            includeEntities = true;
+        });
         if (effects.isEmpty()) {
             done.complete(List.of());
             return done;
@@ -612,9 +688,11 @@ public final class RollbackEngine {
                     BlockSnapshot replacement = effect.replacement();
                     BlockLocation loc = effect.location();
                     try {
-                        if (isProtectedLive(world, loc.x(), loc.y(), loc.z())) {
+                        String cellSkip = blockCellSkip(world, loc.x(), loc.y(), loc.z(),
+                                replacement.material());
+                        if (cellSkip != null) {
                             resultArray[targetIndex] = new RollbackResult.Skipped(effect,
-                                    new RollbackReason.NotSupported(PROTECTED_SKIP));
+                                    new RollbackReason.NotSupported(cellSkip));
                             continue;
                         }
                         BlockData bd =
@@ -768,19 +846,20 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 // Live-state reads are main-thread only; the worker half
-                // consults the mask instead of the world (#264).
-                BitSet protectedMask = null;
-                if (!protectedMaterials.isEmpty()) {
-                    protectedMask = new BitSet(chunkEnd - cursor);
+                // consults the precomputed reasons instead of the world
+                // (#264 exclusions, #287 container gate).
+                String[] cellSkips = null;
+                if (!protectedMaterials.isEmpty() || !includeContainers) {
+                    cellSkips = new String[chunkEnd - cursor];
                     for (int j = cursor; j < chunkEnd; j++) {
-                        BlockLocation loc = blockReplaceEffects.get(j).location();
-                        if (isProtectedLive(world, loc.x(), loc.y(), loc.z())) {
-                            protectedMask.set(j - cursor);
-                        }
+                        RollbackEffect.BlockReplace eff = blockReplaceEffects.get(j);
+                        BlockLocation loc = eff.location();
+                        cellSkips[j - cursor] = blockCellSkip(world, loc.x(), loc.y(), loc.z(),
+                                eff.replacement() == null ? null : eff.replacement().material());
                     }
                 }
                 batch.add(new ChunkWork(world, cx, cz, cursor, chunkEnd, ctx, ticketAdded,
-                        protectedMask));
+                        cellSkips));
                 if (!chunkLoaded) {
                     loadsThisHop++;
                 }
@@ -906,9 +985,9 @@ public final class RollbackEngine {
         for (int j = 0; j < chunkSize; j++) {
             int targetIndex = blockReplaceIndices.get(from + j);
             RollbackEffect.BlockReplace effect = blockReplaceEffects.get(from + j);
-            if (work.protectedMask != null && work.protectedMask.get(j)) {
+            if (work.cellSkips != null && work.cellSkips[j] != null) {
                 resultArray[targetIndex] = new RollbackResult.Skipped(effect,
-                        new RollbackReason.NotSupported(PROTECTED_SKIP));
+                        new RollbackReason.NotSupported(work.cellSkips[j]));
                 continue;
             }
             BlockData bd;
@@ -1018,13 +1097,13 @@ public final class RollbackEngine {
         final int chunkEnd;
         final ChunkDirectWriter.ChunkContext ctx;
         final boolean ticketAdded;
-        final BitSet protectedMask;
+        final String[] cellSkips;
         volatile BlockData[] writes;
         volatile BitSet nonSimpleMask;
 
         ChunkWork(World world, int cx, int cz, int from, int chunkEnd,
                   ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded,
-                  BitSet protectedMask) {
+                  String[] cellSkips) {
             this.world = world;
             this.cx = cx;
             this.cz = cz;
@@ -1032,7 +1111,7 @@ public final class RollbackEngine {
             this.chunkEnd = chunkEnd;
             this.ctx = ctx;
             this.ticketAdded = ticketAdded;
-            this.protectedMask = protectedMask;
+            this.cellSkips = cellSkips;
         }
     }
 
@@ -1059,10 +1138,13 @@ public final class RollbackEngine {
         public long cancelled;
         /** Cells the live-state guard left untouched (#264). Benign. */
         public long protectedCells;
+        /** Live-container cells withheld without --containers (#287). Benign. */
+        public long containerCells;
 
         /** Total skipped across every benign and error reason. */
         public long skipped() {
-            return blockChanged + unparseable + invalidLocation + cancelled + protectedCells;
+            return blockChanged + unparseable + invalidLocation + cancelled
+                    + protectedCells + containerCells;
         }
 
         /** Skips that are real failures (parity with RollbackReason.Error). */
@@ -1077,6 +1159,7 @@ public final class RollbackEngine {
             invalidLocation += other.invalidLocation;
             cancelled += other.cancelled;
             protectedCells += other.protectedCells;
+            containerCells += other.containerCells;
         }
     }
 
@@ -1088,7 +1171,11 @@ public final class RollbackEngine {
             throw new IllegalStateException("RollbackEngine.applyColumnsChunked must run on the main thread.");
         }
         CompletableFuture<ApplyCounts> done = new CompletableFuture<>();
-        done.whenComplete((r, t) -> protectedMaterials = Set.of());
+        done.whenComplete((r, t) -> {
+            protectedMaterials = Set.of();
+            includeContainers = true;
+            includeEntities = true;
+        });
         ApplyCounts counts = new ApplyCounts();
         int total = cols.count();
         if (total == 0) {
@@ -1181,18 +1268,33 @@ public final class RollbackEngine {
                     salvageHook.onChunkResolved(world, cx, cz);
                 }
                 // Live-state reads are main-thread only; the worker half
-                // consults the mask instead of the world (#264).
-                BitSet protectedMask = null;
-                if (!protectedMaterials.isEmpty()) {
-                    protectedMask = new BitSet(rangeEnd - cursor);
+                // consults the mask instead of the world (#264 exclusions,
+                // #287 container gate; columnar cells are simple blocks, so
+                // only the live side can be a container here). Counting
+                // happens at classify time so the worker only skips.
+                BitSet skipMask = null;
+                long protectedHere = 0;
+                long containersHere = 0;
+                if (!protectedMaterials.isEmpty() || !includeContainers) {
+                    skipMask = new BitSet(rangeEnd - cursor);
                     for (int k = cursor; k < rangeEnd; k++) {
                         int cellIdx = order[k];
-                        if (isProtectedLive(world, cols.x(cellIdx), cols.y(cellIdx), cols.z(cellIdx))) {
-                            protectedMask.set(k - cursor);
+                        String reason = blockCellSkip(world,
+                                cols.x(cellIdx), cols.y(cellIdx), cols.z(cellIdx), null);
+                        if (reason != null) {
+                            skipMask.set(k - cursor);
+                            if (PROTECTED_SKIP.equals(reason)) {
+                                protectedHere++;
+                            } else {
+                                containersHere++;
+                            }
                         }
                     }
                 }
-                batch.add(new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded, protectedMask));
+                ColChunk colChunk = new ColChunk(cx, cz, cursor, rangeEnd, ctx, ticketAdded, skipMask);
+                colChunk.protectedCells = protectedHere;
+                colChunk.containerCells = containersHere;
+                batch.add(colChunk);
                 if (!chunkLoaded) {
                     loadsThisHop++;
                 }
@@ -1254,6 +1356,7 @@ public final class RollbackEngine {
                     counts.blockChanged += cc.blockChanged;
                     counts.unparseable += cc.unparseable;
                     counts.protectedCells += cc.protectedCells;
+                    counts.containerCells += cc.containerCells;
                 } catch (Throwable t) {
                     // finishChunk / onChunkWritten threw; record the failure and
                     // keep cleaning up the rest of the batch (#127).
@@ -1330,11 +1433,9 @@ public final class RollbackEngine {
         long applied = 0;
         long changed = 0;
         long unparse = 0;
-        long protectedCount = 0;
         for (int k = cc.from; k < cc.rangeEnd; k++) {
-            if (cc.protectedMask != null && cc.protectedMask.get(k - cc.from)) {
-                protectedCount++;
-                continue;
+            if (cc.skipMask != null && cc.skipMask.get(k - cc.from)) {
+                continue; // counted at classify time on the main thread
             }
             int idx = order[k];
             int x = cols.x(idx);
@@ -1356,7 +1457,6 @@ public final class RollbackEngine {
         cc.applied = applied;
         cc.blockChanged = changed;
         cc.unparseable = unparse;
-        cc.protectedCells = protectedCount;
     }
 
     // Main-thread fallback for a chunk whose prepareChunk failed: single
@@ -1364,11 +1464,9 @@ public final class RollbackEngine {
     private void writeColumnChunkMain(World world, BlockColumns cols, int[] order, ColChunk cc) {
         long applied = 0;
         long unparse = 0;
-        long protectedCount = 0;
         for (int k = cc.from; k < cc.rangeEnd; k++) {
-            if (cc.protectedMask != null && cc.protectedMask.get(k - cc.from)) {
-                protectedCount++;
-                continue;
+            if (cc.skipMask != null && cc.skipMask.get(k - cc.from)) {
+                continue; // counted at classify time on the main thread
             }
             int idx = order[k];
             int x = cols.x(idx);
@@ -1389,7 +1487,6 @@ public final class RollbackEngine {
         }
         cc.applied = applied;
         cc.unparseable = unparse;
-        cc.protectedCells = protectedCount;
     }
 
     // One chunk's columnar work unit: the [from, rangeEnd) slice of the
@@ -1402,20 +1499,21 @@ public final class RollbackEngine {
         final int rangeEnd;
         final ChunkDirectWriter.ChunkContext ctx;
         final boolean ticketAdded;
-        final BitSet protectedMask;
+        final BitSet skipMask;
         volatile long applied;
         volatile long blockChanged;
         volatile long unparseable;
         volatile long protectedCells;
+        volatile long containerCells;
 
         ColChunk(int cx, int cz, int from, int rangeEnd,
                  ChunkDirectWriter.ChunkContext ctx, boolean ticketAdded,
-                 BitSet protectedMask) {
+                 BitSet skipMask) {
             this.cx = cx;
             this.cz = cz;
             this.from = from;
             this.rangeEnd = rangeEnd;
-            this.protectedMask = protectedMask;
+            this.skipMask = skipMask;
             this.ctx = ctx;
             this.ticketAdded = ticketAdded;
         }
@@ -1602,6 +1700,13 @@ public final class RollbackEngine {
                                      List<Integer> indices,
                                      List<RollbackEffect.ContainerSlotWrite> writes,
                                      RollbackResult[] resultArray) {
+        if (!includeContainers) {
+            for (int i = 0; i < indices.size(); i++) {
+                resultArray[indices.get(i)] = new RollbackResult.Skipped(writes.get(i),
+                        new RollbackReason.NotSupported(CONTAINERS_SKIP));
+            }
+            return;
+        }
         Optional<World> world = BlockLocations.resolveWorld(location);
         if (world.isEmpty()) {
             for (int i = 0; i < indices.size(); i++) {
@@ -1708,6 +1813,9 @@ public final class RollbackEngine {
     }
 
     private RollbackResult applyEntitySpawn(RollbackEffect.EntitySpawn effect) {
+        if (!includeEntities) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(ENTITIES_SKIP));
+        }
         Optional<World> world = BlockLocations.resolveWorld(effect.location());
         if (world.isEmpty()) {
             return new RollbackResult.Skipped(effect, new RollbackReason.InvalidLocation(effect.location()));
@@ -1764,6 +1872,9 @@ public final class RollbackEngine {
     }
 
     private RollbackResult applyEntityRemove(RollbackEffect.EntityRemove effect) {
+        if (!includeEntities) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(ENTITIES_SKIP));
+        }
         if (effect.entityId() == null || effect.entityId().isBlank()) {
             return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported("No entity id."));
         }
@@ -1799,6 +1910,9 @@ public final class RollbackEngine {
     }
 
     private RollbackResult applyContainerSlotWrite(RollbackEffect.ContainerSlotWrite effect) {
+        if (!includeContainers) {
+            return new RollbackResult.Skipped(effect, new RollbackReason.NotSupported(CONTAINERS_SKIP));
+        }
         Optional<World> world = BlockLocations.resolveWorld(effect.location());
         if (world.isEmpty()) {
             return new RollbackResult.Skipped(effect, new RollbackReason.InvalidLocation(effect.location()));

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
@@ -109,6 +109,30 @@ class QueryStringParserTest {
         assertThat(request.predicates()).hasSize(2);
     }
 
+    // ---- #287: rollback inclusion flags ----
+
+    @Test
+    void inclusionFlagsParseWithSingleOrDoubleDash() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        QueryRequest doubled = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "--containers --entities", 0);
+        assertThat(doubled.flags())
+                .contains(net.medievalrp.spyglass.api.query.Flag.INCLUDE_CONTAINERS,
+                        net.medievalrp.spyglass.api.query.Flag.INCLUDE_ENTITIES);
+
+        QueryRequest single = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "-containers", 0);
+        assertThat(single.flags())
+                .contains(net.medievalrp.spyglass.api.query.Flag.INCLUDE_CONTAINERS)
+                .doesNotContain(net.medievalrp.spyglass.api.query.Flag.INCLUDE_ENTITIES);
+
+        QueryRequest none = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "-g", 0);
+        assertThat(none.flags())
+                .doesNotContain(net.medievalrp.spyglass.api.query.Flag.INCLUDE_CONTAINERS,
+                        net.medievalrp.spyglass.api.query.Flag.INCLUDE_ENTITIES);
+    }
+
     // ---- #150: ip: pre-resolution off the main thread ----
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackInclusionFlagsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackInclusionFlagsTest.java
@@ -1,0 +1,149 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.rollback.RollbackEffect;
+import net.medievalrp.spyglass.api.rollback.RollbackReason;
+import net.medievalrp.spyglass.api.rollback.RollbackResult;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * #287: containers and entities are opt-in per job. Without the
+ * inclusions, container slot writes and entity spawn/removal skip with
+ * the flag-naming messages; with them (and for direct engine callers,
+ * whose default is include-everything), behavior is unchanged. The
+ * container-BLOCK gate needs the live material registry and is covered
+ * by in-game verification.
+ */
+class RollbackInclusionFlagsTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private static RollbackEffect depositRevert() {
+        Instant now = Instant.now();
+        // afterItem built by the real serializer over the same stubbed
+        // bytes the live mock serializes to, so the expected-state guard
+        // passes when the gate lets the write through.
+        StoredItem after = net.medievalrp.spyglass.plugin.util.ItemSerialization
+                .storedItem(0, ironStack());
+        return new ContainerDepositRecord(
+                UUID.randomUUID(), "deposit", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(UUID.randomUUID(), "Alice"),
+                new BlockLocation(WORLD_ID, "world", 1, 64, 2),
+                "test", "DIAMOND", "CHEST", 0, 40,
+                null, after).rollbackEffect();
+    }
+
+    private static ItemStack ironStack() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(Material.DIAMOND);
+        when(stack.getAmount()).thenReturn(40);
+        when(stack.getItemMeta()).thenReturn(null);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1});
+        return stack;
+    }
+
+    private List<RollbackResult> apply(RollbackEngine engine, RollbackEffect effect) {
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        Inventory inventory = mock(Inventory.class);
+        when(inventory.getSize()).thenReturn(27);
+        ItemStack live = ironStack();
+        when(inventory.getItem(0)).thenReturn(live);
+        Container container = mock(Container.class);
+        when(container.getInventory()).thenReturn(inventory);
+        when(container.getSnapshotInventory()).thenReturn(inventory);
+        Block block = mock(Block.class);
+        when(block.getState()).thenReturn(container);
+        when(world.getBlockAt(1, 64, 2)).thenReturn(block);
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+            bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            return engine.applyAll(List.of(effect), mock(CommandSender.class));
+        }
+    }
+
+    @Test
+    void containerSlotWritesSkipWithoutTheFlagAndNameIt() {
+        RollbackEngine engine = new RollbackEngine();
+        engine.includeInRollback(false, false);
+
+        RollbackResult result = apply(engine, depositRevert()).get(0);
+
+        assertThat(result).isInstanceOf(RollbackResult.Skipped.class);
+        assertThat(((RollbackReason.NotSupported) ((RollbackResult.Skipped) result).reason()).detail())
+                .isEqualTo(RollbackEngine.CONTAINERS_SKIP)
+                .contains("--containers");
+    }
+
+    @Test
+    void entityWorkSkipsWithoutTheFlagAndNamesIt() {
+        RollbackEngine engine = new RollbackEngine();
+        engine.includeInRollback(false, false);
+
+        RollbackEffect remove = new RollbackEffect.EntityRemove(
+                new BlockLocation(WORLD_ID, "world", 1, 64, 2), "sheep", UUID.randomUUID().toString());
+        RollbackResult result = apply(engine, remove).get(0);
+
+        assertThat(result).isInstanceOf(RollbackResult.Skipped.class);
+        assertThat(((RollbackReason.NotSupported) ((RollbackResult.Skipped) result).reason()).detail())
+                .isEqualTo(RollbackEngine.ENTITIES_SKIP)
+                .contains("--entities");
+    }
+
+    @Test
+    void inclusionsRestoreCurrentBehaviorAndDirectCallersDefaultToInclude() {
+        // With the flag (or for a direct caller who never set inclusions),
+        // the deposit revert applies exactly as before #287.
+        RollbackEngine flagged = new RollbackEngine();
+        flagged.includeInRollback(true, true);
+        assertThat(apply(flagged, depositRevert()).get(0))
+                .isInstanceOf(RollbackResult.Applied.class);
+
+        assertThat(apply(new RollbackEngine(), depositRevert()).get(0))
+                .as("engine default is include-everything (tests, legacy undo replay)")
+                .isInstanceOf(RollbackResult.Applied.class);
+    }
+
+    @Test
+    void inclusionsResetToDefaultsWhenTheJobCompletes() {
+        RollbackEngine engine = new RollbackEngine();
+        engine.includeInRollback(false, false);
+        assertThat(apply(engine, depositRevert()).get(0))
+                .isInstanceOf(RollbackResult.Skipped.class);
+
+        // The completed job reset the per-job state: the next job includes.
+        assertThat(apply(engine, depositRevert()).get(0))
+                .as("exclusion never leaks into the next job")
+                .isInstanceOf(RollbackResult.Applied.class);
+    }
+}


### PR DESCRIPTION
Fixes #287; implements the default-skip half of #267 per operator decision (flag spelling `--containers`, plus an `--entities` analogue).

**Stacked on #277** (extends its live-guard machinery); retarget to `dev` after #277 merges.

## Behavior

Default rollback/restore touches only plain blocks:
- never places a container block, never overwrites a live one (generalizes #264: a chest over unrelated history is now safe without `b:!chest`), never reverts deposits/withdrawals - pass `--containers` to include;
- never spawns or removes entities (on top of #284's player-kill rule) - pass `--entities`.

Skipped work surfaces in the summary as benign skips whose message names the flag. Flags are stored with the op reference, so `/sg undo` replays with identical semantics. `-containers`/`--containers` both parse (GNU-style double dash accepted for all flags).

## Implementation

- `Flag.INCLUDE_CONTAINERS` / `INCLUDE_ENTITIES` (api, additive) + parser cases.
- Engine per-job inclusions (same serialized-jobs contract as the #264 state, reset on completion): gates on the container-slot paths and entity spawn/remove, and a shared block-cell classifier (exclusion guard + container gate) feeding the sync loop, the parallel resolve (per-cell reason array), and the columnar mask (counted at classify time).
- Container materials resolved once from the registry (`BlockData#createBlockState() instanceof Container` - the SalvageCapturer set); empty on registry-less JVMs, so unit tests cover the registry-independent gates and in-game verification covers the block gate.
- `ApplyCounts.containerCells` + summary line.

## Tests

Parser (single/double dash, absence), engine gates (slot skip+message, entity skip+message, include restores behavior, per-job reset). Container-BLOCK gate + end-to-end verified live on the 1.21.11 test server.

`./gradlew check` green.