### PR TITLE
fix(rollback): re-pair double-chest halves after restore (#324)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/ChestRepair.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/ChestRepair.java
@@ -1,0 +1,103 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Chest;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Re-pairs restored chest halves so a rolled-back double chest comes back
+ * coherent (#324).
+ *
+ * <p>Breaking the first half of a double chest makes vanilla collapse the
+ * surviving half from {@code type=right} to {@code type=single} before that
+ * half's own break is recorded. Each half is therefore restored to a state
+ * captured at a different instant - {@code left} for the first, {@code single}
+ * for the second - and the direct-write apply path preserves those recorded
+ * states exactly, so the pair comes back mismatched (a {@code left} next to a
+ * {@code single}) and no longer forms one 54-slot inventory.
+ *
+ * <p>After the engine writes a chest cell, {@link #repair} re-derives its
+ * connectivity from its neighbours the way placement does and, when it finds a
+ * matching partner, fixes <em>both</em> halves. Fixing both is what makes the
+ * result independent of which half was written or repaired first, so a pair
+ * split across chunk or batch boundaries still converges: whichever half is
+ * processed once both are in the world repairs the pair.
+ *
+ * <p>Main thread only (Bukkit block access). Cheap: only ever called for the
+ * chest cells an op actually wrote, which a grief rollback has few of.
+ */
+@ApiStatus.Internal
+final class ChestRepair {
+
+    private ChestRepair() {
+    }
+
+    static void repair(World world, int x, int y, int z) {
+        Block block = world.getBlockAt(x, y, z);
+        if (!(block.getBlockData() instanceof Chest chest)) {
+            return;
+        }
+        BlockFace facing = chest.getFacing();
+        // Vanilla ChestBlock.getConnectedDirection: a LEFT chest's partner
+        // sits at facing.clockwise, a RIGHT chest's at facing.counter-
+        // clockwise. Invert that to derive our type from whichever
+        // neighbour is a matching chest.
+        Block clockwise = block.getRelative(clockwise(facing));
+        Block counter = block.getRelative(counterClockwise(facing));
+        if (isPartner(block, clockwise, facing)) {
+            setTypes(block, Chest.Type.LEFT, clockwise, Chest.Type.RIGHT);
+        } else if (isPartner(block, counter, facing)) {
+            setTypes(block, Chest.Type.RIGHT, counter, Chest.Type.LEFT);
+        } else if (chest.getType() != Chest.Type.SINGLE) {
+            chest.setType(Chest.Type.SINGLE);
+            block.setBlockData(chest, false);
+        }
+    }
+
+    // A partner is an identical-material chest (a chest never pairs with a
+    // trapped chest) sharing this chest's facing.
+    private static boolean isPartner(Block self, Block neighbour, BlockFace facing) {
+        return self.getType() == neighbour.getType()
+                && neighbour.getBlockData() instanceof Chest other
+                && other.getFacing() == facing;
+    }
+
+    private static void setTypes(Block a, Chest.Type typeA, Block b, Chest.Type typeB) {
+        applyType(a, typeA);
+        applyType(b, typeB);
+    }
+
+    private static void applyType(Block block, Chest.Type type) {
+        BlockData data = block.getBlockData();
+        if (data instanceof Chest chest && chest.getType() != type) {
+            chest.setType(type);
+            block.setBlockData(chest, false);
+        }
+    }
+
+    // Horizontal clockwise / counter-clockwise viewed from above, matching
+    // net.minecraft.core.Direction. Non-horizontal facings never occur on a
+    // chest, so they map to themselves and yield no partner.
+    private static BlockFace clockwise(BlockFace facing) {
+        return switch (facing) {
+            case NORTH -> BlockFace.EAST;
+            case EAST -> BlockFace.SOUTH;
+            case SOUTH -> BlockFace.WEST;
+            case WEST -> BlockFace.NORTH;
+            default -> facing;
+        };
+    }
+
+    private static BlockFace counterClockwise(BlockFace facing) {
+        return switch (facing) {
+            case NORTH -> BlockFace.WEST;
+            case WEST -> BlockFace.SOUTH;
+            case SOUTH -> BlockFace.EAST;
+            case EAST -> BlockFace.NORTH;
+            default -> facing;
+        };
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -1099,6 +1099,9 @@ public final class RollbackEngine {
         int from = work.from;
         BitSet nonSimpleMask = work.nonSimpleMask;
         BlockData[] writes = work.writes;
+        // Chest cells written this chunk, re-paired after the writes commit
+        // so a rolled-back double chest comes back coherent (#324).
+        List<int[]> chestCells = null;
         try {
             // The worker's palette writes are all in; drop the block
             // entities they orphaned before any tile state resolves
@@ -1128,6 +1131,12 @@ public final class RollbackEngine {
                             Block block = world.getBlockAt(loc.x(), loc.y(), loc.z());
                             applyTileEntityState(block, replacement);
                         }
+                        if (writes[j] instanceof org.bukkit.block.data.type.Chest) {
+                            if (chestCells == null) {
+                                chestCells = new ArrayList<>(2);
+                            }
+                            chestCells.add(new int[]{loc.x(), loc.y(), loc.z()});
+                        }
                         resultArray[targetIndex] = appliedWithInverse(effect);
                     } catch (RuntimeException ex) {
                         resultArray[targetIndex] = new RollbackResult.Skipped(effect,
@@ -1136,6 +1145,11 @@ public final class RollbackEngine {
                 }
             }
             ChunkDirectWriter.finishChunk(work.ctx);
+            if (chestCells != null) {
+                for (int[] cell : chestCells) {
+                    ChestRepair.repair(world, cell[0], cell[1], cell[2]);
+                }
+            }
             // Direct writes never schedule fluid ticks; re-arm the fluid
             // engine over this chunk's cells and their shell (#270).
             if (writes != null) {
@@ -1442,6 +1456,16 @@ public final class RollbackEngine {
                         }
                         ChunkDirectWriter.finishChunk(cc.ctx);
                     }
+                    // Writes for this chunk are committed; re-pair any chest
+                    // halves so a rolled-back double chest comes back coherent
+                    // (#324). tileCells carries every block-entity cell the
+                    // write touched, empty chests included; repair no-ops the
+                    // rest.
+                    if (cc.tileCells != null) {
+                        for (int[] cell : cc.tileCells) {
+                            ChestRepair.repair(world, cell[0], cell[1], cell[2]);
+                        }
+                    }
                     // Direct writes never schedule fluid ticks; re-arm the
                     // fluid engine over this chunk's cells and shell (#270).
                     FluidTickScheduler.Pass fluids = FluidTickScheduler.begin(world);
@@ -1618,6 +1642,14 @@ public final class RollbackEngine {
                 continue;
             }
             forceWriteCell(null, world, x, y, z, bd);
+            // Same block-entity bookkeeping as the worker path so the
+            // post-write chest re-pair (#324) covers this fallback too.
+            if (ChunkDirectWriter.stateHasBlockEntity(bd)) {
+                if (cc.tileCells == null) {
+                    cc.tileCells = new java.util.ArrayList<>(4);
+                }
+                cc.tileCells.add(new int[]{x, y, z});
+            }
             applied++;
         }
         cc.applied = applied;

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ChestRepairTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/ChestRepairTest.java
@@ -1,0 +1,203 @@
+package net.medievalrp.spyglass.plugin.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Chest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the #324 double-chest re-pair. A small mocked world lets the
+ * pure connectivity logic run without a live server: each cell is a chest (or
+ * not) with a facing and a mutable {@link Chest.Type}, and neighbours resolve
+ * by coordinate.
+ */
+class ChestRepairTest {
+
+    private static final class FakeWorld {
+        final Map<Long, Block> blocks = new HashMap<>();
+        final World world = mock(World.class);
+
+        FakeWorld() {
+            when(world.getBlockAt(org.mockito.ArgumentMatchers.anyInt(),
+                    org.mockito.ArgumentMatchers.anyInt(),
+                    org.mockito.ArgumentMatchers.anyInt()))
+                    .thenAnswer(inv -> blocks.get(key(inv.getArgument(0),
+                            inv.getArgument(1), inv.getArgument(2))));
+        }
+
+        /** A chest cell with the given facing and starting type. */
+        void chest(int x, int y, int z, BlockFace facing, Chest.Type type) {
+            put(x, y, z, chestBlock(x, y, z, Material.CHEST, facing, type));
+        }
+
+        /** A trapped-chest cell (a chest never pairs with one). */
+        void trappedChest(int x, int y, int z, BlockFace facing, Chest.Type type) {
+            put(x, y, z, chestBlock(x, y, z, Material.TRAPPED_CHEST, facing, type));
+        }
+
+        /** A non-chest cell (air) at the given spot. */
+        void air(int x, int y, int z) {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(Material.AIR);
+            when(block.getBlockData()).thenReturn(mock(BlockData.class));
+            wireNeighbours(block, x, y, z);
+            put(x, y, z, block);
+        }
+
+        Chest.Type typeAt(int x, int y, int z) {
+            return ((Chest) blocks.get(key(x, y, z)).getBlockData()).getType();
+        }
+
+        private Block chestBlock(int x, int y, int z, Material material,
+                                 BlockFace facing, Chest.Type start) {
+            Block block = mock(Block.class);
+            Chest.Type[] type = {start};
+            when(block.getType()).thenReturn(material);
+            // Each read returns a fresh data view over the current type; a
+            // write commits the type the caller set on that view.
+            when(block.getBlockData()).thenAnswer(inv -> {
+                Chest data = mock(Chest.class);
+                Chest.Type[] pending = {type[0]};
+                when(data.getFacing()).thenReturn(facing);
+                when(data.getType()).thenAnswer(i -> pending[0]);
+                doAnswer(i -> {
+                    pending[0] = i.getArgument(0);
+                    return null;
+                }).when(data).setType(any());
+                return data;
+            });
+            doAnswer(inv -> {
+                type[0] = ((Chest) inv.getArgument(0)).getType();
+                return null;
+            }).when(block).setBlockData(any(), anyBoolean());
+            wireNeighbours(block, x, y, z);
+            return block;
+        }
+
+        private void wireNeighbours(Block block, int x, int y, int z) {
+            when(block.getRelative(any(BlockFace.class))).thenAnswer(inv -> {
+                BlockFace face = inv.getArgument(0);
+                Block n = blocks.get(key(x + face.getModX(), y + face.getModY(), z + face.getModZ()));
+                if (n != null) {
+                    return n;
+                }
+                Block empty = mock(Block.class);
+                when(empty.getType()).thenReturn(Material.AIR);
+                when(empty.getBlockData()).thenReturn(mock(BlockData.class));
+                return empty;
+            });
+        }
+
+        private void put(int x, int y, int z, Block block) {
+            blocks.put(key(x, y, z), block);
+        }
+
+        private static long key(int x, int y, int z) {
+            return ((long) x & 0x3FFFFFF) << 38 | ((long) z & 0x3FFFFFF) << 12 | (y & 0xFFF);
+        }
+    }
+
+    @Test
+    void repairsALeftSinglePairIntoLeftRight() {
+        // The #324 bug shape: breaking the left half first collapsed the
+        // right half to single, so the restore left a (left, single) pair.
+        FakeWorld w = new FakeWorld();
+        w.chest(0, 64, 0, BlockFace.NORTH, Chest.Type.LEFT);
+        w.chest(1, 64, 0, BlockFace.NORTH, Chest.Type.SINGLE);
+
+        ChestRepair.repair(w.world, 0, 64, 0);
+
+        // North-facing: the +X neighbour is the clockwise side, so (0) is the
+        // left half and (1) the right - a coherent pair, fixed from either.
+        assertThat(w.typeAt(0, 64, 0)).isEqualTo(Chest.Type.LEFT);
+        assertThat(w.typeAt(1, 64, 0)).isEqualTo(Chest.Type.RIGHT);
+    }
+
+    @Test
+    void repairingEitherHalfFixesBoth() {
+        // Same pair, but repair is invoked on the half that is already 'left'
+        // -> it must still correct the single partner (fix-both property that
+        // makes the pass order-independent across chunks/batches).
+        FakeWorld w = new FakeWorld();
+        w.chest(0, 64, 0, BlockFace.NORTH, Chest.Type.SINGLE);
+        w.chest(1, 64, 0, BlockFace.NORTH, Chest.Type.RIGHT);
+
+        ChestRepair.repair(w.world, 1, 64, 0);
+
+        assertThat(w.typeAt(0, 64, 0)).isEqualTo(Chest.Type.LEFT);
+        assertThat(w.typeAt(1, 64, 0)).isEqualTo(Chest.Type.RIGHT);
+    }
+
+    @Test
+    void loneChestBecomesSingle() {
+        // A restored half whose partner is genuinely gone must not stay
+        // 'left' claiming a neighbour that no longer exists.
+        FakeWorld w = new FakeWorld();
+        w.chest(0, 64, 0, BlockFace.NORTH, Chest.Type.LEFT);
+        w.air(1, 64, 0);
+
+        ChestRepair.repair(w.world, 0, 64, 0);
+
+        assertThat(w.typeAt(0, 64, 0)).isEqualTo(Chest.Type.SINGLE);
+    }
+
+    @Test
+    void differentFacingNeighbourIsNotAPartner() {
+        FakeWorld w = new FakeWorld();
+        w.chest(0, 64, 0, BlockFace.NORTH, Chest.Type.LEFT);
+        w.chest(1, 64, 0, BlockFace.SOUTH, Chest.Type.SINGLE);
+
+        ChestRepair.repair(w.world, 0, 64, 0);
+
+        assertThat(w.typeAt(0, 64, 0)).isEqualTo(Chest.Type.SINGLE);
+        assertThat(w.typeAt(1, 64, 0)).isEqualTo(Chest.Type.SINGLE);
+    }
+
+    @Test
+    void trappedChestNeighbourIsNotAPartner() {
+        // A chest and a trapped chest never merge, even adjacent + same facing.
+        FakeWorld w = new FakeWorld();
+        w.chest(0, 64, 0, BlockFace.NORTH, Chest.Type.LEFT);
+        w.trappedChest(1, 64, 0, BlockFace.NORTH, Chest.Type.SINGLE);
+
+        ChestRepair.repair(w.world, 0, 64, 0);
+
+        assertThat(w.typeAt(0, 64, 0)).isEqualTo(Chest.Type.SINGLE);
+    }
+
+    @Test
+    void westFacingPairConnectsAlongZ() {
+        // Facing WEST, the clockwise neighbour is -Z (north). Proves the
+        // rotation math is not hard-coded to the north/X case.
+        FakeWorld w = new FakeWorld();
+        w.chest(5, 70, 9, BlockFace.WEST, Chest.Type.SINGLE);
+        w.chest(5, 70, 8, BlockFace.WEST, Chest.Type.SINGLE);
+
+        ChestRepair.repair(w.world, 5, 70, 9);
+
+        // (5,70,9) clockwise (for WEST) is north = -Z = (5,70,8): that side
+        // is the left half.
+        assertThat(w.typeAt(5, 70, 9)).isEqualTo(Chest.Type.LEFT);
+        assertThat(w.typeAt(5, 70, 8)).isEqualTo(Chest.Type.RIGHT);
+    }
+
+    @Test
+    void nonChestBlockIsIgnored() {
+        FakeWorld w = new FakeWorld();
+        w.air(0, 64, 0);
+        // Must not throw when the restored cell is not a chest at all.
+        ChestRepair.repair(w.world, 0, 64, 0);
+    }
+}


### PR DESCRIPTION
Closes #324.

## Problem

Breaking the first half of a double chest makes vanilla collapse the surviving half from `type=right` to `type=single` **before** that half's own break is recorded. Each half is then restored to a state captured at a different instant - `left` for the first, `single` for the second - and the direct-write apply path preserves those recorded states exactly. Result: a rolled-back double chest comes back as a mismatched `left` + `single` pair that no longer forms one 54-slot inventory.

Reproduced live (Paper 1.21.11) before the fix:
```
forced double chest:   A: type=left    B: type=right
after breaking A:      B collapses to  type=single
after rollback:        A: type=left    B: type=single   -> MISMATCH
```

## Fix

New `ChestRepair.repair(world, x, y, z)`: after the engine commits a chest cell, re-derive its connectivity from its neighbours exactly the way placement does (vanilla `ChestBlock.getConnectedDirection`), and when it finds a matching partner (same material, same facing, on the correct perpendicular side) fix **both** halves. Fixing both is what makes the pass independent of which half was written or repaired first, so a pair split across chunk or batch boundaries still converges - whichever half is processed once both are in the world repairs the pair.

Wired into both apply paths' main-thread post steps:
- **columnar** (empty chests ride this path) - over the chunk's block-entity cells, including the prepareChunk-failed fallback;
- **object** (chests with contents) - over the chest cells written in the chunk.

Only ever called for the chest cells an op actually wrote, so no cost on a typical stone rollback. Contents are preserved (the type fix runs after the tile-entity state is applied).

## Tests

- `ChestRepairTest` (7): the `left`+`single` bug shape -> `left`/`right`; repair from either half fixes both; lone chest -> single; different-facing and trapped-chest neighbours are not partners; a west-facing pair (rotation math not hard-coded to north); non-chest is ignored.
- `./gradlew check` + `build` green (store ITs ran, Docker up).
- **Live-verified** on an isolated throwaway both ways: empty double chest (columnar) and loaded double chest (object) each restore a coherent `left`/`right` pair, diamonds + emeralds intact.

Pre-existing bug, independent of #321 (found while testing #321 live). Trapped chests ride the same fix.