### PR TITLE
fix(command): tab-complete -containers / -entities flags

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -21,6 +21,9 @@ public final class SpyglassSuggestions {
 
     private static final List<String> FLAGS = List.of(
             "-ng", "-g", "-nc", "-ex", "-we",
+            // #287 rollback opt-ins: parsed by QueryStringParser but were
+            // missing here, so they worked when typed yet never completed.
+            "-containers", "-entities",
             "-ord=asc", "-ord=desc",
             "-nod=r", "-nod=t");
 

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestionsTest.java
@@ -166,6 +166,28 @@ class SpyglassSuggestionsTest {
         assertThat(captor.getValue()).isEqualTo("pla");
     }
 
+    // ── #287 rollback opt-in flags complete like the other flags ────────
+
+    @Test
+    void dashOffersTheContainerAndEntityFlags() {
+        assertThat(complete("search -"))
+                .contains("-containers", "-entities");
+    }
+
+    @Test
+    void partialContainerFlagCompletes() {
+        assertThat(complete("search -cont")).contains("-containers");
+    }
+
+    @Test
+    void flagCompletionKeepsEarlierParams() {
+        // The greedy-span rule (#55) applies to flags too: the whole
+        // argument must be spanned or the filter drops the suggestion.
+        List<String> out = complete("search player:Steve -ent");
+        assertThat(out).contains("player:Steve -entities");
+        assertThat(out).allMatch(s -> s.startsWith("player:Steve "));
+    }
+
     /** Headless cloud-core manager — no Bukkit server, just the suggestion engine. */
     static final class TestManager extends CommandManager<CommandSender> {
         TestManager() {


### PR DESCRIPTION
## What

`-containers` and `-entities` (the #287 rollback opt-ins) have been parsed by `QueryStringParser` since they were introduced, but they were never added to the `FLAGS` suggestion list in `SpyglassSuggestions`. So they work when typed but never appear in tab completion - which is exactly how you'd expect to discover them.

Found while testing #321 live (a tester hit `/sg` with no `-containers` completion and asked where the flag was).

## Change

One-line addition of `-containers`, `-entities` to the suggestion list, plus three tests that drive the real cloud suggestion pipeline (the same `suggestImmediately` path the Bukkit tab-completer calls): bare `-`, partial `-cont`, and completion across an earlier param (greedy-span rule from #55).

`./gradlew :spyglass:test --tests '*SpyglassSuggestionsTest'` -> 14/14 green.

Pre-existing, independent of #321.