### PR TITLE
fix(rollback): per-cell coalescing for multi-event cells (#321)

### DIFF
--- a/regression/bot/cases/g-rollback.js
+++ b/regression/bot/cases/g-rollback.js
@@ -80,7 +80,7 @@ export default [
 },
 
 {
-    id: 'G3', title: 'identical rollback re-run: skips, no double-apply',
+    id: 'G3', title: 'identical rollback re-run converges, no drift',
     async run(bot) {
         const r = freshResult();
         const plot = nextPlot();
@@ -90,9 +90,14 @@ export default [
             await slabGrief(bot, plot);
             const rb1 = await sgOp(bot, 'rollback', `p:${bot.username} t:60s r:16`);
             const rb2 = await sgOp(bot, 'rollback', `p:${bot.username} t:60s r:16`);
-            check(r, 'sg', rb1.applied >= 64 && rb2.applied === 0 && await allAre(samples, 'stone'),
-                `re-run applied 0 (first ${rb1.applied}; re-run: ${rb2.line.trim()})`,
-                `re-run applied ${rb2.applied}, expected 0 — fast-path force-overwrite, issue #27`);
+            // Force-overwrite (#69) deliberately has no live-state guard:
+            // the re-run re-applies every matched cell to the same recorded
+            // state and the world must not drift. (The old expectation of
+            // "re-run applied 0" asserted the pre-#69 #27 skip semantics.)
+            check(r, 'sg', rb1.applied >= 64 && rb2.applied === rb1.applied
+                    && await allAre(samples, 'stone'),
+                `re-run re-applied ${rb2.applied} and converged (first ${rb1.applied})`,
+                `re-run applied ${rb2.applied}, expected ${rb1.applied} with a stable world: ${rb2.line.trim()}`);
             const cp1 = await coOp(bot, 'rollback', `u:${bot.username} t:60s r:16`);
             r.notes.push(`CP rollback after SG already restored: ${cp1.line.trim()} (world already correct)`);
             check(r, 'cp', await allAre(samples, 'stone'), 'world stays correct', 'CP disturbed a restored world');
@@ -227,7 +232,9 @@ export default [
             await sleep(600);
             await digAt(bot, x, y, z);
             await drain();
-            await sgOp(bot, 'rollback', `p:${bot.username} t:60s r:8`);
+            // Containers are opt-in since #287: restoring a broken chest
+            // (a container-material write) needs the flag.
+            await sgOp(bot, 'rollback', `p:${bot.username} t:60s r:8 -containers`);
             const sgItems = await blockData(x, y, z, 'Items');
             check(r, 'sg', /diamond/.test(sgItems) && /13/.test(sgItems),
                 'chest restored WITH its 13 diamonds', `restored chest items: ${sgItems.slice(0, 120) || '(none)'}`);

--- a/regression/bot/cases/g-rollback.js
+++ b/regression/bot/cases/g-rollback.js
@@ -1,4 +1,4 @@
-// Category G — rollback semantics (use-cases.md G1–G14).
+// Category G - rollback semantics (use-cases.md G1-G15).
 import {
     rcon, sleep, blockIs, blockAmong, blockData, nextPlot, claimPlot,
     releasePlot, placeAt, digAt, sgSearch, coLookup, sgOp, coOp, grep, drain,
@@ -298,5 +298,62 @@ export default [
 },
 
 { id: 'G14', title: 'rollback during live ingest (read-your-writes)', manual: 'flush-gate behavior; covered by rollback-flush-timeout design + perf campaign, noisy in a shared suite' },
+
+{
+    id: 'G15', title: 'multi-event cell rolls back as one net change',
+    async run(bot) {
+        const r = freshResult();
+        const plot = nextPlot();
+        await claimPlot(bot, plot);
+        const [x, y, z] = [plot.cx + 1, plot.y, plot.cz];
+        try {
+            // Churn one cell: place, break, place again (P/B/P). Three
+            // logged events at the SAME cell - the #321 per-cell fold must
+            // apply the rollback as ONE net write (air, the pre-churn
+            // state), not three separate flips.
+            await rcon(`setblock ${x} ${y} ${z} air`);
+            await sleep(400);
+            await placeAt(bot, 'dirt', x, y, z);
+            await digAt(bot, x, y, z);
+            await placeAt(bot, 'dirt', x, y, z);
+            await drain();
+
+            const rb = await sgOp(bot, 'rollback', `p:${bot.username} t:60s r:16`);
+            check(r, 'sg', rb.applied === 1,
+                `one net reversal for the churn cell (${rb.line.trim()})`,
+                `expected 1 net reversal, got ${rb.applied}: ${rb.line.trim()}`);
+            check(r, 'sg', await blockIs(x, y, z, 'air'),
+                'world truth: churn cell landed back on air',
+                `churn cell not air after rollback: ${await blockAmong(x, y, z, ['dirt', 'air'])}`);
+
+            const sg = await sgSearch(bot, `trg:${x},${y},${z} t:60s -ng`);
+            // Distinguish synthesized ROLLBACK receipts from the struck-
+            // through ORIGINAL place/break rows at the same cell - those
+            // also render "placed"/"broke" but are sourced from the bot,
+            // not ROLLBACK. Match both tokens rather than trust exact
+            // adjacency (see G10 for the same ROLLBACK-prefix idiom).
+            const rollbackBroke = /(?=.*ROLLBACK)(?=.*broke)/i;
+            const rollbackPlaced = /(?=.*ROLLBACK)(?=.*placed)/i;
+            const brokeReceipts = grep(sg, rollbackBroke);
+            const placedReceipts = grep(sg, rollbackPlaced);
+            check(r, 'sg', brokeReceipts.length === 1 && placedReceipts.length === 0,
+                `exactly one ROLLBACK broke receipt, zero ROLLBACK placed (${brokeReceipts.length}/${placedReceipts.length})`,
+                `broke=${brokeReceipts.length} placed=${placedReceipts.length}: ${sg.slice(-6).join(' | ')}`);
+
+            await sgOp(bot, 'undo', '');
+            check(r, 'sg', await blockIs(x, y, z, 'dirt'),
+                'undo restored the pre-rollback (dirt) state',
+                `undo did not restore dirt: ${await blockAmong(x, y, z, ['dirt', 'air'])}`);
+            // Per-cell coalescing (#321) is a Spyglass-only apply-window
+            // optimization; CoreProtect has no equivalent notion of net
+            // cells to compare against.
+            r.cp.verdict = NA;
+            r.notes.push('CP has no per-cell fold to compare against (#321 is SG-only coalescing)');
+        } finally {
+            await releasePlot(plot);
+        }
+        return r;
+    },
+},
 
 ];

--- a/regression/use-cases.md
+++ b/regression/use-cases.md
@@ -114,7 +114,7 @@ Measurement discipline (from the perf campaign): same-run comparisons only; judg
 |---|---|---|---|---|
 | G1 | Standard grief → rollback | Server-truth sampling (`verify-rollback.js`): 100% of sampled cells match pre-grief | C | bot |
 | G2 | Rollback → undo | World returns to exact post-grief state (undo = inverse) | C | bot |
-| G3 | Rollback, manual edits inside region, identical rollback re-run | Changed blocks skipped with reasons; SG store grows +1 op row (synthesis); CP growth measured | C,S | bot |
+| G3 | Identical rollback re-run over the same region | Force-overwrite (#69) re-applies every matched cell to the same recorded state; world converges with zero drift | C,S | bot |
 | G4 | Two overlapping ops by one operator; undo twice | LIFO per-operator undo ordering correct both times | C | bot |
 | G5 | Player standing inside region during rollback | No suffocation in restored blocks / sane player handling both sides | U | man |
 | G6 | Preview before applying | **CP `#preview` exists; SG has none — expected CP-ahead capability cell** | K,U | man |
@@ -122,7 +122,7 @@ Measurement discipline (from the perf campaign): same-run comparisons only; judg
 | G8 | `kill -9` the server mid-rollback, restart | SG resume marker offers continuation and completes; CP behavior documented | K,C | man |
 | G9 | Region half loaded, half unloaded | Both halves restored equally | C | bot |
 | G10 | Search `a:rolled-place` after a rollback, then attempt to roll back those entries | Audit entries visible in search; not themselves re-rollbackable into a feedback loop | C,U | bot |
-| G11 | Crater containing chests with loot | Tile entities restored with contents post-rollback | C | bot |
+| G11 | Crater containing chests with loot | Tile entities restored with contents post-rollback (needs `-containers`, opt-in since #287) | C | bot |
 | G12 | Over-broad rollback fixed by `restore` of the same query | World returns to pre-rollback state exactly | C | bot |
 | G13 | Rollback everything except chests (negation filter) | Exclusion honored both sides | C,K | bot |
 | G14 | Rollback while 600 ev/s of live traffic ingests | Read-your-writes: just-recorded grief included (flush gate); no lost or phantom restores | C,P | bot |

--- a/regression/use-cases.md
+++ b/regression/use-cases.md
@@ -108,7 +108,7 @@ Measurement discipline (from the perf campaign): same-run comparisons only; judg
 | F9 | Wither spawn breaks containment blocks | Entity grief rollback | C | rcon |
 | F10 | Lightning starts a fire | Attribution chain (natural); rollback scope correct | C | rcon |
 
-## G. Rollback semantics — G1–G14
+## G. Rollback semantics - G1-G15
 
 | # | Scenario | Verify | Dim | Auto |
 |---|---|---|---|---|
@@ -126,6 +126,7 @@ Measurement discipline (from the perf campaign): same-run comparisons only; judg
 | G12 | Over-broad rollback fixed by `restore` of the same query | World returns to pre-rollback state exactly | C | bot |
 | G13 | Rollback everything except chests (negation filter) | Exclusion honored both sides | C,K | bot |
 | G14 | Rollback while 600 ev/s of live traffic ingests | Read-your-writes: just-recorded grief included (flush gate); no lost or phantom restores | C,P | bot |
+| G15 | Place/break/place churn at ONE cell, then rollback | One net reversal (count=1), world back to pre-churn air, exactly one `ROLLBACK broke` receipt, undo restores dirt (#321) | C | bot |
 
 ## H. Query & search capability — H1–H12
 

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
  * search request we (1) find candidate operations in the request's
  * time window, (2) re-run each operation's stored query narrowed to
  * the request's location constraints, (3) manufacture virtual
- * receipts — {@code Source.environment("ROLLBACK")},
+ * receipts - {@code Source.environment("ROLLBACK")},
  * {@code Origin.rollback(operator)}, the operation's timestamp, the
  * restored material as target — and (4) re-apply the caller's full
  * predicate tree in memory so filter behavior matches persisted rows.

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesis.java
@@ -33,12 +33,14 @@ import org.jetbrains.annotations.Nullable;
  * stored query match a record here at or before its ceiling". So for a
  * search request we (1) find candidate operations in the request's
  * time window, (2) re-run each operation's stored query narrowed to
- * the request's location constraints, (3) manufacture a virtual
- * receipt per covered original, mirroring exactly what the engine used
- * to persist — {@code Source.environment("ROLLBACK")},
+ * the request's location constraints, (3) manufacture virtual
+ * receipts — {@code Source.environment("ROLLBACK")},
  * {@code Origin.rollback(operator)}, the operation's timestamp, the
  * restored material as target — and (4) re-apply the caller's full
  * predicate tree in memory so filter behavior matches persisted rows.
+ * Block receipts are one NET transition per covered cell, matching the
+ * engine's coalesced write (#321); container-slot receipts stay one
+ * per covered transaction.
  *
  * <p>Synthesized coverage is "the operation's query covered this
  * block"; persisted receipts recorded actual writes. The two differ
@@ -288,6 +290,13 @@ public final class RolledSynthesis {
         String operator = op.source() == null ? null : op.source().playerName();
         Source source = Source.environment("ROLLBACK");
         Origin origin = Origin.rollback(operator == null ? "console" : operator);
+        // Block receipts are one per CELL, not per covered event (#321):
+        // a cell with several covered changes nets to a single
+        // current -> restored transition, mirroring the engine's
+        // coalesced write. The verify query streams newest-first, so the
+        // first effect seen at a cell belongs to the newest covered
+        // event and the last to the oldest.
+        java.util.LinkedHashMap<CellKey, NetCell> cells = new java.util.LinkedHashMap<>();
         for (EventRecord original : store.query(verify).records()) {
             if (!(original instanceof Rollbackable rollbackable)) {
                 continue;
@@ -295,11 +304,90 @@ public final class RolledSynthesis {
             if (!includedContainers && coversContainer(rollbackable, rollback)) {
                 continue;
             }
-            EventRecord virtual = toRolled(op, rollback, source, origin, original, rollbackable);
-            if (virtual != null && PredicateEvaluator.matchesAll(request.predicates(), virtual)) {
+            var effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+            if (effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite csw) {
+                // Container transactions keep one receipt per original:
+                // each slot reversal is its own audit line (#265), and
+                // slot coalescing is out of #321's scope.
+                EventRecord virtual = toRolledTransaction(op, source, origin, original, csw);
+                if (PredicateEvaluator.matchesAll(request.predicates(), virtual)) {
+                    out.add(virtual);
+                }
+                continue;
+            }
+            if (!(effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace replace)) {
+                continue; // entity effects still have no receipt shape
+            }
+            var loc = replace.location();
+            CellKey key = new CellKey(loc.worldId(), loc.x(), loc.y(), loc.z());
+            NetCell cell = cells.get(key);
+            if (cell == null) {
+                cells.put(key, new NetCell(replace));
+            } else {
+                cell.last = replace;
+            }
+        }
+        for (NetCell cell : cells.values()) {
+            // Net transition at this cell: a rollback moves the world from
+            // the newest covered event's current state to the oldest one's
+            // restored state; a restore (oldest-first apply) mirrors that.
+            var expected = rollback ? cell.first.expectedCurrent() : cell.last.expectedCurrent();
+            var replacement = rollback ? cell.last.replacement() : cell.first.replacement();
+            if (sameBlockState(expected, replacement)) {
+                // The covered changes cancelled out (a place and its
+                // break): no net transition, and a "broke AIR" receipt
+                // identifies nothing (#269).
+                continue;
+            }
+            var loc = cell.first.location();
+            // Deterministic id: the same op covering the same cell must
+            // synthesize the same identity across repeated searches.
+            UUID id = UUID.nameUUIDFromBytes((op.id() + ":" + loc.worldId() + ":"
+                    + loc.x() + ":" + loc.y() + ":" + loc.z())
+                    .getBytes(StandardCharsets.UTF_8));
+            EventRecord virtual = toRolledBlock(op, source, origin, id, loc, expected, replacement);
+            if (PredicateEvaluator.matchesAll(request.predicates(), virtual)) {
                 out.add(virtual);
             }
         }
+    }
+
+    private record CellKey(UUID worldId, int x, int y, int z) {
+    }
+
+    // First and last BlockReplace streamed for one cell, in verify-query
+    // order (newest first). One-event cells leave first == last.
+    private static final class NetCell {
+        final net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace first;
+        net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace last;
+
+        NetCell(net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace first) {
+            this.first = first;
+            this.last = first;
+        }
+    }
+
+    /**
+     * True when the two snapshots describe the same block state - the
+     * cell's covered events net to nothing. Air compares by the same
+     * rule the receipt classification uses; otherwise material plus
+     * block-data must both match, so an orientation change still gets
+     * its receipt.
+     */
+    private static boolean sameBlockState(net.medievalrp.spyglass.api.event.BlockSnapshot a,
+                                          net.medievalrp.spyglass.api.event.BlockSnapshot b) {
+        boolean aAir = isAir(a);
+        boolean bAir = isAir(b);
+        if (aAir || bAir) {
+            return aAir && bAir;
+        }
+        return a.material() == b.material()
+                && java.util.Objects.equals(a.blockData(), b.blockData());
+    }
+
+    private static boolean isAir(net.medievalrp.spyglass.api.event.BlockSnapshot snapshot) {
+        return snapshot == null || snapshot.material() == null
+                || "AIR".equals(snapshot.material().name());
     }
 
     /**
@@ -324,35 +412,32 @@ public final class RolledSynthesis {
                 && containerMaterials.contains(snapshot.material().name());
     }
 
-    private static @Nullable EventRecord toRolled(RollbackOpRecord op, boolean rollback,
-                                                  Source source, Origin origin,
-                                                  EventRecord original, Rollbackable rollbackable) {
-        var effect = rollback ? rollbackable.rollbackEffect() : rollbackable.restoreEffect();
+    private static EventRecord toRolledTransaction(
+            RollbackOpRecord op, Source source, Origin origin, EventRecord original,
+            net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite csw) {
+        // A rollback that reverted a container transaction used to leave
+        // NO audit entry in either mode (#265). Synthesize the inverse
+        // transaction: clearing a slot is rolled-withdraw of what sat
+        // there, repopulating one is rolled-deposit of what came back.
         // Deterministic id: the same op covering the same record must
         // synthesize the same identity across repeated searches.
         UUID id = UUID.nameUUIDFromBytes(
                 (op.id() + ":" + original.id()).getBytes(StandardCharsets.UTF_8));
-        if (effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.ContainerSlotWrite csw) {
-            // A rollback that reverted a container transaction used to leave
-            // NO audit entry in either mode (#265). Synthesize the inverse
-            // transaction: clearing a slot is rolled-withdraw of what sat
-            // there, repopulating one is rolled-deposit of what came back.
-            var placed = csw.replacement();
-            var removed = csw.expectedCurrent();
-            String event = placed == null ? "rolled-withdraw" : "rolled-deposit";
-            String target = placed != null ? placed.material()
-                    : removed != null ? removed.material() : "UNKNOWN";
-            return new BlockUseRecord(id, event, op.occurred(), op.expiresAt(),
-                    origin, source, csw.location(), op.server(), target);
-        }
-        if (!(effect instanceof net.medievalrp.spyglass.api.rollback.RollbackEffect.BlockReplace replace)) {
-            // Entity effects still have no receipt shape.
-            return null;
-        }
-        var after = replace.replacement();
-        var destroyed = replace.expectedCurrent();
-        boolean toAir = after == null
-                || "AIR".equals(after.material() == null ? "AIR" : after.material().name());
+        var placed = csw.replacement();
+        var removed = csw.expectedCurrent();
+        String event = placed == null ? "rolled-withdraw" : "rolled-deposit";
+        String target = placed != null ? placed.material()
+                : removed != null ? removed.material() : "UNKNOWN";
+        return new BlockUseRecord(id, event, op.occurred(), op.expiresAt(),
+                origin, source, csw.location(), op.server(), target);
+    }
+
+    private static EventRecord toRolledBlock(RollbackOpRecord op, Source source, Origin origin,
+                                             UUID id,
+                                             net.medievalrp.spyglass.api.util.BlockLocation location,
+                                             net.medievalrp.spyglass.api.event.BlockSnapshot destroyed,
+                                             net.medievalrp.spyglass.api.event.BlockSnapshot after) {
+        boolean toAir = isAir(after);
         String event = toAir ? "rolled-break" : "rolled-place";
         // rolled-break names what was DESTROYED, not the air that replaced
         // it - "ROLLBACK broke AIR" identified nothing (#269). rolled-place
@@ -365,7 +450,7 @@ public final class RolledSynthesis {
             target = after.material() == null ? "AIR" : after.material().name();
         }
         return new BlockUseRecord(id, event, op.occurred(), op.expiresAt(),
-                origin, source, replace.location(), op.server(), target);
+                origin, source, location, op.server(), target);
     }
 
     // --- request introspection (flat lists + And nesting; Or/Not are

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSynthesisParityIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSynthesisParityIT.java
@@ -10,6 +10,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
 import net.medievalrp.spyglass.api.event.BlockUseRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
@@ -77,6 +78,18 @@ class ClickHouseSynthesisParityIT {
         receiptsStore.save(originals);
         synthBase.save(originals);
 
+        // #321 multi-event cells live only as originals on the synth side -
+        // the receipts side seeds the NET rows the engine would have
+        // persisted after coalescing. x=103 is a place/break/place churn
+        // that nets to one rolled-break DIRT; x=104 is a cancelling
+        // place/break pair that nets to nothing.
+        synthBase.save(List.of(
+                dirtPlace(103, GRIEF_TIME),
+                dirtBreak(103, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(103, GRIEF_TIME.plusSeconds(2)),
+                dirtPlace(104, GRIEF_TIME),
+                dirtBreak(104, GRIEF_TIME.plusSeconds(1))));
+
         // Receipts store: persisted rows exactly as the engine's
         // buildRollbackSourceRecord used to emit them.
         List<EventRecord> receipts = new ArrayList<>();
@@ -86,11 +99,21 @@ class ClickHouseSynthesisParityIT {
                     Origin.rollback("Operator"), Source.environment("ROLLBACK"),
                     new BlockLocation(WORLD, "world", x, 64, 0), "test", "STONE"));
         }
+        // The churn cell at 103 coalesced to ONE net receipt naming the DIRT
+        // that ended up destroyed; the cancelling pair at 104 nets to
+        // nothing, so no receipt row exists for it.
+        receipts.add(new BlockUseRecord(EventIds.newId(), "rolled-break",
+                OP_TIME, EXPIRES,
+                Origin.rollback("Operator"), Source.environment("ROLLBACK"),
+                new BlockLocation(WORLD, "world", 103, 64, 0), "test", "DIRT"));
         receiptsStore.save(receipts);
 
-        // Synth store: one rollback-op record instead.
+        // Synth store: one rollback-op record instead. Its box spans the
+        // whole griefed run (100..104) and its stored query covers every
+        // event by the griefer, so the churn cells' places are inside
+        // coverage too.
         String blob = UndoReferenceBson.encodeBase64(griefQuery(), "ROLLBACK", OP_TIME,
-                List.of(new UndoReferenceBson.WorldBox(WORLD, 100, 64, 0, 102, 64, 0)), 3, 0);
+                List.of(new UndoReferenceBson.WorldBox(WORLD, 100, 64, 0, 104, 64, 0)), 3, 0);
         synthBase.save(List.of(new RollbackOpRecord(EventIds.newId(), "rollback-op",
                 OP_TIME, EXPIRES,
                 Origin.rollback("Operator"), Source.player(UUID.randomUUID(), "Operator"),
@@ -120,9 +143,12 @@ class ClickHouseSynthesisParityIT {
     }
 
     private static QueryRequest griefQuery() {
+        // Covers every event by the griefer (not just breaks): the #321
+        // churn cells fold place AND break originals, so the op's stored
+        // query must reach the places too. Cells 100-102 still hold only
+        // breaks, so their net stays one rolled-place each.
         return new QueryRequest(List.of(
-                new QueryPredicate.Eq("source.playerId", GRIEFER),
-                new QueryPredicate.Eq("event", "break")),
+                new QueryPredicate.Eq("source.playerId", GRIEFER)),
                 Sort.NEWEST_FIRST, 10_000, EnumSet.of(Flag.NO_GROUP), false);
     }
 
@@ -146,6 +172,30 @@ class ClickHouseSynthesisParityIT {
                 Origin.player(), Source.player(UUID.randomUUID(), "Bystander"),
                 new BlockLocation(WORLD, "world", x, 64, 0),
                 "test", "DIRT", stone, stone);
+    }
+
+    private static BlockPlaceRecord dirtPlace(int x, Instant at) {
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot dirt = new BlockSnapshot(Material.DIRT, "minecraft:dirt",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockPlaceRecord(EventIds.newId(), "place",
+                at, EXPIRES,
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", "DIRT", air, dirt);
+    }
+
+    private static BlockBreakRecord dirtBreak(int x, Instant at) {
+        BlockSnapshot dirt = new BlockSnapshot(Material.DIRT, "minecraft:dirt",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockBreakRecord(EventIds.newId(), "break",
+                at, EXPIRES,
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", "DIRT", dirt, air);
     }
 
     private static QueryRequest search(QueryPredicate... predicates) {
@@ -218,6 +268,36 @@ class ClickHouseSynthesisParityIT {
         QueryRequest request = search(
                 new QueryPredicate.Eq("location.worldId", WORLD),
                 new QueryPredicate.Eq("location.x", 500),
+                new QueryPredicate.Range("occurred",
+                        GRIEF_TIME.minusSeconds(3600), OP_TIME.plusSeconds(3600)));
+        assertThat(project(receiptsStore.query(request).records())).isEmpty();
+        assertThat(project(synthStore.query(request).records())).isEmpty();
+    }
+
+    // #321: the churn cell's three originals fold to the single net receipt
+    // the engine persisted - identical projection, and exactly one rolled row.
+    @Test
+    void multiEventCellShowsOneNetReceiptBothWays() {
+        QueryRequest request = search(
+                new QueryPredicate.Eq("location.worldId", WORLD),
+                new QueryPredicate.Eq("location.x", 103),
+                new QueryPredicate.Eq("location.y", 64),
+                new QueryPredicate.Eq("location.z", 0),
+                new QueryPredicate.Range("occurred",
+                        GRIEF_TIME.minusSeconds(3600), OP_TIME.plusSeconds(3600)));
+        assertParity(request);
+        List<String> synthesized = project(synthStore.query(request).records());
+        assertThat(synthesized).hasSize(1);
+        assertThat(synthesized.get(0)).startsWith("rolled-break|DIRT|103|");
+    }
+
+    // #321: the cancelling place/break pair nets to nothing - the engine
+    // persisted no receipt, and the synth side synthesizes none.
+    @Test
+    void cancelledCellShowsNothingEitherWay() {
+        QueryRequest request = search(
+                new QueryPredicate.Eq("location.worldId", WORLD),
+                new QueryPredicate.Eq("location.x", 104),
                 new QueryPredicate.Range("occurred",
                         GRIEF_TIME.minusSeconds(3600), OP_TIME.plusSeconds(3600)));
         assertThat(project(receiptsStore.query(request).records())).isEmpty();

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -131,12 +131,16 @@ class RolledSynthesisTest {
     // ---- #302: coverage honors the op's inclusion flags ----
 
     private static net.medievalrp.spyglass.api.event.BlockPlaceRecord chestPlace(int x) {
+        return chestPlace(x, GRIEF_TIME);
+    }
+
+    private static net.medievalrp.spyglass.api.event.BlockPlaceRecord chestPlace(int x, Instant at) {
         BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
                 List.of(), List.of(), List.of(), List.of(), null);
         BlockSnapshot chest = new BlockSnapshot(Material.CHEST, "minecraft:chest",
                 List.of(), List.of(), List.of(), List.of(), null);
         return new net.medievalrp.spyglass.api.event.BlockPlaceRecord(UUID.randomUUID(), "place",
-                GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                at, at.plusSeconds(86400),
                 Origin.player(), Source.player(GRIEFER, "Griefer"),
                 new BlockLocation(WORLD, "world", x, 64, 0),
                 "test", "CHEST", air, chest);
@@ -351,6 +355,48 @@ class RolledSynthesisTest {
                 && "DIRT".equals(r.target()) && r.location().x() == 1);
         assertThat(rolled).anyMatch(r -> "rolled-place".equals(r.event())
                 && "STONE".equals(r.target()) && r.location().x() == 2);
+    }
+
+    @Test
+    void mixedCellWithoutContainersFlagNetsOnlyPlainOriginals() {
+        MemoryStore store = new MemoryStore();
+        // Dirt churn plus a chest place at ONE cell, op stored WITHOUT
+        // --containers: the chest-covering original is gated out (#302)
+        // BEFORE the fold, so the net spans only the dirt events.
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2)),
+                chestPlace(1, GRIEF_TIME.plusSeconds(3))));
+        store.save(List.of(op(griefQueryWithFlags(), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store, java.util.Set.of("CHEST"))
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
+        assertThat(rolled.get(0).target()).isEqualTo("DIRT");
+    }
+
+    @Test
+    void mixedCellWithContainersFlagNetsAcrossTheChestToo() {
+        MemoryStore store = new MemoryStore();
+        // Same churn but the op ran WITH --containers: the chest place is
+        // covered, so the net spans all four events - from the newest
+        // covered state (the chest) to the oldest restored one (air).
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2)),
+                chestPlace(1, GRIEF_TIME.plusSeconds(3))));
+        store.save(List.of(op(griefQueryWithFlags(Flag.INCLUDE_CONTAINERS), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store, java.util.Set.of("CHEST"))
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
+        assertThat(rolled.get(0).target()).isEqualTo("CHEST");
     }
 
     @Test

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -46,7 +46,7 @@ class RolledSynthesisTest {
         @Override
         public QueryResult query(QueryRequest request) {
             queryCount++;
-            // Honor the requested sort like every real backend does — the
+            // Honor the requested sort like every real backend does - the
             // per-cell net fold (#321) reads the verify stream's order.
             java.util.Comparator<EventRecord> byTime = java.util.Comparator
                     .comparing(EventRecord::occurred)
@@ -143,8 +143,12 @@ class RolledSynthesisTest {
     }
 
     private static net.medievalrp.spyglass.api.event.ContainerDepositRecord deposit(int x) {
+        return deposit(x, GRIEF_TIME);
+    }
+
+    private static net.medievalrp.spyglass.api.event.ContainerDepositRecord deposit(int x, Instant at) {
         return new net.medievalrp.spyglass.api.event.ContainerDepositRecord(UUID.randomUUID(),
-                "deposit", GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                "deposit", at, at.plusSeconds(86400),
                 Origin.player(), Source.player(GRIEFER, "Griefer"),
                 new BlockLocation(WORLD, "world", x, 64, 0), "test",
                 "DIRT", "CHEST", 0, 8, null,
@@ -366,6 +370,117 @@ class RolledSynthesisTest {
         assertThat(first).hasSize(1);
         assertThat(second).hasSize(1);
         assertThat(first.get(0).id()).isEqualTo(second.get(0).id());
+    }
+
+    @Test
+    void twoOpsAtTheSameCellSynthesizeDistinctReceipts() {
+        MemoryStore store = new MemoryStore();
+        // One covered cell, two separate rollback ops over it. The net-cell
+        // id keys on the OP, so the fold is per (op, cell) and never across
+        // ops - each op stamps its own receipt with its own id.
+        store.save(List.of(griefBreak(1)));
+        store.save(List.of(
+                op(griefQuery(), "ROLLBACK", OP_TIME),
+                op(griefQuery(), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(2);
+        assertThat(rolled).extracting(EventRecord::id).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void orientationChangeIsNotSuppressed() {
+        MemoryStore store = new MemoryStore();
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot stairsNorth = new BlockSnapshot(Material.OAK_STAIRS,
+                "minecraft:oak_stairs[facing=north]",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot stairsSouth = new BlockSnapshot(Material.OAK_STAIRS,
+                "minecraft:oak_stairs[facing=south]",
+                List.of(), List.of(), List.of(), List.of(), null);
+        // Break the north-facing stairs, then place south-facing ones in the
+        // same cell. The net rollback transition is south -> north: same
+        // material but different block data, so it is not an identity net
+        // and must keep its receipt.
+        store.save(List.of(
+                new BlockBreakRecord(UUID.randomUUID(), "break",
+                        GRIEF_TIME, GRIEF_TIME.plusSeconds(86400),
+                        Origin.player(), Source.player(GRIEFER, "Griefer"),
+                        new BlockLocation(WORLD, "world", 1, 64, 0),
+                        "test", "OAK_STAIRS", stairsNorth, air),
+                new net.medievalrp.spyglass.api.event.BlockPlaceRecord(UUID.randomUUID(), "place",
+                        GRIEF_TIME.plusSeconds(1), GRIEF_TIME.plusSeconds(86400),
+                        Origin.player(), Source.player(GRIEFER, "Griefer"),
+                        new BlockLocation(WORLD, "world", 1, 64, 0),
+                        "test", "OAK_STAIRS", air, stairsSouth)));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).target()).isEqualTo("OAK_STAIRS");
+    }
+
+    @Test
+    void breakThenReplaceSameMaterialSuppresses() {
+        MemoryStore store = new MemoryStore();
+        // Break DIRT then place DIRT back, same block data. The net rollback
+        // is dirt -> dirt, an identity, so nothing is synthesized.
+        store.save(List.of(
+                dirtBreak(1, GRIEF_TIME),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(1))));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+
+        assertThat(new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD))))
+                .isEmpty();
+    }
+
+    @Test
+    void groupedChurnCellCollapsesToCountOne() {
+        MemoryStore store = new MemoryStore();
+        // The P/B/P churn at ONE cell. A grouped search must show a single
+        // rolled-break aggregation counted ONCE, not the "x2" a per-event
+        // receipt would have produced (#321) - the disappearing count proof.
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2))));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+        SynthesizingRecordStore wrapped = new SynthesizingRecordStore(store, true);
+
+        QueryRequest grouped = new QueryRequest(
+                List.of(new QueryPredicate.Eq("location.worldId", WORLD)),
+                net.medievalrp.spyglass.api.query.Sort.NEWEST_FIRST,
+                100, EnumSet.noneOf(Flag.class), true);
+        QueryResult result = wrapped.query(grouped);
+
+        assertThat(result.aggregations())
+                .anyMatch(aggregation -> "rolled-break".equals(aggregation.sample().event())
+                        && aggregation.count() == 1);
+    }
+
+    @Test
+    void containerReceiptsStayPerOriginal() {
+        MemoryStore store = new MemoryStore();
+        // Two deposits into the SAME container cell. Container-slot receipts
+        // are NOT folded (#321 coalesces block writes only), so each covered
+        // transaction keeps its own rolled-withdraw line with its own id.
+        store.save(List.of(
+                deposit(1, GRIEF_TIME),
+                deposit(1, GRIEF_TIME.plusSeconds(1))));
+        store.save(List.of(op(griefQueryWithFlags(Flag.INCLUDE_CONTAINERS), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        assertThat(rolled).hasSize(2);
+        assertThat(rolled).allMatch(r -> "rolled-withdraw".equals(r.event()));
+        assertThat(rolled).extracting(EventRecord::id).doesNotHaveDuplicates();
     }
 
     @Test

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -46,8 +46,17 @@ class RolledSynthesisTest {
         @Override
         public QueryResult query(QueryRequest request) {
             queryCount++;
+            // Honor the requested sort like every real backend does — the
+            // per-cell net fold (#321) reads the verify stream's order.
+            java.util.Comparator<EventRecord> byTime = java.util.Comparator
+                    .comparing(EventRecord::occurred)
+                    .thenComparing(r -> r.id().toString());
+            if (request.sort() != net.medievalrp.spyglass.api.query.Sort.OLDEST_FIRST) {
+                byTime = byTime.reversed();
+            }
             List<EventRecord> matched = rows.stream()
                     .filter(r -> PredicateEvaluator.matchesAll(request.predicates(), r))
+                    .sorted(byTime)
                     .limit(request.limit())
                     .toList();
             return new QueryResult(matched, List.of());
@@ -231,6 +240,132 @@ class RolledSynthesisTest {
         assertThat(rolled).hasSize(1);
         assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
         assertThat(rolled.get(0).target()).isEqualTo("STONE");
+    }
+
+    // ---- #321: multi-event cells net to one receipt ----
+
+    private static net.medievalrp.spyglass.api.event.BlockPlaceRecord dirtPlace(int x, Instant at) {
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot dirt = new BlockSnapshot(Material.DIRT, "minecraft:dirt",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new net.medievalrp.spyglass.api.event.BlockPlaceRecord(UUID.randomUUID(), "place",
+                at, at.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", "DIRT", air, dirt);
+    }
+
+    private static BlockBreakRecord dirtBreak(int x, Instant at) {
+        BlockSnapshot dirt = new BlockSnapshot(Material.DIRT, "minecraft:dirt",
+                List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot air = new BlockSnapshot(Material.AIR, "minecraft:air",
+                List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockBreakRecord(UUID.randomUUID(), "break",
+                at, at.plusSeconds(86400),
+                Origin.player(), Source.player(GRIEFER, "Griefer"),
+                new BlockLocation(WORLD, "world", x, 64, 0),
+                "test", "DIRT", dirt, air);
+    }
+
+    private static QueryRequest grieferQuery() {
+        return request(new QueryPredicate.Eq("source.playerId", GRIEFER));
+    }
+
+    @Test
+    void multiEventCellNetsToOneReceipt() {
+        MemoryStore store = new MemoryStore();
+        // The #321 repro: place, break, place again at ONE cell. The net
+        // world change of rolling all three back is dirt -> air.
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2))));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        // One net receipt, not broke x2 + placed x1.
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-break");
+        assertThat(rolled.get(0).target()).isEqualTo("DIRT");
+    }
+
+    @Test
+    void cancellingPairSynthesizesNothing() {
+        MemoryStore store = new MemoryStore();
+        // Place then break: rolling both back returns the cell to the
+        // air it started as. No net transition, no receipt - a "broke
+        // AIR" line identifies nothing (#269).
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1))));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+
+        assertThat(new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD))))
+                .isEmpty();
+    }
+
+    @Test
+    void restoreOfMultiEventCellNetsToOnePlace() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2))));
+        store.save(List.of(op(grieferQuery(), "RESTORE", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        // Re-applying the history oldest-first lands on the newest
+        // event's outcome: dirt. Net = air -> dirt, one rolled-place.
+        assertThat(rolled).hasSize(1);
+        assertThat(rolled.get(0).event()).isEqualTo("rolled-place");
+        assertThat(rolled.get(0).target()).isEqualTo("DIRT");
+    }
+
+    @Test
+    void churnCellAndPlainCellEachKeepTheirOwnReceipt() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2)),
+                griefBreak(2)));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+
+        List<EventRecord> rolled = new RolledSynthesis(store)
+                .synthesize(request(new QueryPredicate.Eq("location.worldId", WORLD)));
+
+        // The churn cell nets to one rolled-break DIRT; the untouched
+        // single-event cell keeps its ordinary rolled-place STONE.
+        assertThat(rolled).hasSize(2);
+        assertThat(rolled).anyMatch(r -> "rolled-break".equals(r.event())
+                && "DIRT".equals(r.target()) && r.location().x() == 1);
+        assertThat(rolled).anyMatch(r -> "rolled-place".equals(r.event())
+                && "STONE".equals(r.target()) && r.location().x() == 2);
+    }
+
+    @Test
+    void netReceiptIdsAreDeterministicAcrossSearches() {
+        MemoryStore store = new MemoryStore();
+        store.save(List.of(
+                dirtPlace(1, GRIEF_TIME),
+                dirtBreak(1, GRIEF_TIME.plusSeconds(1)),
+                dirtPlace(1, GRIEF_TIME.plusSeconds(2))));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+        QueryRequest search = request(new QueryPredicate.Eq("location.worldId", WORLD));
+
+        List<EventRecord> first = synthesis.synthesize(search);
+        List<EventRecord> second = synthesis.synthesize(search);
+
+        assertThat(first).hasSize(1);
+        assertThat(second).hasSize(1);
+        assertThat(first.get(0).id()).isEqualTo(second.get(0).id());
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/RollbackService.java
@@ -1046,17 +1046,25 @@ public final class RollbackService {
 
         // Simple block-replace: folded straight into primitive columns,
         // block-data interned to a palette id — no effect/snapshot object.
+        // Repeats of one cell within a window coalesce to the net write
+        // (#321): the stream arrives in apply order, so the last effect's
+        // write is what per-event replay would have left in the world.
+        // The cursor bookkeeping (seen/lastOccurred/lastId) still counts
+        // every row - a coalesced row was consumed off the wire and must
+        // advance checkpoints - while effectCount tracks distinct rows so
+        // window fullness stays a bound on live memory, not rows read.
         void block(UUID worldId, int x, int y, int z, String blockData,
                    String expectedData, java.time.Instant occurred, UUID id) {
             long start = System.nanoTime();
             seen++;
-            effectCount++;
             lastOccurred = occurred;
             lastId = id;
             BlockColumns cols = columnsByWorld.computeIfAbsent(
                     worldId, k -> new BlockColumns(columnInitialCapacity));
-            cols.add(x, y, z, cols.intern(blockData), cols.intern(expectedData));
-            recordChunkAndBox(worldId, x, y, z);
+            if (cols.addOrReplace(x, y, z, cols.intern(blockData), cols.intern(expectedData))) {
+                effectCount++;
+                recordChunkAndBox(worldId, x, y, z);
+            }
             foldNanos.addAndGet(System.nanoTime() - start);
         }
 

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/BlockColumns.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/BlockColumns.java
@@ -41,6 +41,14 @@ public final class BlockColumns {
     private int[] expId;
     private int count;
 
+    // Cell index for per-cell coalescing (#321): packed (x,y,z) -> row,
+    // open-addressed with linear probing at <= 50% load, primitives only
+    // (same no-boxing rule as the columns themselves). Rows enter it only
+    // through addOrReplace; plain add() stays index-blind.
+    private long[] cellKeys;
+    private int[] cellRows;
+    private int cellCount;
+
     // Tiny per-window palette: a bulk rollback repeats a handful of
     // materials, so each cell carries an int id into this shared table
     // instead of its own block-data string reference.
@@ -64,6 +72,30 @@ public final class BlockColumns {
         zs = new int[cap];
         replId = new int[cap];
         expId = new int[cap];
+        int tableLen = tableSizeFor(cap);
+        cellKeys = new long[tableLen];
+        cellRows = new int[tableLen];
+        Arrays.fill(cellRows, -1);
+    }
+
+    /** Smallest power of two holding {@code rows} at <= 50% load. */
+    private static int tableSizeFor(int rows) {
+        int needed = Math.max(32, rows * 2);
+        return Integer.highestOneBit(needed - 1) << 1;
+    }
+
+    /**
+     * One long per cell: x/z span 26 bits (the world border sits at
+     * |30M|, well inside +/-33.5M), y spans 12 (build limits are
+     * hundreds). Distinct in-world cells can never collide.
+     */
+    private static long packCell(int x, int y, int z) {
+        return ((x & 0x3FFFFFFL) << 38) | ((z & 0x3FFFFFFL) << 12) | (y & 0xFFFL);
+    }
+
+    private static int spread(long key) {
+        long h = key * 0x9E3779B97F4A7C15L;
+        return (int) (h ^ (h >>> 32));
     }
 
     /** Intern a block-data string to its palette id; {@code -1} for null. */
@@ -106,6 +138,61 @@ public final class BlockColumns {
         if (x > maxX) maxX = x;
         if (y > maxY) maxY = y;
         if (z > maxZ) maxZ = z;
+    }
+
+    /**
+     * Append one cell, or - when this (x,y,z) already has a row - fold
+     * into it (#321). Effects stream in apply order, so the write that
+     * arrives last is the one per-event replay would have left in the
+     * world: it wins the row's write side. The first arrival's
+     * expected-current stays - it names what is physically at the cell
+     * before any write. Only rows inserted here are foldable; raw
+     * {@link #add} appends are invisible to the index.
+     *
+     * @return {@code true} when a new row was appended, {@code false}
+     *     when an existing row absorbed the write
+     */
+    public boolean addOrReplace(int x, int y, int z, int replPaletteId, int expPaletteId) {
+        long key = packCell(x, y, z);
+        int mask = cellKeys.length - 1;
+        int slot = spread(key) & mask;
+        while (true) {
+            int row = cellRows[slot];
+            if (row < 0) {
+                cellKeys[slot] = key;
+                cellRows[slot] = count;
+                add(x, y, z, replPaletteId, expPaletteId);
+                if (++cellCount * 2 > cellKeys.length) {
+                    growCellTable();
+                }
+                return true;
+            }
+            if (cellKeys[slot] == key) {
+                replId[row] = replPaletteId;
+                return false;
+            }
+            slot = (slot + 1) & mask;
+        }
+    }
+
+    private void growCellTable() {
+        long[] oldKeys = cellKeys;
+        int[] oldRows = cellRows;
+        cellKeys = new long[oldKeys.length * 2];
+        cellRows = new int[oldRows.length * 2];
+        Arrays.fill(cellRows, -1);
+        int mask = cellKeys.length - 1;
+        for (int i = 0; i < oldRows.length; i++) {
+            if (oldRows[i] < 0) {
+                continue;
+            }
+            int slot = spread(oldKeys[i]) & mask;
+            while (cellRows[slot] >= 0) {
+                slot = (slot + 1) & mask;
+            }
+            cellKeys[slot] = oldKeys[i];
+            cellRows[slot] = oldRows[i];
+        }
     }
 
     public int count() {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -626,6 +626,59 @@ class RollbackServiceTest {
     }
 
     @Test
+    void mixedSimpleAndComplexAtOneCellFoldOnlyTheSimpleSide() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequestWithContainers());
+        // Two breaks (simple) and a deposit (complex) at the SAME cell:
+        // the simple side folds to one columnar row while the container
+        // effect rides the object path untouched - per-cell coalescing
+        // never reaches across the simple/complex split (#321).
+        Instant base = Instant.now();
+        BlockBreakRecord newer = record();
+        BlockBreakRecord older = record();
+        ContainerDepositRecord slot = depositAt(base);
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(
+                        List.of(newer, slot, older), null));
+        java.util.concurrent.atomic.AtomicReference<BlockColumns> columns =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        when(fixture.engine.applyColumnsChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    BlockColumns cols = inv.getArgument(1);
+                    columns.set(cols);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
+                });
+        java.util.concurrent.atomic.AtomicReference<List<RollbackEffect>> complex =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        when(fixture.engine.applyAllChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    List<RollbackEffect> effects = inv.getArgument(0);
+                    complex.set(effects);
+                    List<RollbackResult> results = effects.stream()
+                            .<RollbackResult>map(e -> new RollbackResult.Applied(e, e))
+                            .toList();
+                    return CompletableFuture.completedFuture(results);
+                });
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+
+        assertThat(columns.get()).isNotNull();
+        assertThat(columns.get().count()).isEqualTo(1);
+        assertThat(complex.get()).isNotNull();
+        assertThat(complex.get()).hasSize(1);
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("2 reversals") && !line.contains("skipped"));
+    }
+
+    @Test
     void warnsWhenNoRollbackables() throws Exception {
         TestFixture fixture = new TestFixture();
         when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -16,7 +16,9 @@ import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
+import net.medievalrp.spyglass.api.event.BlockPlaceRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.Source;
@@ -81,6 +83,10 @@ class RollbackServiceTest {
                 mock(net.medievalrp.spyglass.plugin.pipeline.Recorder.class);
         final net.medievalrp.spyglass.plugin.storage.RecordStore store =
                 mock(net.medievalrp.spyglass.plugin.storage.RecordStore.class);
+        // Real store spied (not mocked) so a test can verify the cursor a
+        // checkpoint wrote even though a clean run's markFinish deletes the
+        // on-disk marker before execute() returns (#321 resume coverage).
+        final RollbackResumeStore resumeStore;
         final RollbackService subject;
 
         TestFixture() {
@@ -110,15 +116,19 @@ class RollbackServiceTest {
             RollbackJobQueue queue = new RollbackJobQueue();
             // Test resume store points at a temp dir — no real
             // persistence is needed for these tests, but the
-            // constructor demands one.
-            RollbackResumeStore resumeStore;
+            // constructor demands one. Spied (Mockito 5's default inline
+            // mock maker handles the final class) so tests can verify
+            // markProgress/markFinish calls; behavior is untouched since a
+            // spy delegates to the real method unless stubbed.
+            RollbackResumeStore realResumeStore;
             try {
-                resumeStore = new RollbackResumeStore(
+                realResumeStore = new RollbackResumeStore(
                         java.nio.file.Files.createTempDirectory("spyglass-test-"),
                         Logger.getLogger("test"));
             } catch (java.io.IOException ex) {
                 throw new RuntimeException(ex);
             }
+            resumeStore = org.mockito.Mockito.spy(realResumeStore);
             IpQueryResolver ipResolver = new IpQueryResolver(
                     parser, new net.medievalrp.spyglass.plugin.command.param.IpParam(ip -> java.util.List.of()),
                     ServiceSupport.synchronous(), Logger.getLogger("test"));
@@ -447,6 +457,172 @@ class RollbackServiceTest {
 
         assertThat(ServiceTestSupport.plainTexts(messages))
                 .anyMatch(line -> line.contains("3 reversals") && !line.contains("skipped"));
+    }
+
+    // ---- #321: fold coverage beyond the initial landing ----
+
+    // Restore of a place at (0, 64, 0): a place's restoreEffect re-applies
+    // the place, expecting the air it started from and writing `afterMat`.
+    private static BlockPlaceRecord placeAt(Instant occurred, Material afterMat, String afterData) {
+        BlockSnapshot air = new BlockSnapshot(
+                Material.AIR, "minecraft:air", List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot after = new BlockSnapshot(
+                afterMat, afterData, List.of(), List.of(), List.of(), List.of(), null);
+        return new BlockPlaceRecord(
+                UUID.randomUUID(),
+                "place",
+                occurred,
+                occurred.plusSeconds(60),
+                Origin.player(),
+                Source.player(UUID.randomUUID(), "Alice"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 0, 64, 0),
+                "test",
+                afterMat.name(),
+                air,
+                after);
+    }
+
+    // A container deposit at (0, 64, 0): its effect is a ContainerSlotWrite,
+    // not a BlockReplace, so it always routes to the complex path - per-cell
+    // folding must leave it alone (#321).
+    private static ContainerDepositRecord depositAt(Instant occurred) {
+        return new ContainerDepositRecord(
+                UUID.randomUUID(),
+                "deposit",
+                occurred,
+                occurred.plusSeconds(60),
+                Origin.player(),
+                Source.player(UUID.randomUUID(), "Alice"),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 0, 64, 0),
+                "test",
+                "DIRT", "CHEST", 0, 8, null,
+                new net.medievalrp.spyglass.api.event.StoredItem(
+                        0, "DIRT", "", null, List.of(), List.of(), null));
+    }
+
+    // sampleRequest() with INCLUDE_CONTAINERS set, mirroring a real
+    // --containers op so the request carries the flag a container effect
+    // would actually ride in production.
+    private static QueryRequest sampleRequestWithContainers() {
+        return new QueryRequest(
+                List.of(),
+                Sort.NEWEST_FIRST,
+                10_000,
+                java.util.EnumSet.of(Flag.INCLUDE_CONTAINERS),
+                true);
+    }
+
+    @Test
+    void restoreDirectionNetsToNewestState() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        // Three places at ONE cell: restore mode streams oldest-first, so
+        // per-event replay would land on the newest placement - the
+        // LAST-streamed write must win the fold (#321), same as rollback
+        // direction but exercised the other way round.
+        Instant base = Instant.now();
+        BlockPlaceRecord oldest = placeAt(base, Material.STONE, "minecraft:stone");
+        BlockPlaceRecord middle = placeAt(base.plusSeconds(1), Material.DIRT, "minecraft:dirt");
+        BlockPlaceRecord newest = placeAt(base.plusSeconds(2), Material.OAK_PLANKS, "minecraft:oak_planks");
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(
+                        List.of(oldest, middle, newest), null));
+        java.util.concurrent.atomic.AtomicReference<BlockColumns> captured =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        when(fixture.engine.applyColumnsChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    BlockColumns cols = inv.getArgument(1);
+                    captured.set(cols);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
+                });
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:place", RollbackMode.RESTORE);
+
+        BlockColumns cols = captured.get();
+        assertThat(cols).isNotNull();
+        assertThat(cols.count()).isEqualTo(1);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:oak_planks");
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("1 reversals") && !line.contains("skipped"));
+    }
+
+    @Test
+    void complexEffectsAtOneCellAreNotCoalesced() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequestWithContainers());
+        // Two deposits at the SAME cell: unlike simple block-replaces, the
+        // complex path (containers, entities, tile-entity blocks) is not
+        // folded per cell (#321) - both effects must reach the engine.
+        Instant base = Instant.now();
+        ContainerDepositRecord first = depositAt(base);
+        ContainerDepositRecord second = depositAt(base.plusSeconds(1));
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(
+                        List.of(first, second), null));
+        java.util.concurrent.atomic.AtomicReference<List<RollbackEffect>> captured =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        when(fixture.engine.applyAllChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    List<RollbackEffect> effects = inv.getArgument(0);
+                    captured.set(effects);
+                    List<RollbackResult> results = effects.stream()
+                            .<RollbackResult>map(e -> new RollbackResult.Applied(e, e))
+                            .toList();
+                    return CompletableFuture.completedFuture(results);
+                });
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:deposit", RollbackMode.ROLLBACK);
+
+        List<RollbackEffect> effects = captured.get();
+        assertThat(effects).isNotNull();
+        assertThat(effects).hasSize(2);
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("2 reversals") && !line.contains("skipped"));
+    }
+
+    @Test
+    void foldedRowsStillAdvanceTheResumeCursor() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        // Three break events at the SAME cell fold to one columnar row
+        // (#321). The cursor bookkeeping must still walk every row, so the
+        // checkpoint has to land on the LAST-streamed record, not stall on
+        // the first one folded.
+        BlockBreakRecord a = record();
+        BlockBreakRecord b = record();
+        BlockBreakRecord c = record();
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(a, b, c), null));
+        stubColumnarApplied(fixture);
+        ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+
+        // markFinish deletes the on-disk marker on this clean completion,
+        // so the on-disk state can't be inspected afterward - the spy's
+        // recorded invocation is the only place the mid-run cursor survives.
+        org.mockito.ArgumentCaptor<RollbackResumeStore.Cursor> cursor =
+                org.mockito.ArgumentCaptor.forClass(RollbackResumeStore.Cursor.class);
+        // operatorName is bare any(): fixture.sender is a plain mock whose
+        // getName() returns null, and any(String.class) does not match null.
+        verify(fixture.resumeStore, org.mockito.Mockito.atLeastOnce()).markProgress(
+                any(UUID.class), any(), any(), any(String.class),
+                any(RollbackJob.Mode.class), any(), any(Instant.class),
+                cursor.capture(), anyInt(), anyInt());
+        assertThat(cursor.getValue()).isNotNull();
+        assertThat(cursor.getValue().id()).isEqualTo(c.id());
+        assertThat(cursor.getValue().occurred()).isEqualTo(c.occurred());
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/RollbackServiceTest.java
@@ -45,11 +45,17 @@ class RollbackServiceTest {
     private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
 
     private static BlockBreakRecord record() {
+        return recordAt(0, Material.STONE, "minecraft:stone");
+    }
+
+    // Break of `beforeMat` at (x, 64, 0): its rollback effect writes the
+    // broken block back and expects the air the break left behind.
+    private static BlockBreakRecord recordAt(int x, Material beforeMat, String beforeData) {
         Instant now = Instant.now();
         BlockSnapshot air = new BlockSnapshot(
                 Material.AIR, "minecraft:air", List.of(), List.of(), List.of(), List.of(), null);
-        BlockSnapshot stone = new BlockSnapshot(
-                Material.STONE, "minecraft:stone", List.of(), List.of(), List.of(), List.of(), null);
+        BlockSnapshot before = new BlockSnapshot(
+                beforeMat, beforeData, List.of(), List.of(), List.of(), List.of(), null);
         return new BlockBreakRecord(
                 UUID.randomUUID(),
                 "break",
@@ -57,10 +63,10 @@ class RollbackServiceTest {
                 now.plusSeconds(60),
                 Origin.player(),
                 Source.player(UUID.randomUUID(), "Alice"),
-                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", 0, 64, 0),
+                new net.medievalrp.spyglass.api.util.BlockLocation(WORLD, "world", x, 64, 0),
                 "test",
-                "STONE",
-                stone,
+                beforeMat.name(),
+                before,
                 air);
     }
 
@@ -352,11 +358,9 @@ class RollbackServiceTest {
         TestFixture fixture = new TestFixture();
         when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
                 .thenReturn(sampleRequest());
-        // Distinct records, identical block-data — the columnar fold (#67)
-        // collapses both cells into one BlockColumns whose palette holds one
-        // entry per distinct block-data (stone + air), so the per-cell cost
-        // is two int ids, not a graph of snapshot objects that MTT=1 would
-        // promote to old gen.
+        // Two events at the SAME cell: the palette dedupes the repeated
+        // block-data (#67) and the cell fold collapses the rows to one
+        // net write (#321), so the summary counts the cell once.
         BlockBreakRecord a = record();
         BlockBreakRecord b = record();
         when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
@@ -373,16 +377,76 @@ class RollbackServiceTest {
                     counts.applied = cols.count();
                     return CompletableFuture.completedFuture(counts);
                 });
-        ServiceTestSupport.captureMessages(fixture.sender);
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
 
         fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
 
         BlockColumns cols = captured.get();
         assertThat(cols).isNotNull();
-        assertThat(cols.count()).isEqualTo(2);
-        // Two cells, each writing stone and expecting air = 4 intern calls,
-        // but only the two distinct strings land in the palette.
+        assertThat(cols.count()).isEqualTo(1);
+        // Stone + air are still the only palette entries.
         assertThat(cols.paletteSize()).isEqualTo(2);
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("1 reversals") && !line.contains("skipped"));
+    }
+
+    @Test
+    void multiEventCellAppliesOneNetWrite() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        // Three logged changes at ONE cell, streamed newest-first (#321):
+        // per-event replay would write planks last, so the coalesced row
+        // must carry the LAST streamed write - the oldest event's block.
+        BlockBreakRecord newest = recordAt(0, Material.STONE, "minecraft:stone");
+        BlockBreakRecord middle = recordAt(0, Material.DIRT, "minecraft:dirt");
+        BlockBreakRecord oldest = recordAt(0, Material.OAK_PLANKS, "minecraft:oak_planks");
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(
+                        List.of(newest, middle, oldest), null));
+        java.util.concurrent.atomic.AtomicReference<BlockColumns> captured =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        when(fixture.engine.applyColumnsChunked(
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.any()))
+                .thenAnswer(inv -> {
+                    BlockColumns cols = inv.getArgument(1);
+                    captured.set(cols);
+                    RollbackEngine.ApplyCounts counts = new RollbackEngine.ApplyCounts();
+                    counts.applied = cols.count();
+                    return CompletableFuture.completedFuture(counts);
+                });
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+
+        BlockColumns cols = captured.get();
+        assertThat(cols).isNotNull();
+        assertThat(cols.count()).isEqualTo(1);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:oak_planks");
+        // First-streamed (newest) event's expected-current is kept.
+        assertThat(cols.expData(0)).isEqualTo("minecraft:air");
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("1 reversals") && !line.contains("skipped"));
+    }
+
+    @Test
+    void distinctCellsDoNotCoalesce() throws Exception {
+        TestFixture fixture = new TestFixture();
+        when(fixture.parser.parse(any(CommandSender.class), any(String.class), anyInt(), any()))
+                .thenReturn(sampleRequest());
+        BlockBreakRecord a = recordAt(0, Material.STONE, "minecraft:stone");
+        BlockBreakRecord b = recordAt(1, Material.STONE, "minecraft:stone");
+        BlockBreakRecord c = recordAt(2, Material.STONE, "minecraft:stone");
+        when(fixture.store.queryPage(any(QueryRequest.class), any(), anyInt()))
+                .thenReturn(new net.medievalrp.spyglass.plugin.storage.QueryPage(List.of(a, b, c), null));
+        stubColumnarApplied(fixture);
+        List<Component> messages = ServiceTestSupport.captureMessages(fixture.sender);
+
+        fixture.subject.execute(fixture.sender, "a:break", RollbackMode.ROLLBACK);
+
+        assertThat(ServiceTestSupport.plainTexts(messages))
+                .anyMatch(line -> line.contains("3 reversals") && !line.contains("skipped"));
     }
 
     @Test

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/BlockColumnsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/BlockColumnsTest.java
@@ -94,4 +94,89 @@ class BlockColumnsTest {
         one.add(1, 2, 3, one.intern("minecraft:stone"), -1);
         assertThat(one.chunkSortedOrder()).containsExactly(0);
     }
