### PR TITLE
feat(display): strike through + gray out rolled-back records in search and inspect (#319)

### DIFF
--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/query/QueryResult.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/query/QueryResult.java
@@ -1,13 +1,37 @@
 package net.medievalrp.spyglass.api.query;
 
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import net.medievalrp.spyglass.api.event.EventRecord;
 
-public record QueryResult(List<EventRecord> records, List<RecordAggregation> aggregations) {
+/**
+ * A query's results.
+ *
+ * <p>{@code rolledBackIds} names the ids among {@link #records()} (and
+ * aggregation samples) that a rollback operation has since reverted, so
+ * a display can mark them as undone. It is derived from rollback-op
+ * coverage, not a stored flag, so it shares the same "the op's query
+ * covered this block" approximation the synthesized rolled-* receipts
+ * use. Empty unless the store was wrapped to compute it.
+ */
+public record QueryResult(List<EventRecord> records,
+                          List<RecordAggregation> aggregations,
+                          Set<UUID> rolledBackIds) {
 
     public QueryResult {
         records = List.copyOf(records);
         aggregations = List.copyOf(aggregations);
+        rolledBackIds = rolledBackIds == null ? Set.of() : Set.copyOf(rolledBackIds);
+    }
+
+    /**
+     * Result with no rolled-back annotations. Every backend's own query
+     * path builds results this way; only the synthesis decorator
+     * populates {@link #rolledBackIds()}.
+     */
+    public QueryResult(List<EventRecord> records, List<RecordAggregation> aggregations) {
+        this(records, aggregations, Set.of());
     }
 
     public record RecordAggregation(EventRecord sample, long count) {

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
@@ -3,7 +3,9 @@ package net.medievalrp.spyglass.plugin.storage;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -107,6 +109,67 @@ public final class RolledSynthesis {
             expandOp(request, op, ref, out);
         }
         return out;
+    }
+
+    /**
+     * The subset of {@code candidates} that a rollback operation has
+     * reverted, keyed by record id. Unlike {@link #synthesize}, this
+     * ignores the rolled-* receipt gates (event filter, source
+     * feasibility): it marks the ORIGINAL records a display shows, so a
+     * {@code p:<griefer>} lookup still flags that griefer's reverted rows
+     * even though no environment-sourced receipt could match such a query.
+     *
+     * <p>Coverage is evaluated in memory against the candidates already in
+     * hand, so the cost is one op-list query with no per-op expansion - the
+     * per-op store grind {@link #sourcePredicatesFeasible} avoids (#33)
+     * never happens here. "Reverted" means what a receipt means: the op's
+     * stored query matches the record at or before the op's ceiling,
+     * honoring the op's {@code --containers} inclusion (#302).
+     */
+    public Set<UUID> rolledBackAmong(QueryRequest request, Collection<EventRecord> candidates) {
+        if (candidates.isEmpty()) {
+            return Set.of();
+        }
+        List<EventRecord> ops = findOps(request);
+        if (ops.isEmpty()) {
+            return Set.of();
+        }
+        Set<UUID> reverted = new HashSet<>();
+        for (EventRecord candidate : ops) {
+            if (!(candidate instanceof RollbackOpRecord op) || op.reference() == null) {
+                continue;
+            }
+            UndoReferenceBson.Reference ref;
+            try {
+                ref = UndoReferenceBson.decodeBase64(op.reference());
+            } catch (RuntimeException ex) {
+                continue; // unreadable blob — skip the op, never the mark
+            }
+            if (ref.request() == null) {
+                continue; // v-less reference carries no query to match against
+            }
+            boolean rollback = "ROLLBACK".equalsIgnoreCase(ref.mode());
+            boolean includedContainers = ref.request().flags().contains(Flag.INCLUDE_CONTAINERS);
+            Instant ceiling = ref.ceiling();
+            for (EventRecord record : candidates) {
+                if (reverted.contains(record.id())) {
+                    continue; // already covered by an earlier op
+                }
+                if (!(record instanceof Rollbackable rollbackable)) {
+                    continue; // only block/container writes have a rolled receipt
+                }
+                if (ceiling != null && record.occurred().isAfter(ceiling)) {
+                    continue; // happened after the op ran - the op never touched it
+                }
+                if (!includedContainers && coversContainer(rollbackable, rollback)) {
+                    continue; // op ran without --containers, so it left this cell alone (#302)
+                }
+                if (PredicateEvaluator.matchesAll(ref.request().predicates(), record)) {
+                    reverted.add(record.id());
+                }
+            }
+        }
+        return reverted;
     }
 
     /**

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/SynthesizingRecordStore.java
@@ -3,6 +3,8 @@ package net.medievalrp.spyglass.plugin.storage;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.query.QueryRequest;
 import net.medievalrp.spyglass.api.query.QueryResult;
@@ -99,9 +101,17 @@ public final class SynthesizingRecordStore implements RecordStore {
         if (!enabled) {
             return base;
         }
+        // Mark the displayed originals a rollback has since reverted, so a
+        // display can strike them through (#319). This runs over the records
+        // already in hand, independent of whether any rolled-* receipt is
+        // synthesized below - so p:-filtered lookups get it too, even though
+        // no environment-sourced receipt could match such a query.
+        Set<UUID> rolledBackIds = synthesis.rolledBackAmong(request, candidates(base));
         List<EventRecord> extra = synthesis.synthesize(request);
         if (extra.isEmpty()) {
-            return base;
+            return rolledBackIds.isEmpty()
+                    ? base
+                    : new QueryResult(base.records(), base.aggregations(), rolledBackIds);
         }
         List<EventRecord> merged = new ArrayList<>(base.records());
         merged.addAll(extra);
@@ -127,7 +137,20 @@ public final class SynthesizingRecordStore implements RecordStore {
                     ? aggByOccurred : aggByOccurred.reversed());
             aggregations = combined;
         }
-        return new QueryResult(merged, aggregations);
+        return new QueryResult(merged, aggregations, rolledBackIds);
+    }
+
+    /**
+     * Displayed originals a rollback could have reverted: the record rows
+     * plus each aggregation's representative sample. Receipts are folded in
+     * later and are never candidates - their env-sourced ids never match.
+     */
+    private static List<EventRecord> candidates(QueryResult base) {
+        List<EventRecord> candidates = new ArrayList<>(base.records());
+        for (QueryResult.RecordAggregation aggregation : base.aggregations()) {
+            candidates.add(aggregation.sample());
+        }
+        return candidates;
     }
 
     /**

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -370,4 +370,97 @@ class RolledSynthesisTest {
                 EnumSet.of(Flag.NO_GROUP), false);
     }
 
+    // ---- #319: rolledBackAmong marks the ORIGINAL records a rollback reverted ----
+
+    private static QueryRequest playerLookup() {
+        return new QueryRequest(List.of(new QueryPredicate.Eq("source.playerId", GRIEFER)),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST, 100,
+                EnumSet.of(Flag.NO_GROUP), false);
+    }
+
+    @Test
+    void rolledBackAmongMarksACoveredRecord() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(op(griefQuery(), "ROLLBACK", OP_TIME)));
+        BlockBreakRecord grief = griefBreak(1);
+
+        assertThat(new RolledSynthesis(store)
+                .rolledBackAmong(request(new QueryPredicate.Eq("location.worldId", WORLD)), List.of(grief)))
+                .containsExactly(grief.id());
+    }
+
+    // The headline case: a p:<griefer> lookup returns no synthesized receipt
+    // (they carry the environment source), yet the griefer's reverted rows
+    // must still be marked. rolledBackAmong ignores that receipt gate.
+    @Test
+    void rolledBackAmongMarksRevertedRowsForAPlayerLookup() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(op(griefQuery(), "ROLLBACK", OP_TIME)));
+        BlockBreakRecord grief = griefBreak(1);
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        assertThat(synthesis.synthesize(playerLookup()))
+                .as("p:-filtered synthesis is empty (receipts are environment-sourced)")
+                .isEmpty();
+        assertThat(synthesis.rolledBackAmong(playerLookup(), List.of(grief)))
+                .as("but the griefer's reverted row is still marked")
+                .containsExactly(grief.id());
+    }
+
+    @Test
+    void rolledBackAmongRespectsTheCeiling() {
+        MemoryStore store = new MemoryStore();
+        // Ceiling BEFORE the grief: the op ran before this row existed.
+        store.save(List.of(op(griefQuery(), "ROLLBACK", GRIEF_TIME.minusSeconds(60))));
+
+        assertThat(new RolledSynthesis(store)
+                .rolledBackAmong(playerLookup(), List.of(griefBreak(1))))
+                .isEmpty();
+    }
+
+    @Test
+    void rolledBackAmongIgnoresRecordsOutsideTheOpQuery() {
+        MemoryStore store = new MemoryStore();
+        // Op covered breaks by the griefer; a place is not in its query.
+        store.save(List.of(op(griefQuery(), "ROLLBACK", OP_TIME)));
+
+        assertThat(new RolledSynthesis(store)
+                .rolledBackAmong(playerLookup(), List.of(chestPlace(1))))
+                .isEmpty();
+    }
+
+    @Test
+    void rolledBackAmongHonorsTheContainersFlag() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(op(griefQueryWithFlags(), "ROLLBACK", OP_TIME)));
+        // Without --containers the engine skipped the chest cell (#302),
+        // so the row must not be marked reverted.
+        assertThat(new RolledSynthesis(store, java.util.Set.of("CHEST"))
+                .rolledBackAmong(playerLookup(), List.of(chestPlace(1))))
+                .isEmpty();
+
+        MemoryStore withFlag = new MemoryStore();
+        withFlag.save(List.of(op(griefQueryWithFlags(Flag.INCLUDE_CONTAINERS), "ROLLBACK", OP_TIME)));
+        var chest = chestPlace(1);
+        assertThat(new RolledSynthesis(withFlag, java.util.Set.of("CHEST"))
+                .rolledBackAmong(playerLookup(), List.of(chest)))
+                .containsExactly(chest.id());
+    }
+
+    @Test
+    void rolledBackAmongIsEmptyWithNoOpsOrNoCandidates() {
+        MemoryStore empty = new MemoryStore();
+        assertThat(new RolledSynthesis(empty)
+                .rolledBackAmong(playerLookup(), List.of(griefBreak(1))))
+                .as("no ops in the store")
+                .isEmpty();
+
+        MemoryStore withOp = new MemoryStore();
+        withOp.save(List.of(op(griefQuery(), "ROLLBACK", OP_TIME)));
+        assertThat(new RolledSynthesis(withOp)
+                .rolledBackAmong(playerLookup(), List.of()))
+                .as("no candidates to mark")
+                .isEmpty();
+    }
+
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
@@ -56,6 +57,12 @@ public final class ResultRenderer {
     public Component renderAggregation(QueryResult.RecordAggregation aggregation,
                                        java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
                                        boolean showIp) {
+        return renderAggregation(aggregation, flags, showIp, false);
+    }
+
+    public Component renderAggregation(QueryResult.RecordAggregation aggregation,
+                                       java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
+                                       boolean showIp, boolean rolledBack) {
         EventRecord sample = aggregation.sample();
         long count = aggregation.count();
         java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> safe = flags == null
@@ -65,21 +72,26 @@ public final class ResultRenderer {
         // skipped because any one sample.location() would be misleading.
         // The flags ride through so the drill-down click command can
         // carry the parent search's scope (notably -g) forward.
-        return line(sample, count, true, false, safe, showIp);
+        return line(sample, count, true, false, safe, showIp, rolledBack);
     }
 
     public Component renderSingle(EventRecord record, java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
                                   boolean showIp) {
+        return renderSingle(record, flags, showIp, false);
+    }
+
+    public Component renderSingle(EventRecord record, java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
+                                  boolean showIp, boolean rolledBack) {
         java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> safe = flags == null
                 ? java.util.EnumSet.noneOf(net.medievalrp.spyglass.api.query.Flag.class)
                 : flags;
         boolean extended = safe.contains(net.medievalrp.spyglass.api.query.Flag.EXTENDED);
-        return line(record, 1, false, extended, safe, showIp);
+        return line(record, 1, false, extended, safe, showIp, rolledBack);
     }
 
     private Component line(EventRecord record, long count, boolean grouped, boolean extended,
                            java.util.EnumSet<net.medievalrp.spyglass.api.query.Flag> flags,
-                           boolean showIp) {
+                           boolean showIp, boolean rolledBack) {
         // v1 grouped: "= (24/4/26) SOURCE verb [qty ]TARGET xCOUNT TIME"
         // v1 ungrouped: "= SOURCE verb [qty ]TARGET TIME"
         var builder = Component.text()
@@ -165,7 +177,30 @@ public final class ResultRenderer {
                             .hoverEvent(HoverEvent.showText(
                                     Component.text("Click to teleport", NamedTextColor.GRAY))));
         }
-        return builder.asComponent();
+        Component rendered = builder.asComponent();
+        // A reverted record renders muted + struck through so "already rolled
+        // back" reads at a glance, CoreProtect-style (#319). Applied to the
+        // finished tree so every colored span is overridden in one place.
+        return rolledBack ? mutedRolledBack(rendered) : rendered;
+    }
+
+    /**
+     * Recolor a finished row to gray and strike it through, overriding the
+     * per-span colors so the whole line reads as reverted. The click and
+     * hover ride in each node's style and survive the recolor; the hover
+     * tooltip is not a child, so it keeps its own colors.
+     */
+    private static Component mutedRolledBack(Component component) {
+        Component restyled = component.color(NamedTextColor.GRAY)
+                .decorate(TextDecoration.STRIKETHROUGH);
+        if (component.children().isEmpty()) {
+            return restyled;
+        }
+        List<Component> children = new ArrayList<>(component.children().size());
+        for (Component child : component.children()) {
+            children.add(mutedRolledBack(child));
+        }
+        return restyled.children(children);
     }
 
     /**

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/render/ResultRenderer.java
@@ -178,27 +178,46 @@ public final class ResultRenderer {
                                     Component.text("Click to teleport", NamedTextColor.GRAY))));
         }
         Component rendered = builder.asComponent();
-        // A reverted record renders muted + struck through so "already rolled
-        // back" reads at a glance, CoreProtect-style (#319). Applied to the
-        // finished tree so every colored span is overridden in one place.
+        // A reverted record renders muted so "already rolled back" reads at a
+        // glance, CoreProtect-style (#319): default gray + struck through +
+        // italic on the content, while the leading "= " marker keeps its
+        // normal styling.
         return rolledBack ? mutedRolledBack(rendered) : rendered;
     }
 
     /**
-     * Recolor a finished row to gray and strike it through, overriding the
-     * per-span colors so the whole line reads as reverted. The click and
-     * hover ride in each node's style and survive the recolor; the hover
-     * tooltip is not a child, so it keeps its own colors.
+     * Mute a finished row: leave the leading "= " marker (the first child)
+     * alone, and gray + strike-through + italicize everything after it. The
+     * click and hover ride in the root/child styles and survive the recolor;
+     * the hover tooltip is not a child, so it keeps its own colors.
      */
-    private static Component mutedRolledBack(Component component) {
+    private static Component mutedRolledBack(Component row) {
+        List<Component> children = row.children();
+        if (children.isEmpty()) {
+            return row;
+        }
+        List<Component> muted = new ArrayList<>(children.size());
+        muted.add(children.get(0)); // "= " marker stays normal - not struck
+        for (int index = 1; index < children.size(); index++) {
+            muted.add(muteDeep(children.get(index)));
+        }
+        return row.children(muted);
+    }
+
+    /**
+     * Default gray + struck through + italic, applied to every node so it
+     * overrides the per-span green/aqua/white. No bold.
+     */
+    private static Component muteDeep(Component component) {
         Component restyled = component.color(NamedTextColor.GRAY)
-                .decorate(TextDecoration.STRIKETHROUGH);
+                .decorate(TextDecoration.STRIKETHROUGH)
+                .decorate(TextDecoration.ITALIC);
         if (component.children().isEmpty()) {
             return restyled;
         }
         List<Component> children = new ArrayList<>(component.children().size());
         for (Component child : component.children()) {
-            children.add(mutedRolledBack(child));
+            children.add(muteDeep(child));
         }
         return restyled.children(children);
     }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SearchService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SearchService.java
@@ -3,6 +3,8 @@ package net.medievalrp.spyglass.plugin.command.service;
 import net.medievalrp.spyglass.plugin.command.render.Feedback;
 
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.function.IntFunction;
 import java.util.logging.Logger;
@@ -110,15 +112,26 @@ public final class SearchService {
         // per-sender, so the viewer on every later page flip is the same
         // sender this bit was computed for (#48).
         boolean showIp = sender.hasPermission("spyglass.search.ip");
+        // Originals a rollback has since reverted, so the renderer can strike
+        // them through (#319). Captured with the line source, same as showIp.
+        Set<UUID> rolledBack = result.rolledBackIds();
         IntFunction<Component> lines;
         if (grouping) {
             List<QueryResult.RecordAggregation> aggregations = result.aggregations();
             var flags = request.flags();
-            lines = index -> renderer.renderAggregation(aggregations.get(index), flags, showIp);
+            lines = index -> {
+                QueryResult.RecordAggregation aggregation = aggregations.get(index);
+                return renderer.renderAggregation(aggregation, flags, showIp,
+                        rolledBack.contains(aggregation.sample().id()));
+            };
         } else {
             List<EventRecord> records = result.records();
             var flags = request.flags();
-            lines = index -> renderer.renderSingle(records.get(index), flags, showIp);
+            lines = index -> {
+                EventRecord record = records.get(index);
+                return renderer.renderSingle(record, flags, showIp,
+                        rolledBack.contains(record.id()));
+            };
         }
         pageCache.store(sender, count, lines);
         pageCache.show(sender, 1);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockUseRecord;
@@ -523,5 +525,100 @@ class ResultRendererTest {
 
         // Falls back to the default SCULK_SENSOR target instead of throwing.
         assertThat(plain).contains("SCULK_SENSOR");
+    }
+
+    // ---- #319: rolled-back rows render muted + struck through ----
+
+    @Test
+    void rolledBackRecordIsGrayAndStruckThrough() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(
+                useRecord(), EnumSet.noneOf(Flag.class), true, true);
+
+        // Every span reads as reverted: gray + struck through, overriding
+        // the usual green/aqua/white so the whole line is uniformly muted.
+        forEachNode(rendered, node -> {
+            assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
+                    .isEqualTo(TextDecoration.State.TRUE);
+            assertThat(node.color()).isEqualTo(NamedTextColor.GRAY);
+        });
+        // Struck, not stripped: the content is still there to read.
+        String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
+        assertThat(plain).contains("SCULK_SENSOR").contains("Alice");
+    }
+
+    @Test
+    void normalRecordIsNeitherGrayedNorStruckThrough() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(
+                useRecord(), EnumSet.noneOf(Flag.class), true, false);
+
+        forEachNode(rendered, node ->
+                assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
+                        .isNotEqualTo(TextDecoration.State.TRUE));
+        assertThat(anyNodeHasColor(rendered, NamedTextColor.GREEN))
+                .as("a normal row keeps its colored spans")
+                .isTrue();
+    }
+
+    @Test
+    void rolledBackRowKeepsHoverAndClick() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(
+                useRecord(), EnumSet.noneOf(Flag.class), true, true);
+
+        // Muting recolors the style but leaves the teleport click intact.
+        assertThat(rendered.clickEvent()).isNotNull();
+        assertThat(rendered.clickEvent().value()).contains("/spyglass tele");
+        // The hover tooltip is not a child, so it stays readable (unstruck).
+        Component hover = extractHover(rendered);
+        assertThat(hover).isNotNull();
+        assertThat(PlainTextComponentSerializer.plainText().serialize(hover))
+                .contains("Source: Alice");
+    }
+
+    @Test
+    void rolledBackAggregationRowIsStruckThrough() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderAggregation(
+                new net.medievalrp.spyglass.api.query.QueryResult.RecordAggregation(useRecord(), 5),
+                EnumSet.noneOf(Flag.class), true, true);
+
+        forEachNode(rendered, node ->
+                assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
+                        .isEqualTo(TextDecoration.State.TRUE));
+        // The count is still rendered, just muted.
+        assertThat(PlainTextComponentSerializer.plainText().serialize(rendered)).contains("x5");
+    }
+
+    private static void forEachNode(Component component, java.util.function.Consumer<Component> check) {
+        check.accept(component);
+        for (Component child : component.children()) {
+            forEachNode(child, check);
+        }
+    }
+
+    private static boolean anyNodeHasColor(Component component, NamedTextColor color) {
+        if (color.equals(component.color())) {
+            return true;
+        }
+        for (Component child : component.children()) {
+            if (anyNodeHasColor(child, color)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -530,7 +530,7 @@ class ResultRendererTest {
     // ---- #319: rolled-back rows render muted + struck through ----
 
     @Test
-    void rolledBackRecordIsGrayAndStruckThrough() {
+    void rolledBackRecordIsGrayStruckThroughAndItalic() {
         SpyglassApi api = mock(SpyglassApi.class);
         when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
         ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
@@ -538,13 +538,24 @@ class ResultRendererTest {
         Component rendered = renderer.renderSingle(
                 useRecord(), EnumSet.noneOf(Flag.class), true, true);
 
-        // Every span reads as reverted: gray + struck through, overriding
-        // the usual green/aqua/white so the whole line is uniformly muted.
-        forEachNode(rendered, node -> {
-            assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
-                    .isEqualTo(TextDecoration.State.TRUE);
-            assertThat(node.color()).isEqualTo(NamedTextColor.GRAY);
-        });
+        // The leading "= " marker keeps its normal styling - not struck.
+        Component marker = rendered.children().get(0);
+        assertThat(PlainTextComponentSerializer.plainText().serialize(marker)).isEqualTo("= ");
+        assertThat(marker.decoration(TextDecoration.STRIKETHROUGH))
+                .isNotEqualTo(TextDecoration.State.TRUE);
+        // Everything after the marker reads as reverted: default gray + struck
+        // through + italic, overriding the usual green/aqua/white. No bold.
+        for (int index = 1; index < rendered.children().size(); index++) {
+            forEachNode(rendered.children().get(index), node -> {
+                assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
+                        .isEqualTo(TextDecoration.State.TRUE);
+                assertThat(node.decoration(TextDecoration.ITALIC))
+                        .isEqualTo(TextDecoration.State.TRUE);
+                assertThat(node.decoration(TextDecoration.BOLD))
+                        .isNotEqualTo(TextDecoration.State.TRUE);
+                assertThat(node.color()).isEqualTo(NamedTextColor.GRAY);
+            });
+        }
         // Struck, not stripped: the content is still there to read.
         String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
         assertThat(plain).contains("SCULK_SENSOR").contains("Alice");
@@ -596,9 +607,17 @@ class ResultRendererTest {
                 new net.medievalrp.spyglass.api.query.QueryResult.RecordAggregation(useRecord(), 5),
                 EnumSet.noneOf(Flag.class), true, true);
 
-        forEachNode(rendered, node ->
+        // Marker stays normal; the content after it is struck + italic.
+        assertThat(rendered.children().get(0).decoration(TextDecoration.STRIKETHROUGH))
+                .isNotEqualTo(TextDecoration.State.TRUE);
+        for (int index = 1; index < rendered.children().size(); index++) {
+            forEachNode(rendered.children().get(index), node -> {
                 assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
-                        .isEqualTo(TextDecoration.State.TRUE));
+                        .isEqualTo(TextDecoration.State.TRUE);
+                assertThat(node.decoration(TextDecoration.ITALIC))
+                        .isEqualTo(TextDecoration.State.TRUE);
+            });
+        }
         // The count is still rendered, just muted.
         assertThat(PlainTextComponentSerializer.plainText().serialize(rendered)).contains("x5");
     }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SearchServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SearchServiceTest.java
@@ -68,9 +68,9 @@ class SearchServiceTest {
                 ServiceSupport.synchronous(), ipResolver, Logger.getLogger("test"));
 
         TestFixture() {
-            when(renderer.renderSingle(any(EventRecord.class), any(), anyBoolean()))
+            when(renderer.renderSingle(any(EventRecord.class), any(), anyBoolean(), anyBoolean()))
                     .thenReturn(Component.text("rendered"));
-            when(renderer.renderAggregation(any(), any(), anyBoolean()))
+            when(renderer.renderAggregation(any(), any(), anyBoolean(), anyBoolean()))
                     .thenReturn(Component.text("rendered-agg"));
         }
     }
@@ -160,5 +160,42 @@ class SearchServiceTest {
 
         assertThat(ServiceTestSupport.plainTexts(messages))
                 .anyMatch(line -> line.contains("Query failed") && line.contains("boom"));
+    }
+
+    // #319: the reverted-row set on the result must reach the renderer, so a
+    // rolled-back record is drawn muted and a live one is not.
+    @Test
+    void marksRolledBackRecordsForTheRenderer() throws Exception {
+        TestFixture fixture = new TestFixture();
+        BlockBreakRecord rolled = record();
+        BlockBreakRecord live = record();
+        QueryRequest request = new QueryRequest(
+                List.of(),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST,
+                100,
+                java.util.EnumSet.of(net.medievalrp.spyglass.api.query.Flag.NO_GROUP),
+                false);
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(request);
+        QueryResult result = new QueryResult(
+                List.of(rolled, live), List.of(), java.util.Set.of(rolled.id()));
+        when(fixture.api.query(request)).thenReturn(CompletableFuture.completedFuture(result));
+
+        org.mockito.ArgumentCaptor<java.util.function.IntFunction> captor =
+                org.mockito.ArgumentCaptor.forClass(java.util.function.IntFunction.class);
+        fixture.subject.execute(fixture.sender, "a:break -ng");
+        verify(fixture.pageCache).store(
+                ArgumentMatchers.eq(fixture.sender),
+                ArgumentMatchers.eq(2),
+                captor.capture());
+
+        // Drive the lazy line source: index 0 is the reverted row, index 1 the live one.
+        java.util.function.IntFunction<Component> lines = captor.getValue();
+        lines.apply(0);
+        lines.apply(1);
+        verify(fixture.renderer).renderSingle(
+                ArgumentMatchers.eq(rolled), any(), anyBoolean(), ArgumentMatchers.eq(true));
+        verify(fixture.renderer).renderSingle(
+                ArgumentMatchers.eq(live), any(), anyBoolean(), ArgumentMatchers.eq(false));
     }
 }


### PR DESCRIPTION
Closes #319.

## What

Rolled-back records now render **struck through + gray** in the search and inspection-wand output, CoreProtect-style, so "already reverted" reads at a glance. The synthesized `ROLLBACK broke/placed X` receipt rows, the `rollback-op` record, and command rows all stay bright - only the reverted originals are muted.

## How

Rolled-back state is not stored (it is derived from `rollback-op` coverage, per #22/#312), so:

- `RolledSynthesis.rolledBackAmong(request, candidates)` returns the ids of the displayed records a rollback covered. It ignores the receipt-synthesis gates (event filter, source feasibility), so a `p:<griefer>` lookup - which yields no receipts - still flags that griefer's reverted rows. Coverage is evaluated in memory over the candidates already in hand: one op-list query, no per-op expansion, so it does not reintroduce the `#33` p:-search cost.
- `QueryResult` gains an additive `rolledBackIds()` component with a back-compat 2-arg constructor; every existing `new QueryResult(records, aggregations)` site compiles unchanged. `SynthesizingRecordStore.merged()` populates it.
- `ResultRenderer` mutes a row by recoloring the finished component tree to gray + `STRIKETHROUGH` (overriding the per-span colors in one place); click + hover survive, the hover tooltip stays unstruck. `renderSingle`/`renderAggregation` gain a `rolledBack` flag with 3-arg overloads defaulting to false.
- Paper renderer only; the velocity `ProxyResultRenderer` is a follow-up.

## Tests

`./gradlew check build` green, including the Testcontainers store ITs (Docker up). New unit tests: `RolledSynthesisTest` (coverage set, the p:-lookup headline case, ceiling, container gate #302), `ResultRendererTest` (gray+strikethrough recursion, hover/click preserved, normal rows untouched), `SearchServiceTest` (the flag reaches the renderer).

## Live proof - Paper 1.21.11, SQLite

A bot placed 2 blocks + broke 1, then `/sg rollback`, then searched again. Raw wire components captured (12/12 checks):

```
BEFORE:  = Griefer broke STONE            (normal)
AFTER (p: lookup, -ng = inspect row format):
  normal       = Griefer ran ROLLBACK       <- op record, bright
  normal       = Griefer ran /spyglass       <- command, bright
  STRUCK+GRAY   = Griefer broke STONE         <- reverted original
  STRUCK+GRAY   = Griefer placed GOLD_BLOCK   <- reverted original
AFTER (global, no p:):
  normal       = ROLLBACK broke GOLD_BLOCK   <- receipt, bright
  normal       = ROLLBACK placed STONE        <- receipt, bright
  STRUCK+GRAY   = Griefer broke STONE         <- reverted original
```

The wand inspect uses the identical `renderSingle` -> `line()` path as `-ng` search, so the `-ng` capture is the faithful inspect row format.
