### PR TITLE
perf(listener): defer crafter item serialization off the main thread (#327)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -423,7 +423,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 new ShulkerTransactionListener(recorder, support,
                         task -> getServer().getScheduler().runTask(this, task)),
                 new BundleTransactionListener(recorder, support, this),
-                new CrafterListener(recorder, support),
+                new CrafterListener(recorder, support, deferredSerializer),
                 new SculkListener(recorder, support),
                 new BrushListener(recorder, support, delayedTracker),
                 new VaultListener(recorder, support, delayedTracker));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/modern/CrafterListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/modern/CrafterListener.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.plugin.listener.modern;
 
 import java.util.Set;
+import java.util.concurrent.Executor;
 import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
 import net.medievalrp.spyglass.api.event.RecordContext;
 import net.medievalrp.spyglass.api.event.StoredItem;
@@ -16,15 +17,28 @@ import org.bukkit.event.block.CrafterCraftEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Records crafter (1.21+ auto-crafting block) craft results. A crafter farm
+ * fires this once per pulse per crafter, so the handler only takes a cheap
+ * snapshot on the server thread: {@code getResult()} already hands back a
+ * defensive clone, and the context is minted at event time to keep id and
+ * timestamp ordering. The {@code serializeAsBytes()} blob build and the
+ * record hand-off run on the injected serializer (#98 pattern, #327). The
+ * record is a rollbackable {@link ContainerWithdrawRecord}, so the full item
+ * blob stays and the serializer's flush barrier keeps read-your-writes for
+ * rollback.
+ */
 @ApiStatus.Internal
 public final class CrafterListener implements RecordingListener {
 
     private final Recorder recorder;
     private final RecordingSupport support;
+    private final Executor serializer;
 
-    public CrafterListener(Recorder recorder, RecordingSupport support) {
+    public CrafterListener(Recorder recorder, RecordingSupport support, Executor serializer) {
         this.recorder = recorder;
         this.support = support;
+        this.serializer = serializer;
     }
 
     @Override
@@ -39,9 +53,13 @@ public final class CrafterListener implements RecordingListener {
             return;
         }
         BlockLocation location = BlockLocations.fromLocation(event.getBlock().getLocation());
-        StoredItem stored = ItemSerialization.storedItem(0, result);
         RecordContext ctx = support.environmentContext("crafter", location);
-        recorder.record(ContainerWithdrawRecord.of(ctx, "crafter", result.getType().name(),
-                "CRAFTER", 0, result.getAmount(), stored, null));
+        String material = result.getType().name();
+        int amount = result.getAmount();
+        serializer.execute(() -> {
+            StoredItem stored = ItemSerialization.storedItem(0, result);
+            recorder.record(ContainerWithdrawRecord.of(ctx, "crafter", material,
+                    "CRAFTER", 0, amount, stored, null));
+        });
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/modern/CrafterListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/modern/CrafterListenerTest.java
@@ -1,0 +1,173 @@
+package net.medievalrp.spyglass.plugin.listener.modern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.CrafterCraftEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the deferred serialization strategy for CrafterListener (#327):
+ *
+ * <ul>
+ *   <li>The handler takes only a cheap snapshot on the handling thread;
+ *       serializeAsBytes() and record() run on the injected serializer.</li>
+ *   <li>The finished record is shape-identical to the old inline path
+ *       (crafter withdraw, slot 0, full item blob, null after-item) - the
+ *       record is rollbackable, so the blob must survive the deferral.</li>
+ *   <li>The RecordContext (occurred + id) is stamped at event time on the
+ *       handling thread, not at serialization time (#98 read-your-writes).</li>
+ * </ul>
+ */
+class CrafterListenerTest {
+
+    private static final UUID WORLD_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+
+    private final CapturingRecorder recorder = new CapturingRecorder();
+    private final RecordingSupport support = new RecordingSupport(Duration.parse("4w"), "test");
+    // Strong ref so Location's weak World reference can't be collected mid-test.
+    private final World world = mock(World.class);
+
+    @Test
+    void serializationAndRecordAreDeferredToTheExecutorNotInline() {
+        List<Runnable> deferred = new ArrayList<>();
+        CrafterListener listener = new CrafterListener(recorder, support, deferred::add);
+        ItemStack result = mockStack(Material.COBBLESTONE, 4);
+
+        listener.onCrafterCraft(craft(result));
+
+        // Nothing recorded inline: one deferred task, no serialization yet.
+        assertThat(deferred).hasSize(1);
+        assertThat(recorder.records).isEmpty();
+        verify(result, never()).serializeAsBytes();
+
+        deferred.get(0).run();
+
+        assertThat(recorder.records).hasSize(1);
+        verify(result).serializeAsBytes();
+    }
+
+    /**
+     * The record the deferred task builds must match the old inline path
+     * field for field, including the full base64 blob - crafter records are
+     * rollbackable ContainerWithdrawRecords, so the blob is the replay
+     * source of truth and must not degrade to a projection.
+     */
+    @Test
+    void finishedRecordMatchesTheInlineShape() {
+        List<Runnable> deferred = new ArrayList<>();
+        CrafterListener listener = new CrafterListener(recorder, support, deferred::add);
+
+        listener.onCrafterCraft(craft(mockStack(Material.COBBLESTONE, 4)));
+        deferred.get(0).run();
+
+        ContainerWithdrawRecord record = (ContainerWithdrawRecord) recorder.records.get(0);
+        assertThat(record.event()).isEqualTo("crafter");
+        assertThat(record.target()).isEqualTo("COBBLESTONE");
+        assertThat(record.containerType()).isEqualTo("CRAFTER");
+        assertThat(record.slot()).isEqualTo(0);
+        assertThat(record.amount()).isEqualTo(4);
+        assertThat(record.beforeItem().material()).isEqualTo("COBBLESTONE");
+        assertThat(record.beforeItem().data())
+                .isEqualTo(Base64.getEncoder().encodeToString(new byte[]{1, 2, 3}));
+        assertThat(record.afterItem()).isNull();
+        assertThat(record.location().y()).isEqualTo(64);
+    }
+
+    /**
+     * #98 read-your-writes: occurred and id must be stamped at event time on
+     * the handling thread, not at serialization time on the executor thread.
+     */
+    @Test
+    void occurredAndIdAreStampedAtEventTimeNotAtSerializationTime() {
+        List<Runnable> deferred = new ArrayList<>();
+        CrafterListener listener = new CrafterListener(recorder, support, deferred::add);
+
+        Instant before = Instant.now();
+        listener.onCrafterCraft(craft(mockStack(Material.COBBLESTONE, 1)));
+        Instant after = Instant.now();
+
+        // Simulate delayed executor (the record is built strictly after the event window).
+        deferred.get(0).run();
+
+        ContainerWithdrawRecord record = (ContainerWithdrawRecord) recorder.records.get(0);
+        assertThat(record.occurred())
+                .as("occurred must be stamped at event time, not serialization time")
+                .isBetween(before, after);
+        assertThat(record.id()).isNotNull();
+    }
+
+    @Test
+    void nullResultDefersNothing() {
+        List<Runnable> deferred = new ArrayList<>();
+        CrafterListener listener = new CrafterListener(recorder, support, deferred::add);
+        CrafterCraftEvent event = mock(CrafterCraftEvent.class);
+        when(event.getResult()).thenReturn(null);
+
+        listener.onCrafterCraft(event);
+
+        assertThat(deferred).isEmpty();
+        assertThat(recorder.records).isEmpty();
+    }
+
+    // ── fixtures ────────────────────────────────────────────────
+
+    private CrafterCraftEvent craft(ItemStack result) {
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+
+        Block block = mock(Block.class);
+        when(block.getLocation()).thenReturn(new Location(world, 10, 64, 20));
+
+        CrafterCraftEvent event = mock(CrafterCraftEvent.class);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getResult()).thenReturn(result);
+        return event;
+    }
+
+    private static ItemStack mockStack(Material material, int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(material);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.getItemMeta()).thenReturn(null);
+        when(stack.serializeAsBytes()).thenReturn(new byte[]{1, 2, 3});
+        return stack;
+    }
+
+    private static final class CapturingRecorder implements Recorder {
+        final List<EventRecord> records = new ArrayList<>();
+
+        @Override
+        public void record(EventRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public boolean flush(Duration timeout) {
+            return true;
+        }
+
+        @Override
+        public net.medievalrp.spyglass.plugin.pipeline.AsyncRecorder.ShutdownReport shutdown(Duration timeout) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #327.

## What

`CrafterListener` was the last hot listener doing full item serialization (`serializeAsBytes()` NBT encode + gzip + Base64) inline in its event handler. On the live v1.0.9 profile with crafter farms active it was 1.09 of the plugin's 1.47 Server-thread points - about three quarters of Spyglass's entire main-thread footprint.

This applies the established #98 deferral pattern, same as `ContainerTransactionListener` / `HopperTransferListener`:

- Main thread: cheap snapshot only. `event.getResult()` already returns a defensive clone (paper-api 1.21.8 sources), material name + amount read inline, `RecordContext` minted at event time so id/occurred ordering is unchanged.
- Injected `DeferredSerializer`: `ItemSerialization.storedItem()` + `recorder.record()`.
- The record stays a full-blob rollbackable `ContainerWithdrawRecord` (no projection downgrade) and the serializer is already the recorder's flush barrier, so rollback read-your-writes holds with no new coordination.

## Record shape

Byte-identical to the inline path: `crafter` withdraw, target = result material, container `CRAFTER`, slot 0, full item blob, null after-item. The AIR-result edge also behaves as before (null stored item).

## Tests

New `CrafterListenerTest` (capturing-executor idiom from `BlockBreakListenerTest` / `HopperTransferListenerTest`) pins:
- no serialization or record inline; both happen when the deferred task runs
- finished record matches the inline shape field for field, including the base64 blob
- occurred + id stamped at event time, not serialization time
- null result defers nothing

`./gradlew check build` green with Docker up (store ITs ran; no skip warning).