### PR TITLE
feat(config): schema versioning + migration, plus Mongo discrete-field settings

### DIFF
--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoConnectionString.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/MongoConnectionString.java
@@ -1,0 +1,61 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Resolves the MongoDB connection string from config.
+ *
+ * <p>The discrete {@code host} / {@code port} / {@code user} / {@code password}
+ * / {@code ssl} fields cover the common single-node case and read consistently
+ * with the other backends. Anything they can't express - a replica set,
+ * {@code mongodb+srv://} (Atlas), or advanced TLS - goes in the optional
+ * {@code uri} override, which when set is used verbatim.
+ */
+public final class MongoConnectionString {
+
+    private MongoConnectionString() {
+    }
+
+    /**
+     * Returns {@code override} untouched when it is set; otherwise builds a
+     * {@code mongodb://} string from the discrete fields, percent-encoding the
+     * credentials (MongoDB requires it when they contain reserved characters).
+     */
+    public static String resolve(String override, String host, int port,
+                                 String user, String password, boolean ssl) {
+        if (override != null && !override.isBlank()) {
+            return override.trim();
+        }
+        StringBuilder uri = new StringBuilder("mongodb://");
+        if (user != null && !user.isBlank()) {
+            uri.append(encode(user));
+            if (password != null && !password.isEmpty()) {
+                uri.append(':').append(encode(password));
+            }
+            uri.append('@');
+        }
+        uri.append(host).append(':').append(port);
+        if (ssl) {
+            uri.append("/?tls=true");
+        }
+        return uri.toString();
+    }
+
+    // Percent-encode per RFC 3986, escaping everything outside the unreserved
+    // set so a credential containing ':' '@' '/' '?' etc. can't break the URI.
+    private static String encode(String value) {
+        StringBuilder out = new StringBuilder(value.length());
+        for (byte raw : value.getBytes(StandardCharsets.UTF_8)) {
+            int c = raw & 0xFF;
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+                    || c == '-' || c == '.' || c == '_' || c == '~') {
+                out.append((char) c);
+            } else {
+                out.append('%')
+                        .append(Character.toUpperCase(Character.forDigit((c >> 4) & 0xF, 16)))
+                        .append(Character.toUpperCase(Character.forDigit(c & 0xF, 16)));
+            }
+        }
+        return out.toString();
+    }
+}

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoConnectionStringTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/MongoConnectionStringTest.java
@@ -1,0 +1,40 @@
+package net.medievalrp.spyglass.plugin.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MongoConnectionStringTest {
+
+    @Test
+    void overrideIsUsedVerbatimWhenSet() {
+        String override = "mongodb+srv://u:p@cluster.example.mongodb.net/?retryWrites=true";
+        assertThat(MongoConnectionString.resolve(override, "ignored", 1, "ignored", "ignored", true))
+                .isEqualTo(override);
+    }
+
+    @Test
+    void blankOverrideAssemblesFromHostAndPort() {
+        assertThat(MongoConnectionString.resolve("", "db.internal", 27018, "", "", false))
+                .isEqualTo("mongodb://db.internal:27018");
+    }
+
+    @Test
+    void credentialsAreIncludedAndPercentEncoded() {
+        // '@' ':' '/' in the password would break the URI unless escaped.
+        assertThat(MongoConnectionString.resolve(null, "localhost", 27017, "admin", "p@ss:w/rd", false))
+                .isEqualTo("mongodb://admin:p%40ss%3Aw%2Frd@localhost:27017");
+    }
+
+    @Test
+    void userWithoutPasswordStillAuthenticates() {
+        assertThat(MongoConnectionString.resolve("", "localhost", 27017, "reader", "", false))
+                .isEqualTo("mongodb://reader@localhost:27017");
+    }
+
+    @Test
+    void sslAddsTheTlsOption() {
+        assertThat(MongoConnectionString.resolve("", "localhost", 27017, "", "", true))
+                .isEqualTo("mongodb://localhost:27017/?tls=true");
+    }
+}

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/SpyglassProxy.java
@@ -102,7 +102,7 @@ public final class SpyglassProxy {
             case MONGO -> new MongoRecordStore(
                     // Read-only companion: skip collection-create, backfill, and
                     // index writes. The backend plugin owns schema and migrations.
-                    db.uri(), db.name(), db.collection(), new IndexManager(), false);
+                    db.mongo().uri(), db.mongo().database(), db.mongo().collection(), new IndexManager(), false);
             case CLICKHOUSE -> {
                 SpyglassProxyConfig.ClickHouse ch = db.clickhouse();
                 yield new ClickHouseRecordStore(

--- a/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
+++ b/spyglass-velocity/src/main/java/net/medievalrp/spyglass/proxy/config/SpyglassProxyConfig.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.storage.MongoConnectionString;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
 
@@ -45,9 +46,16 @@ public record SpyglassProxyConfig(
         return new SpyglassProxyConfig(
                 new Database(
                         backend,
-                        root.node("database", "uri").getString("mongodb://localhost:27017"),
-                        root.node("database", "name").getString("Spyglass"),
-                        root.node("database", "collection").getString("EventRecords"),
+                        new Mongo(
+                                MongoConnectionString.resolve(
+                                        mongoSetting(root, "uri", "uri", ""),
+                                        root.node("database", "mongo", "host").getString("localhost"),
+                                        root.node("database", "mongo", "port").getInt(27017),
+                                        root.node("database", "mongo", "user").getString(""),
+                                        root.node("database", "mongo", "password").getString(""),
+                                        root.node("database", "mongo", "ssl").getBoolean(false)),
+                                mongoSetting(root, "database", "name", "Spyglass"),
+                                mongoSetting(root, "collection", "collection", "EventRecords")),
                         new ClickHouse(
                                 root.node("database", "clickhouse", "host").getString("localhost"),
                                 root.node("database", "clickhouse", "port").getInt(8123),
@@ -81,12 +89,21 @@ public record SpyglassProxyConfig(
 
     public record Database(
             Backend backend,
-            String uri,
-            String name,
-            String collection,
+            Mongo mongo,
             ClickHouse clickhouse,
             Sqlite sqlite,
             MariaDb mariadb) {
+    }
+
+    /**
+     * Resolved MongoDB connection (used when {@code backend = "mongo"}); the uri
+     * is the operator's override or one assembled from the discrete fields by
+     * {@link net.medievalrp.spyglass.plugin.storage.MongoConnectionString}.
+     */
+    public record Mongo(
+            String uri,
+            String database,
+            String collection) {
     }
 
     /**
@@ -143,6 +160,15 @@ public record SpyglassProxyConfig(
     public record Limits(int searchResult, int pageSize) {
     }
 
+    // Reads a mongo setting from the new database.mongo.<key> location, falling
+    // back to the pre-v2 top-level database.<oldKey> for a proxy config an
+    // operator hasn't restructured yet. The proxy config is hand-maintained, so
+    // it keeps this fallback rather than running the plugin's config migrator.
+    private static String mongoSetting(ConfigurationNode root, String key, String oldKey, String def) {
+        ConfigurationNode current = root.node("database", "mongo", key);
+        return (current.virtual() ? root.node("database", oldKey) : current).getString(def);
+    }
+
     private static String defaultConfig() {
         return """
                 # Spyglass proxy plugin - Velocity-side companion to the Paper
@@ -154,9 +180,18 @@ public record SpyglassProxyConfig(
                   backend = "mongo"
 
                   # Mongo (used when backend = "mongo")
-                  uri = "mongodb://localhost:27017"
-                  name = "Spyglass"
-                  collection = "EventRecords"
+                  mongo {
+                    host = "localhost"
+                    port = 27017
+                    database = "Spyglass"
+                    user = ""
+                    password = ""
+                    ssl = false
+                    collection = "EventRecords"
+                    # Optional full connection string (replica set / Atlas /
+                    # advanced TLS); overrides the fields above when set.
+                    uri = ""
+                  }
 
                   # ClickHouse (used when backend = "clickhouse")
                   clickhouse {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -214,7 +214,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                 case MONGO -> {
                     SpyglassConfig.Database db = config.database();
                     MongoRecordStore mongoStore = new MongoRecordStore(
-                            db.uri(), db.name(), db.collection(), new IndexManager(), retentionPolicy);
+                            db.mongo().uri(), db.mongo().database(), db.mongo().collection(),
+                            new IndexManager(), retentionPolicy);
                     recordStore = mongoStore;
                     undoStack = new MongoUndoStack(
                             mongoStore.database(), mongoStore.codecRegistry());
@@ -655,8 +656,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                         serviceSupport,
                         target -> switch (target) {
                             case MONGO -> new MongoRecordStore(
-                                    config.database().uri(), config.database().name(),
-                                    config.database().collection(), new IndexManager(),
+                                    config.database().mongo().uri(), config.database().mongo().database(),
+                                    config.database().mongo().collection(), new IndexManager(),
                                     retentionPolicy);
                             case CLICKHOUSE -> {
                                 SpyglassConfig.ClickHouse ch = config.database().clickhouse();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/ConfigMigrator.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/ConfigMigrator.java
@@ -1,0 +1,104 @@
+package net.medievalrp.spyglass.plugin.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+/**
+ * Upgrades an on-disk config to the current schema version without losing the
+ * operator's settings.
+ *
+ * <p>Configs predating the {@code config-version} key read as version 1. When
+ * the on-disk version is older than {@link SpyglassConfig#CONFIG_VERSION} the
+ * loader backs up the file (see {@link #backup}) and then rebuilds it with
+ * {@link #migrate}: the bundled template supplies the structure, comments, and
+ * new defaults, and the operator's values are overlaid on top. Moved keys are
+ * relocated via a remap table; everything else lands at the same path. Keys the
+ * template no longer has are dropped, so removed settings don't linger.
+ *
+ * <p>Rebuilding from the template (rather than editing the old file in place) is
+ * what lets an upgraded config pick up the current comments - the comments live
+ * on the template node, not on the operator's old file.
+ */
+@ApiStatus.Internal
+public final class ConfigMigrator {
+
+    private ConfigMigrator() {
+    }
+
+    /** The on-disk schema version; absent (pre-versioning) reads as 1. */
+    public static int readVersion(ConfigurationNode root) {
+        return root.node("config-version").getInt(1);
+    }
+
+    /**
+     * Copies {@code configFile} to a sibling {@code <name>.<label>.bak}, adding a
+     * numeric suffix rather than overwriting an existing backup, and returns the
+     * path written. Called before any migration touches the original, so a failed
+     * or half-written migration always leaves the operator's file recoverable.
+     */
+    public static Path backup(Path configFile, String label) throws IOException {
+        Path dir = configFile.getParent();
+        String base = configFile.getFileName() + "." + label + ".bak";
+        Path target = dir.resolve(base);
+        int suffix = 1;
+        while (Files.exists(target)) {
+            target = dir.resolve(base + "." + suffix++);
+        }
+        Files.copy(configFile, target, StandardCopyOption.COPY_ATTRIBUTES);
+        return target;
+    }
+
+    /**
+     * Overlays the operator's values from {@code user} onto {@code template} and
+     * stamps {@code toVersion}. {@code remaps} maps an old dotted key path to its
+     * new location; a null target drops the key. Lists and scalars are copied
+     * whole (so a list value replaces the default rather than index-merging with
+     * it); maps are recursed. Mutates and returns {@code template}.
+     */
+    public static ConfigurationNode migrate(ConfigurationNode user, ConfigurationNode template,
+                                            Map<String, String> remaps, int toVersion)
+            throws SerializationException {
+        overlay(user, template, remaps, new ArrayDeque<>());
+        template.node("config-version").set(toVersion);
+        return template;
+    }
+
+    private static void overlay(ConfigurationNode node, ConfigurationNode template,
+                                Map<String, String> remaps, Deque<Object> path)
+            throws SerializationException {
+        if (node.isMap()) {
+            for (Map.Entry<Object, ? extends ConfigurationNode> child : node.childrenMap().entrySet()) {
+                path.addLast(child.getKey());
+                overlay(child.getValue(), template, remaps, path);
+                path.removeLast();
+            }
+            return;
+        }
+        // Scalar or list leaf. raw() hands back the whole value (a List stays a
+        // List), so setting it replaces the template default outright.
+        StringBuilder dotted = new StringBuilder();
+        for (Object key : path) {
+            if (dotted.length() > 0) {
+                dotted.append('.');
+            }
+            dotted.append(key);
+        }
+        if (remaps.containsKey(dotted.toString())) {
+            String target = remaps.get(dotted.toString());
+            if (target == null) {
+                return;
+            }
+            template.node((Object[]) target.split("\\.")).set(node.raw());
+        } else {
+            template.node(path.toArray()).set(node.raw());
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.storage.MongoConnectionString;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -35,6 +36,20 @@ public record SpyglassConfig(
             "login", "register", "l", "reg", "changepassword", "changepw",
             "unregister", "premium", "2fa", "totp", "auth");
 
+    /**
+     * Current config schema version. Bumped whenever the on-disk layout changes
+     * in a way {@link ConfigMigrator} has to reconcile (a moved or renamed key).
+     * A config with an older {@code config-version} is migrated on load.
+     */
+    public static final int CONFIG_VERSION = 2;
+
+    // v1 -> v2: the bare database.uri/name/collection keys moved under a
+    // mongo { } block, and `name` became `database`.
+    private static final Map<String, String> MIGRATION_REMAP = Map.of(
+            "database.uri", "database.mongo.uri",
+            "database.name", "database.mongo.database",
+            "database.collection", "database.mongo.collection");
+
     public static SpyglassConfig load(JavaPlugin plugin) throws IOException {
         Path path = plugin.getDataFolder().toPath().resolve("config.conf");
         Files.createDirectories(path.getParent());
@@ -45,7 +60,31 @@ public record SpyglassConfig(
         HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
                 .path(path)
                 .build();
-        ConfigurationNode root = loader.load();
+        ConfigurationNode root;
+        try {
+            root = loader.load();
+        } catch (IOException ex) {
+            // A hand-broken config must not silently reset to defaults - that
+            // would repoint the backend and credentials. Preserve it and stop.
+            Path saved = ConfigMigrator.backup(path, "corrupt");
+            throw new IOException("Spyglass config.conf could not be parsed; backed up to "
+                    + saved.getFileName() + ". Fix the syntax and restart.", ex);
+        }
+
+        int version = ConfigMigrator.readVersion(root);
+        if (version < CONFIG_VERSION) {
+            Path saved = ConfigMigrator.backup(path, "v" + version);
+            try {
+                root = ConfigMigrator.migrate(root, loadBundledDefaults(plugin),
+                        MIGRATION_REMAP, CONFIG_VERSION);
+                loader.save(root);
+            } catch (org.spongepowered.configurate.serialize.SerializationException ex) {
+                throw new IOException("Spyglass config migration failed; your original config is at "
+                        + saved.getFileName(), ex);
+            }
+            plugin.getLogger().info("Spyglass: migrated config v" + version + " -> v" + CONFIG_VERSION
+                    + "; previous file backed up to " + saved.getFileName());
+        }
 
         // Auto-merge: any event present in the jar's default config.conf but missing from
         // the on-disk config gets added with defaults. Prevents silent "event not enabled"
@@ -78,9 +117,16 @@ public record SpyglassConfig(
         return new SpyglassConfig(
                 new Database(
                         backend,
-                        root.node("database", "uri").getString("mongodb://localhost:27017"),
-                        root.node("database", "name").getString("Spyglass"),
-                        root.node("database", "collection").getString("EventRecords"),
+                        new Mongo(
+                                MongoConnectionString.resolve(
+                                        root.node("database", "mongo", "uri").getString(""),
+                                        root.node("database", "mongo", "host").getString("localhost"),
+                                        root.node("database", "mongo", "port").getInt(27017),
+                                        root.node("database", "mongo", "user").getString(""),
+                                        root.node("database", "mongo", "password").getString(""),
+                                        root.node("database", "mongo", "ssl").getBoolean(false)),
+                                root.node("database", "mongo", "database").getString("Spyglass"),
+                                root.node("database", "mongo", "collection").getString("EventRecords")),
                         new ClickHouse(
                                 root.node("database", "clickhouse", "host").getString("localhost"),
                                 root.node("database", "clickhouse", "port").getInt(8123),
@@ -113,8 +159,8 @@ public record SpyglassConfig(
                         root.node("defaults", "radius").getInt(250),
                         Duration.parse(root.node("defaults", "time").getString("4h"))),
                 new Limits(
-                        root.node("limits", "max-radius").getInt(250),
-                        root.node("limits", "search-result").getInt(1_000),
+                        root.node("limits", "max-radius").getInt(500),
+                        root.node("limits", "search-result").getInt(5_000),
                         root.node("limits", "chat-dump").getInt(50),
                         root.node("limits", "rollback-batch-size").getInt(4_000),
                         Duration.parse(root.node("limits", "rollback-flush-timeout").getString("30s")),
@@ -243,12 +289,23 @@ public record SpyglassConfig(
 
     public record Database(
             Backend backend,
-            String uri,
-            String name,
-            String collection,
+            Mongo mongo,
             ClickHouse clickhouse,
             Sqlite sqlite,
             MariaDb mariadb) {
+    }
+
+    /**
+     * Resolved MongoDB connection (used when {@code backend = "mongo"}). The
+     * {@code uri} is either the operator's explicit {@code uri} override or a
+     * string assembled from the discrete host/port/user/password/ssl fields by
+     * {@link MongoConnectionString}, so downstream only ever sees a connection
+     * string plus the database and collection names.
+     */
+    public record Mongo(
+            String uri,
+            String database,
+            String collection) {
     }
 
     /**

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/migrate/MigrateService.java
@@ -275,11 +275,11 @@ public final class MigrateService {
     public static String validateTargetConfig(SpyglassConfig.Database db, Backend target) {
         switch (target) {
             case MONGO -> {
-                if (isBlank(db.uri())) {
-                    return "database.uri is blank.";
+                if (isBlank(db.mongo().uri())) {
+                    return "database.mongo.uri is blank.";
                 }
-                if (isBlank(db.name()) || isBlank(db.collection())) {
-                    return "database.name / database.collection are blank.";
+                if (isBlank(db.mongo().database()) || isBlank(db.mongo().collection())) {
+                    return "database.mongo.database / database.mongo.collection are blank.";
                 }
             }
             case CLICKHOUSE -> {

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -1,58 +1,62 @@
+# Config version - do not edit.
+config-version = 2
+
 database {
-  # Which backend stores Spyglass data. Pick one; the other blocks are ignored.
-  #   "sqlite"     - embedded file, zero setup. The default; right for most servers.
-  #   "mariadb"    - MariaDB / MySQL ("mysql" selects the same backend). For hosts
-  #                  that already run one.
+  # Storage backend; only the matching settings below are read, the rest are
+  # ignored.
+  #   "sqlite"     - embedded file, zero setup. Default; right for most servers.
+  #   "mariadb"    - MariaDB / MySQL ("mysql" selects the same backend), for a
+  #                  host already running one.
   #   "mongo"      - MongoDB.
-  #   "clickhouse" - columnar; best storage compression and rollback speed at very
-  #                  large scale, slower on per-player search lookups.
+  #   "clickhouse" - columnar; recommended for large servers, best compression
+  #                  and rollback speed at scale.
   backend = "sqlite"
 
-  # If the database lives on another machine, secure the link first:
-  # auth + least-privilege user, TLS or a private network, firewalled ports.
-
-  # Mongo connection (used when backend = "mongo").
-  uri = "mongodb://localhost:27017"
-  name = "Spyglass"            # database name
-  collection = "EventRecords"  # main event collection (others derive from it)
-
-  # ClickHouse connection (used when backend = "clickhouse").
-  clickhouse {
-    host = "localhost"       # host serving the HTTP interface
-    port = 8123              # HTTP port (the native 9000 port is not used)
-    database = "spyglass"    # auto-created on first start if missing
-    table = "event_records"  # auto-created and migrated on first start
-    user = "default"
-    password = ""            # "" = none
-    ssl = false              # true = HTTPS/TLS
+  mongo {
+    host = "localhost"
+    port = 27017
+    database = "Spyglass"
+    user = ""
+    password = ""
+    ssl = false
+    collection = "EventRecords"
+    # Optional: a full connection string for a replica set, Atlas
+    # (mongodb+srv), or advanced TLS. When set it overrides the fields above.
+    uri = ""
   }
 
-  # SQLite location (used when backend = "sqlite"). Relative paths resolve
-  # against plugins/Spyglass/. WAL mode adds -wal/-shm sidecar files; keep
-  # the file on a local disk, not a network mount.
   sqlite {
     path = "spyglass.db"
   }
 
-  # MariaDB / MySQL connection (used when backend = "mariadb" or "mysql").
   mariadb {
     host = "localhost"
     port = 3306
-    database = "spyglass"    # created on first start if the user can
+    database = "spyglass"
     user = "root"
-    password = ""            # "" = none
-    ssl = false              # true = TLS (encrypt, no cert verify)
+    password = ""
+    ssl = false
+  }
+
+  clickhouse {
+    host = "localhost"
+    port = 8123
+    database = "spyglass"
+    table = "event_records"
+    user = "default"
+    password = ""
+    ssl = false
   }
 }
 
 storage {
   # Crash durability of the ingest queue.
-  #   "ram"         (default) - in-memory only; a hard JVM crash loses the last
-  #                 ~250 ms of events. Fine for most servers.
+  #   "ram"         (recommended) - in-memory only; a hard JVM crash loses the
+  #                 last ~250 ms of events. Fine for most servers.
   #   "wal-batched" - fsync each drain batch to an append-only log before the
   #                 database ack; leftover files replay on startup. Costs one
-  #                 fsync per batch (~every 250 ms under load), per-event
-  #                 overhead negligible. For audit logs that must survive crashes.
+  #                 fsync per batch (~every 250 ms under load). For audit logs
+  #                 that must survive crashes.
   durability = "ram"
 
   # How the per-block rollback audit trail is stored.
@@ -67,11 +71,10 @@ storage {
   # doublings past it log again). Sized ~10x steady-state peak.
   queue-capacity = 100000
 
-  # Hard ceiling on the in-memory queue. Past it, bulk-edit producers
-  # (WorldEdit/FAWE) backpressure and overflow goes to the disk spill; normal
-  # play is always admitted and the main thread never blocks on this. ~400
-  # bytes/record, so 500000 is roughly 200 MiB. 0 disables the ceiling
-  # (a big enough edit can then OOM). Keep it above queue-capacity.
+  # Hard ceiling on the in-memory queue. Past it, bulk edits (WorldEdit/FAWE)
+  # spill to disk instead of buffering in RAM. ~400 bytes/record, so 500000 is
+  # roughly 200 MiB. 0 removes the ceiling (a large edit can then OOM). Keep it
+  # above queue-capacity.
   queue-max = 500000
 
   # Spill records past queue-max to plugins/Spyglass/spill/ and replay them as
@@ -195,15 +198,13 @@ defaults {
 }
 
 limits {
-  # Hard ceiling on r:<radius>; larger values clamp down to it. This is the
-  # practical size bound on a rollback - it reverts everything its query
-  # matches inside the radius and time window, and the streaming engine keeps
-  # heap flat, so raising it costs wall-clock, never memory.
-  max-radius = 250
+  # Hard ceiling on r:<radius>; larger values clamp down to it. A rollback
+  # reverts everything its query matches inside the radius and time window.
+  max-radius = 500
 
   # Max rows a /sg search renders, and the cap on ip: reverse lookups.
   # Display-only; does not affect rollback.
-  search-result = 1000
+  search-result = 5000
 
   # Max lines one chat-history dump prints at a time.
   chat-dump = 50
@@ -228,7 +229,7 @@ limits {
 tool {
   # The inspector wand: /sg tool gives (or toggles) a block of this material;
   # clicking with it shows the block's history instead of placing/breaking.
-  material = "GLOWSTONE"
+  material = "REDSTONE_LAMP"
 
   # How far back a wand inspect looks. A cheap point query - match it to
   # storage.retention if the wand should see everything Spyglass holds.

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/ConfigMigratorTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/ConfigMigratorTest.java
@@ -1,0 +1,176 @@
+package net.medievalrp.spyglass.plugin.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+class ConfigMigratorTest {
+
+    // The v1 -> v2 remap, mirroring SpyglassConfig.MIGRATION_REMAP.
+    private static final Map<String, String> MONGO_REMAP = Map.of(
+            "database.uri", "database.mongo.uri",
+            "database.name", "database.mongo.database",
+            "database.collection", "database.mongo.collection");
+
+    @Test
+    void movesMongoKeysUnderTheBlockAndRenamesName() throws SerializationException {
+        ConfigurationNode user = BasicConfigurationNode.root();
+        user.node("database", "backend").set("mongo");
+        user.node("database", "uri").set("mongodb://db.internal:27017");
+        user.node("database", "name").set("MyDb");
+        user.node("database", "collection").set("Events");
+
+        ConfigurationNode template = freshV2Template();
+        ConfigMigrator.migrate(user, template, MONGO_REMAP, 2);
+
+        assertThat(template.node("database", "mongo", "uri").getString())
+                .isEqualTo("mongodb://db.internal:27017");
+        assertThat(template.node("database", "mongo", "database").getString()).isEqualTo("MyDb");
+        assertThat(template.node("database", "mongo", "collection").getString()).isEqualTo("Events");
+        // The operator's backend choice survives...
+        assertThat(template.node("database", "backend").getString()).isEqualTo("mongo");
+        // ...and the old bare keys are gone (the template never had them and the
+        // migration relocated rather than re-adding them).
+        assertThat(template.node("database", "uri").virtual()).isTrue();
+        assertThat(template.node("database", "name").virtual()).isTrue();
+        assertThat(template.node("config-version").getInt()).isEqualTo(2);
+    }
+
+    @Test
+    void keepsOperatorValuesThatDifferFromNewDefaults() throws SerializationException {
+        ConfigurationNode user = BasicConfigurationNode.root();
+        user.node("limits", "max-radius").set(250);   // operator kept the pre-v2 value
+        user.node("storage", "retention").set("8w");
+
+        ConfigurationNode template = freshV2Template();
+        template.node("limits", "max-radius").set(500);   // new shipped default
+        template.node("storage", "retention").set("26w");
+
+        ConfigMigrator.migrate(user, template, MONGO_REMAP, 2);
+
+        assertThat(template.node("limits", "max-radius").getInt()).isEqualTo(250);
+        assertThat(template.node("storage", "retention").getString()).isEqualTo("8w");
+    }
+
+    @Test
+    void newTemplateKeysStayAtTheirDefaultsWhenTheUserLacksThem() throws SerializationException {
+        ConfigurationNode user = BasicConfigurationNode.root();
+        user.node("server", "name").set("lobby");
+
+        ConfigurationNode template = freshV2Template();
+        template.node("metrics", "enabled").set(true);   // a key the old config never had
+
+        ConfigMigrator.migrate(user, template, MONGO_REMAP, 2);
+
+        assertThat(template.node("server", "name").getString()).isEqualTo("lobby");
+        assertThat(template.node("metrics", "enabled").getBoolean()).isTrue();
+    }
+
+    @Test
+    void replacesListValuesWholesaleRatherThanIndexMerging() throws SerializationException {
+        ConfigurationNode user = BasicConfigurationNode.root();
+        user.node("events", "command", "redact").set(List.of("login", "reg"));
+
+        ConfigurationNode template = freshV2Template();
+        template.node("events", "command", "redact").set(List.of("a", "b", "c", "d"));
+
+        ConfigMigrator.migrate(user, template, MONGO_REMAP, 2);
+
+        assertThat(template.node("events", "command", "redact").getList(String.class))
+                .containsExactly("login", "reg");
+    }
+
+    @Test
+    void absentVersionReadsAsOne() throws SerializationException {
+        ConfigurationNode node = BasicConfigurationNode.root();
+        assertThat(ConfigMigrator.readVersion(node)).isEqualTo(1);
+        node.node("config-version").set(2);
+        assertThat(ConfigMigrator.readVersion(node)).isEqualTo(2);
+    }
+
+    @Test
+    void backupDoesNotClobberAnExistingOne(@TempDir Path dir) throws IOException {
+        Path config = dir.resolve("config.conf");
+        Files.writeString(config, "config-version = 1\n");
+
+        Path first = ConfigMigrator.backup(config, "v1");
+        Files.writeString(config, "config-version = 1\nedited = true\n");
+        Path second = ConfigMigrator.backup(config, "v1");
+
+        assertThat(first).isNotEqualTo(second);
+        assertThat(Files.exists(first)).isTrue();
+        assertThat(Files.exists(second)).isTrue();
+        // The first backup still holds the original, untouched.
+        assertThat(Files.readString(first)).isEqualTo("config-version = 1\n");
+    }
+
+    @Test
+    void endToEndAgainstRealTemplateKeepsValuesAndComments(@TempDir Path dir) throws Exception {
+        // Load the actual shipped template (a main resource on the test classpath).
+        ConfigurationNode template;
+        try (java.io.InputStream in = ConfigMigratorTest.class.getResourceAsStream("/config.conf")) {
+            assertThat(in).as("bundled config.conf on classpath").isNotNull();
+            String templateText = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            template = HoconConfigurationLoader.builder()
+                    .source(() -> new java.io.BufferedReader(new java.io.StringReader(templateText)))
+                    .build().load();
+        }
+
+        // A pre-v2 on-disk config: bare mongo keys plus a value the operator kept.
+        Path file = dir.resolve("config.conf");
+        Files.writeString(file, "database {\n"
+                + "  backend = \"mongo\"\n"
+                + "  uri = \"mongodb://ops.example:27017\"\n"
+                + "  name = \"ProdDb\"\n"
+                + "  collection = \"Events\"\n"
+                + "}\n"
+                + "limits { max-radius = 250 }\n");
+        HoconConfigurationLoader loader = HoconConfigurationLoader.builder().path(file).build();
+        ConfigurationNode user = loader.load();
+
+        assertThat(ConfigMigrator.readVersion(user)).isEqualTo(1);
+        ConfigMigrator.migrate(user, template, MONGO_REMAP, 2);
+        loader.save(template);
+
+        // Re-parse the written file: structure and values are correct.
+        ConfigurationNode result = HoconConfigurationLoader.builder().path(file).build().load();
+        assertThat(result.node("database", "mongo", "uri").getString()).isEqualTo("mongodb://ops.example:27017");
+        assertThat(result.node("database", "mongo", "database").getString()).isEqualTo("ProdDb");
+        assertThat(result.node("database", "mongo", "collection").getString()).isEqualTo("Events");
+        // The v2 discrete fields arrive from the template at their defaults; the
+        // migrated connection string lands in the override, so a URI-configured
+        // operator keeps working untouched.
+        assertThat(result.node("database", "mongo", "host").getString()).isEqualTo("localhost");
+        assertThat(result.node("database", "mongo", "port").getInt()).isEqualTo(27017);
+        assertThat(result.node("database", "uri").virtual()).isTrue();            // bare key relocated
+        assertThat(result.node("database", "backend").getString()).isEqualTo("mongo");
+        assertThat(result.node("limits", "max-radius").getInt()).isEqualTo(250);  // kept, not reset to 500
+        assertThat(result.node("config-version").getInt()).isEqualTo(2);
+
+        // The template's comments made it into the upgraded file - the reason we
+        // rebuild from the template rather than editing the old file in place.
+        String written = Files.readString(file);
+        assertThat(written).contains("Storage backend");
+        assertThat(written).contains("recommended for large servers");
+    }
+
+    private static ConfigurationNode freshV2Template() throws SerializationException {
+        ConfigurationNode template = BasicConfigurationNode.root();
+        template.node("config-version").set(2);
+        template.node("database", "backend").set("sqlite");
+        template.node("database", "mongo", "uri").set("mongodb://localhost:27017");
+        template.node("database", "mongo", "database").set("Spyglass");
+        template.node("database", "mongo", "collection").set("EventRecords");
+        return template;
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/migrate/MigrateServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/migrate/MigrateServiceTest.java
@@ -93,7 +93,8 @@ class MigrateServiceTest {
     }
 
     private static SpyglassConfig.Database db(Backend active, String mongoUri, String chHost) {
-        return new SpyglassConfig.Database(active, mongoUri, "Spyglass", "EventRecords",
+        return new SpyglassConfig.Database(active,
+                new SpyglassConfig.Mongo(mongoUri, "Spyglass", "EventRecords"),
                 new SpyglassConfig.ClickHouse(chHost, 8123, "spyglass", "event_records", "default", "", false),
                 new SpyglassConfig.Sqlite("spyglass.db"),
                 new SpyglassConfig.MariaDb("localhost", 3306, "spyglass", "root", "", false));
@@ -187,7 +188,7 @@ class MigrateServiceTest {
     void validateTargetConfigFlagsBlankFields() {
         SpyglassConfig.Database blankMongo = db(Backend.SQLITE, " ", "localhost");
         assertThat(MigrateService.validateTargetConfig(blankMongo, Backend.MONGO))
-                .contains("database.uri");
+                .contains("database.mongo.uri");
 
         SpyglassConfig.Database blankCh = db(Backend.SQLITE, "mongodb://localhost", "");
         assertThat(MigrateService.validateTargetConfig(blankCh, Backend.CLICKHOUSE))


### PR DESCRIPTION
Closes #310.

## Summary
- **config-version + migrator**: an older config is backed up (non-clobbering) and rebuilt from the shipped template with the operator's values spliced in, so settings carry over and comments refresh. An unparseable config backs up and fails loud rather than resetting DB settings to defaults. The plugin gets the full migrator; the Velocity proxy keeps a read-with-fallback plus an updated stub.
- **Mongo discrete fields**: `host`/`port`/`database`/`user`/`password`/`ssl`/`collection` plus an optional `uri` override (replica sets, `mongodb+srv://` Atlas, advanced TLS). The connection string is assembled with the credentials percent-encoded, or the override is used verbatim. The record stays `(uri, database, collection)`, so no store or consumer changes.
- **v1 to v2 migration**: old bare `database.uri`/`name`/`collection` move under `mongo { }`; an old URI lands in the `uri` override so existing servers keep working untouched.
- Folds in the default-config cleanup: trimmed comments, `max-radius` 500, `search-result` 5000, wand `REDSTONE_LAMP`, durability/queue wording.

## Testing
- `ConfigMigratorTest`: remap, value preservation, list-wholesale replace, non-clobbering backup, and an end-to-end run against the real bundled `config.conf` confirming values carry over and the template comments survive the save.
- `MongoConnectionStringTest`: override-wins, assembly from fields, credential percent-encoding, TLS option.
- Full compile across all five modules; config / migrate / resolver suites green. Store integration tests need Docker and were not run (this change does not touch them).