+
+    // --- per-cell coalescing (#321) ---
+
+    @Test
+    void addOrReplaceFoldsRepeatCellsToTheLastWrite() {
+        BlockColumns cols = new BlockColumns(8);
+        int dirt = cols.intern("minecraft:dirt");
+        int air = cols.intern("minecraft:air");
+        // place, break, place at one cell, rollback direction: the
+        // stream's writes are air (newest place), dirt (break), air
+        // (oldest place). Net write = the last arrival = air.
+        assertThat(cols.addOrReplace(4, 64, 4, air, dirt)).isTrue();
+        assertThat(cols.addOrReplace(4, 64, 4, dirt, air)).isFalse();
+        assertThat(cols.addOrReplace(4, 64, 4, air, dirt)).isFalse();
+
+        assertThat(cols.count()).isEqualTo(1);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:air");
+        // First arrival's expected-current survives the folds.
+        assertThat(cols.expData(0)).isEqualTo("minecraft:dirt");
+    }
+
+    @Test
+    void addOrReplaceKeepsDistinctCellsApart() {
+        BlockColumns cols = new BlockColumns(8);
+        int stone = cols.intern("minecraft:stone");
+        int air = cols.intern("minecraft:air");
+        assertThat(cols.addOrReplace(0, 64, 0, stone, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, 65, 0, air, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, 64, 1, air, -1)).isTrue();
+        assertThat(cols.addOrReplace(1, 64, 0, air, -1)).isTrue();
+        assertThat(cols.count()).isEqualTo(4);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:stone");
+    }
+
+    @Test
+    void addOrReplaceDoesNotWidenBoundsOnAFold() {
+        BlockColumns cols = new BlockColumns(8);
+        int id = cols.intern("minecraft:stone");
+        cols.addOrReplace(5, 70, -3, id, -1);
+        cols.addOrReplace(5, 70, -3, id, -1);
+        assertThat(cols.minX()).isEqualTo(5);
+        assertThat(cols.maxX()).isEqualTo(5);
+        assertThat(cols.minY()).isEqualTo(70);
+        assertThat(cols.maxY()).isEqualTo(70);
+        assertThat(cols.minZ()).isEqualTo(-3);
+        assertThat(cols.maxZ()).isEqualTo(-3);
+    }
+
+    @Test
+    void cellIndexSurvivesGrowthAndExtremeCoordinates() {
+        BlockColumns cols = new BlockColumns(2);
+        int id = cols.intern("minecraft:stone");
+        int other = cols.intern("minecraft:dirt");
+        // Push far past the initial table so the index rehashes, with
+        // world-border-scale and negative coordinates in the mix.
+        for (int i = 0; i < 500; i++) {
+            assertThat(cols.addOrReplace(29_999_000 - i, -64 + (i % 300), -29_999_000 + i, id, -1))
+                    .isTrue();
+        }
+        assertThat(cols.count()).isEqualTo(500);
+        // Every one of the 500 still folds instead of appending.
+        for (int i = 0; i < 500; i++) {
+            assertThat(cols.addOrReplace(29_999_000 - i, -64 + (i % 300), -29_999_000 + i, other, -1))
+                    .isFalse();
+        }
+        assertThat(cols.count()).isEqualTo(500);
+        assertThat(cols.replData(0)).isEqualTo("minecraft:dirt");
+        assertThat(cols.replData(499)).isEqualTo("minecraft:dirt");
+    }
+
+    @Test
+    void nearMissNeighborsAreNotFolded() {
+        // Cells that differ in exactly one axis by one must never share
+        // a packed key (the classic packing-collision bug shape).
+        BlockColumns cols = new BlockColumns(8);
+        int id = cols.intern("minecraft:stone");
+        assertThat(cols.addOrReplace(0, 0, 0, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(1, 0, 0, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(-1, 0, 0, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, 1, 0, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, -1, 0, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, 0, 1, id, -1)).isTrue();
+        assertThat(cols.addOrReplace(0, 0, -1, id, -1)).isTrue();
+        assertThat(cols.count()).isEqualTo(7);
+    }
 }


### PR DESCRIPTION
Closes #321.

## What

A cell with N logged changes was rolled back with N physical writes, counted as N reversals, and audited with N synthesized receipts (the repro's place/break/place read as "3 reversals" + broke x2/placed x1). Both halves now coalesce per cell, CoreProtect-style, per the decided direction on the issue:

- **Apply path**: `BlockColumns` keys rows by packed (x,y,z); `WindowAccumulator.block()` folds repeat cells with the last-streamed write winning. The stream is strictly seq-ordered per direction (rollback newest-first writes `orig_block`, restore oldest-first writes `new_block`), so the surviving write is byte-identical to what per-event replay left behind - one write instead of N, and "N reversals" now counts cells. Cursor/checkpoint bookkeeping still advances on every streamed row.
- **Receipts**: `RolledSynthesis.expandOp` folds covered BlockReplace originals per (world, x, y, z) into one net current -> restored transition (rollback: newest's expected -> oldest's replacement; restore mirrored), classified by the unchanged #269 rules. Receipt ids key on (op, cell). Cells whose changes cancel out (place then break) synthesize nothing - a "broke AIR" line identifies nothing.

## Deliberate semantics

- **Complex effects stay per-event** (tile entities, containers, entities, custom): the #287/#290 container gates keep seeing every effect, and container-slot receipts keep one line per transaction (#265). Container cells and slot receipts are out of scope per the issue.
- **Identity-net cells still get their one engine write** (force-overwrite #69 convergence under drift is preserved exactly - the written state matches today's final state in every case), but synthesize no receipt. So a pure place+break cell counts 1 reversal with no audit line.
- **Coalescing is window-scoped** (131k effects): a cell straddling a window boundary converges to the same final state and just counts once per window - the first-cut option the issue blesses. `smallApplyWindowSplitsOnePageIntoMultipleApplies` pins that behavior.

## Verification

- `./gradlew check` green with Docker up (store ITs ran) + `./gradlew build`.
- Unit: BlockColumns fold/rehash/extreme-coords, service-level net writes for both directions, complex-not-folded, folded-rows-advance-resume-cursor, synthesis nets/identity-suppression/orientation-kept/two-ops-distinct/grouped-count-1/containers-per-original.
- `ClickHouseSynthesisParityIT` extended: churn cell nets to the one persisted receipt, cancelling pair shows nothing either way, on a real ClickHouse container.
- Live on an isolated throwaway Paper 1.21.11 + SQLite with the shaded jar: the #321 repro now reports "1 reversals across 1 chunk", world converges to air, receipts read ROLLBACK broke DIRT x1 / placed x0; new bot case G15 passes end-to-end including the undo leg (undo restores dirt through the same coalesced path).

## Out of scope / follow-ups

- #322 (filed during verification): the #319 strikethrough decoration does not survive to the wire on Paper 1.21.11 - bisected to be pre-existing on the unmodified dev tip, independent of this change and of ViaVersion. Receipts and coverage marking themselves behave correctly.
- Tile-entity same-cell churn (e.g. a sign placed/broken repeatedly) still replays per-event by design - it rides the complex path.