### PR TITLE
chore(config): collapse the schema version to 2, harden against lazy hand-edits

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/ConfigMigrator.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/ConfigMigrator.java
@@ -59,25 +59,29 @@ public final class ConfigMigrator {
     /**
      * Overlays the operator's values from {@code user} onto {@code template} and
      * stamps {@code toVersion}. {@code remaps} maps an old dotted key path to its
-     * new location; a null target drops the key. Lists and scalars are copied
-     * whole (so a list value replaces the default rather than index-merging with
-     * it); maps are recursed. Mutates and returns {@code template}.
+     * new location; a null target drops the key, and a relocation is skipped when
+     * the user's file already sets the new location explicitly (a half-updated
+     * config keeps the new-format value, whatever order its blocks are in).
+     * Lists and scalars are copied whole (so a list value replaces the default
+     * rather than index-merging with it); maps are recursed. Mutates and returns
+     * {@code template}.
      */
     public static ConfigurationNode migrate(ConfigurationNode user, ConfigurationNode template,
                                             Map<String, String> remaps, int toVersion)
             throws SerializationException {
-        overlay(user, template, remaps, new ArrayDeque<>());
+        overlay(user, user, template, remaps, new ArrayDeque<>());
         template.node("config-version").set(toVersion);
         return template;
     }
 
-    private static void overlay(ConfigurationNode node, ConfigurationNode template,
+    private static void overlay(ConfigurationNode userRoot, ConfigurationNode node,
+                                ConfigurationNode template,
                                 Map<String, String> remaps, Deque<Object> path)
             throws SerializationException {
         if (node.isMap()) {
             for (Map.Entry<Object, ? extends ConfigurationNode> child : node.childrenMap().entrySet()) {
                 path.addLast(child.getKey());
-                overlay(child.getValue(), template, remaps, path);
+                overlay(userRoot, child.getValue(), template, remaps, path);
                 path.removeLast();
             }
             return;
@@ -96,7 +100,14 @@ public final class ConfigMigrator {
             if (target == null) {
                 return;
             }
-            template.node((Object[]) target.split("\\.")).set(node.raw());
+            Object[] targetPath = target.split("\\.");
+            // The user's file may carry both the old key and an explicit value
+            // at its new location; the new-format value wins over relocation
+            // regardless of which block comes first in the file.
+            if (!userRoot.node(targetPath).virtual()) {
+                return;
+            }
+            template.node(targetPath).set(node.raw());
         } else {
             template.node(path.toArray()).set(node.raw());
         }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -41,16 +41,16 @@ public record SpyglassConfig(
      * in a way {@link ConfigMigrator} has to reconcile (a moved or renamed key).
      * A config with an older {@code config-version} is migrated on load.
      */
-    public static final int CONFIG_VERSION = 4;
+    public static final int CONFIG_VERSION = 2;
 
-    // v1 -> v2: the bare database.uri/name/collection keys moved under a
-    // mongo { } block, and `name` became `database`.
-    // v2 -> v3: storage.durability removed with the wal-batched mode (#307);
-    // a null target drops the key. Map.of rejects null values, so the table
-    // is built by hand. Package-visible so ConfigMigratorTest exercises the
-    // real table instead of a mirror.
-    // v3 -> v4: storage.rolled-audit removed; synthesized is the only
-    // rollback-audit behavior (#312).
+    // v1 -> v2 (v1 = the unversioned format up through release 1.0.8; #311,
+    // #307, and #312 all land in one release, so they share one hop): the
+    // bare database.uri/name/collection keys moved under a mongo { } block
+    // with `name` becoming `database`, and storage.durability (#307) +
+    // storage.rolled-audit (#312) were removed - a null target drops the
+    // key. Map.of rejects null values, so the table is built by hand.
+    // Package-visible so ConfigMigratorTest exercises the real table
+    // instead of a mirror.
     static final Map<String, String> MIGRATION_REMAP;
 
     static {
@@ -97,6 +97,22 @@ public record SpyglassConfig(
             }
             plugin.getLogger().info("Spyglass: migrated config v" + version + " -> v" + CONFIG_VERSION
                     + "; previous file backed up to " + saved.getFileName());
+        } else {
+            // A hand-stamped config-version on an old-format file skips
+            // migration, so its pre-move keys would be silently ignored
+            // (e.g. bare database.uri no longer selects the Mongo target).
+            // Say so instead of misreading the operator's intent quietly.
+            ConfigurationNode current = root;
+            java.util.List<String> stale = MIGRATION_REMAP.keySet().stream()
+                    .filter(key -> !current.node((Object[]) key.split("\\.")).virtual())
+                    .sorted()
+                    .toList();
+            if (!stale.isEmpty()) {
+                plugin.getLogger().warning("Spyglass: config-version is current (" + version
+                        + ") but the file still contains pre-v" + CONFIG_VERSION + " keys "
+                        + stale + "; they are IGNORED. Remove the hand-set config-version"
+                        + " line to migrate them, or delete the old keys.");
+            }
         }
 
         // Auto-merge: any event present in the jar's default config.conf but missing from

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -1,5 +1,5 @@
 # Config version - do not edit.
-config-version = 4
+config-version = 2
 
 database {
   # Storage backend; only the matching settings below are read, the rest are

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/ConfigMigratorTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/ConfigMigratorTest.java
@@ -166,47 +166,58 @@ class ConfigMigratorTest {
         assertThat(written).contains("recommended for large servers");
     }
 
-    // The upgrade the wal-batched removal (#307) leans on: an operator who
-    // opted into the knob boots the new jar with every other setting intact
-    // and the dead key gone. Before v3 a leftover unrecognized durability
-    // value would have hard-disabled the plugin at config load.
+    // The upgrade the #307/#312 removals lean on: a 1.0.8 operator who opted
+    // into wal-batched durability and receipts rolled-audit (both removed)
+    // boots the new jar with every other setting intact and the dead keys
+    // gone. Before this, a leftover unrecognized durability value would have
+    // hard-disabled the plugin at config load.
     @Test
-    void versionTwoConfigWithWalBatchedMigratesCleanly() throws SerializationException {
+    void unversionedConfigWithBothRemovedKnobsMigratesCleanly() throws SerializationException {
         ConfigurationNode user = BasicConfigurationNode.root();
-        user.node("config-version").set(2);
         user.node("storage", "durability").set("wal-batched");
+        user.node("storage", "rolled-audit").set("receipts");
         user.node("storage", "retention").set("8w");
+        user.node("storage", "queue-max").set(250_000);
         user.node("database", "backend").set("clickhouse");
 
         ConfigurationNode template = freshV2Template();
         template.node("storage", "retention").set("26w");
+        template.node("storage", "queue-max").set(500_000);
         ConfigMigrator.migrate(user, template, REMAP, SpyglassConfig.CONFIG_VERSION);
 
         assertThat(template.node("storage", "durability").virtual()).isTrue();
+        assertThat(template.node("storage", "rolled-audit").virtual()).isTrue();
         assertThat(template.node("storage", "retention").getString()).isEqualTo("8w");
+        assertThat(template.node("storage", "queue-max").getInt()).isEqualTo(250_000);
         assertThat(template.node("database", "backend").getString()).isEqualTo("clickhouse");
         assertThat(template.node("config-version").getInt())
                 .isEqualTo(SpyglassConfig.CONFIG_VERSION);
     }
 
-    // Same shape for the v4 removal (#312): an operator who opted into
-    // receipts mode migrates to always-synthesized with the dead key
-    // dropped and everything else intact.
+    // A half-updated file (the operator pasted the new mongo block but left
+    // the old bare keys) must resolve to the explicit new-format value no
+    // matter which block comes first - not to whichever the overlay happens
+    // to visit last.
     @Test
-    void versionThreeConfigWithReceiptsRolledAuditMigratesCleanly() throws SerializationException {
-        ConfigurationNode user = BasicConfigurationNode.root();
-        user.node("config-version").set(3);
-        user.node("storage", "rolled-audit").set("receipts");
-        user.node("storage", "queue-max").set(250_000);
-
-        ConfigurationNode template = freshV2Template();
-        template.node("storage", "queue-max").set(500_000);
-        ConfigMigrator.migrate(user, template, REMAP, SpyglassConfig.CONFIG_VERSION);
-
-        assertThat(template.node("storage", "rolled-audit").virtual()).isTrue();
-        assertThat(template.node("storage", "queue-max").getInt()).isEqualTo(250_000);
-        assertThat(template.node("config-version").getInt())
-                .isEqualTo(SpyglassConfig.CONFIG_VERSION);
+    void halfUpdatedConfigKeepsTheExplicitNewFormatValueInEitherOrder() throws Exception {
+        String bareFirst = "database {\n"
+                + "  uri = \"mongodb://old.example:27017\"\n"
+                + "  mongo { uri = \"mongodb://new.example:27017\" }\n"
+                + "}\n";
+        String blockFirst = "database {\n"
+                + "  mongo { uri = \"mongodb://new.example:27017\" }\n"
+                + "  uri = \"mongodb://old.example:27017\"\n"
+                + "}\n";
+        for (String content : List.of(bareFirst, blockFirst)) {
+            ConfigurationNode user = HoconConfigurationLoader.builder()
+                    .source(() -> new java.io.BufferedReader(new java.io.StringReader(content)))
+                    .build().load();
+            ConfigurationNode template = freshV2Template();
+            ConfigMigrator.migrate(user, template, REMAP, SpyglassConfig.CONFIG_VERSION);
+            assertThat(template.node("database", "mongo", "uri").getString())
+                    .as("explicit mongo.uri wins over the relocated bare uri")
+                    .isEqualTo("mongodb://new.example:27017");
+        }
     }
 
     private static ConfigurationNode freshV2Template() throws SerializationException {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
@@ -1,0 +1,208 @@
+package net.medievalrp.spyglass.plugin.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
+
+/**
+ * The operator who upgrades the jar and never reads a changelog. Every case
+ * here is a hand-mangled config that must either boot with sane values or
+ * fail loudly with the original file preserved - never silently reset, never
+ * a stack trace pointing nowhere. All through the real
+ * {@link SpyglassConfig#load} boot path.
+ */
+class LazyOperatorConfigTest {
+
+    private static JavaPlugin pluginIn(Path dataFolder) {
+        return pluginIn(dataFolder, Logger.getLogger("test"));
+    }
+
+    private static JavaPlugin pluginIn(Path dataFolder, Logger logger) {
+        JavaPlugin plugin = mock(JavaPlugin.class);
+        when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+        when(plugin.getLogger()).thenReturn(logger);
+        when(plugin.getResource("config.conf")).thenAnswer(inv ->
+                LazyOperatorConfigTest.class.getResourceAsStream("/config.conf"));
+        return plugin;
+    }
+
+    private static Path write(Path dataFolder, String content) throws IOException {
+        Path file = dataFolder.resolve("config.conf");
+        Files.writeString(file, content);
+        return file;
+    }
+
+    @Test
+    void garbageValuesInRemovedKnobsDoNotBreakBoot(@TempDir Path dataFolder) throws Exception {
+        // Nothing reads these keys anymore, so even values the old parser
+        // would have thrown on must be inert.
+        write(dataFolder, "storage {\n"
+                + "  durability = \"wal-batchedd\"\n"
+                + "  rolled-audit = 42\n"
+                + "  retention = \"8w\"\n"
+                + "}\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.storage().retention().seconds())
+                .isEqualTo(java.time.Duration.ofDays(7 * 8).toSeconds());
+    }
+
+    @Test
+    void handBrokenSyntaxFailsLoudAndPreservesTheFile(@TempDir Path dataFolder) throws Exception {
+        String broken = "database {\n  backend = \"mongo\"\n"; // unclosed brace
+        Path file = write(dataFolder, broken);
+
+        assertThatThrownBy(() -> SpyglassConfig.load(pluginIn(dataFolder)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Fix the syntax");
+
+        // The operator's file is untouched and a backup sits beside it.
+        assertThat(Files.readString(file)).isEqualTo(broken);
+        try (Stream<Path> siblings = Files.list(dataFolder)) {
+            assertThat(siblings.filter(p -> p.getFileName().toString()
+                    .startsWith("config.conf.corrupt.bak"))).hasSize(1);
+        }
+    }
+
+    @Test
+    void emptyFileLoadsDefaultsAndStampsTheVersion(@TempDir Path dataFolder) throws Exception {
+        Path file = write(dataFolder, "");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.database().backend()).isEqualTo(SpyglassConfig.Backend.SQLITE);
+        ConfigurationNode written = HoconConfigurationLoader.builder().path(file).build().load();
+        assertThat(written.node("config-version").getInt())
+                .isEqualTo(SpyglassConfig.CONFIG_VERSION);
+    }
+
+    @Test
+    void handEditedFutureVersionSkipsMigrationAndStillBoots(@TempDir Path dataFolder)
+            throws Exception {
+        write(dataFolder, "config-version = 99\n"
+                + "storage { durability = \"wal-batched\", retention = \"8w\" }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.storage().retention().seconds())
+                .isEqualTo(java.time.Duration.ofDays(7 * 8).toSeconds());
+        // No migration ran, so no backup appeared.
+        try (Stream<Path> siblings = Files.list(dataFolder)) {
+            assertThat(siblings.filter(p -> p.getFileName().toString().contains(".bak")))
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void handStampedCurrentVersionOnOldFormatFileWarnsAboutIgnoredKeys(@TempDir Path dataFolder)
+            throws Exception {
+        // The nastiest lazy edit: copying "config-version = 2" into an
+        // old-format file suppresses migration, so the bare mongo keys are
+        // silently dead. The load must say so.
+        write(dataFolder, "config-version = " + SpyglassConfig.CONFIG_VERSION + "\n"
+                + "database {\n"
+                + "  backend = \"mongo\"\n"
+                + "  uri = \"mongodb://ops.example:27017\"\n"
+                + "}\n"
+                + "storage { durability = \"wal-batched\" }\n");
+
+        StringBuilder warnings = new StringBuilder();
+        Logger logger = Logger.getLogger("lazy-test-" + System.nanoTime());
+        logger.setUseParentHandlers(false);
+        logger.addHandler(new Handler() {
+            @Override public void publish(LogRecord r) { warnings.append(r.getMessage()).append('\n'); }
+            @Override public void flush() { }
+            @Override public void close() { }
+        });
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder, logger));
+
+        // Boots - but on the mongo defaults, and the log names the dead keys.
+        assertThat(config.database().backend()).isEqualTo(SpyglassConfig.Backend.MONGO);
+        assertThat(warnings.toString())
+                .contains("IGNORED")
+                .contains("database.uri")
+                .contains("storage.durability");
+    }
+
+    @Test
+    void nonNumericVersionReadsAsPreVersioningAndMigrates(@TempDir Path dataFolder)
+            throws Exception {
+        Path file = write(dataFolder, "config-version = \"latest\"\n"
+                + "storage { rolled-audit = \"receipts\", retention = \"8w\" }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.storage().retention().seconds())
+                .isEqualTo(java.time.Duration.ofDays(7 * 8).toSeconds());
+        ConfigurationNode written = HoconConfigurationLoader.builder().path(file).build().load();
+        assertThat(written.node("config-version").getInt())
+                .isEqualTo(SpyglassConfig.CONFIG_VERSION);
+        assertThat(written.node("storage", "rolled-audit").virtual()).isTrue();
+    }
+
+    @Test
+    void wrongTypedNumbersFallBackToDefaultsInsteadOfCrashing(@TempDir Path dataFolder)
+            throws Exception {
+        write(dataFolder, "storage { queue-max = \"half a million\" }\n"
+                + "defaults { radius = \"big\" }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.storage().queueMax()).isEqualTo(500_000);
+        assertThat(config.defaults().radius()).isEqualTo(250);
+    }
+
+    @Test
+    void unparseableRetentionDisablesLoudlyRatherThanGuessing(@TempDir Path dataFolder)
+            throws Exception {
+        // Deliberate hard-fail: retention drives deletion, and guessing a
+        // default here could purge history the operator meant to keep
+        // forever. The plugin disables with the cause instead.
+        write(dataFolder, "storage { retention = \"banana\" }\n");
+
+        assertThatThrownBy(() -> SpyglassConfig.load(pluginIn(dataFolder)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void removedLimitsKnobsAndInventedKeysAreHarmless(@TempDir Path dataFolder) throws Exception {
+        write(dataFolder, "limits {\n"
+                + "  rollback-result = 1000\n"
+                + "  rollback-page-size = 50\n"
+                + "  rollback-undo-cap = 10\n"
+                + "  max-radius = 350\n"
+                + "}\n"
+                + "storage { chunk-loading = \"async\" }\n"
+                + "my-own-block { note = \"do not delete\" }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.limits().maxRadius()).isEqualTo(350);
+    }
+
+    @Test
+    void eventEntryWithWrongShapeFallsBackToDefaults(@TempDir Path dataFolder) throws Exception {
+        write(dataFolder, "events { break = \"yes\" }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.enabled("break")).isTrue();
+        assertThat(config.pastTense("break")).isEqualTo("break");
+    }
+}


### PR DESCRIPTION
Follow-up to #313 / #316. Since #311, #307, and #312 all ship in the unreleased 1.0.9, the on-disk schema needs only one hop: v1 (the unversioned 1.0.8 format) -> v2 (current). `CONFIG_VERSION` drops from 4 to 2; the cumulative remap table is unchanged.

Also the results of an adversarial pass playing the operator who upgrades the jar without reading a changelog - every case driven through the real `SpyglassConfig.load` (new `LazyOperatorConfigTest`, 10 cases) and the worst two verified on a live Paper 1.21.8 boot:

**Fixed**
- Half-updated config (old bare `database.uri` AND a pasted `mongo { uri }` block): the explicit new-format value now wins regardless of block order; previously whichever key the overlay visited last won.
- Hand-stamped `config-version = 2` on an old-format file suppresses migration and silently kills the bare mongo keys; the load now WARNs naming the ignored keys and the fix.

**Verified already-safe (pinned as tests)**
- Typo'd removed knobs (`durability = "wal-bached"`, `rolled-audit = "recipts"`) boot fine - the old parser would have hard-disabled on these.
- Broken HOCON syntax: plugin disables with a clear message, `.corrupt.bak` backup, original preserved.
- Empty file, future `config-version = 99`, non-numeric `config-version = "latest"`, wrong-typed numbers (`queue-max = "lots"` -> default), resurrected pre-1.0.8 limits knobs, invented keys and blocks (carried, not lost).
- `retention = "banana"` still hard-fails on purpose - guessing a retention could purge history meant to be kept forever.

Live boot: the 1.0.8 config with all of the above mangling at once migrated `v1 -> v2`, kept every custom value, dropped the dead knobs, and enabled cleanly.

`./gradlew check` green.