### PR TITLE
test(render): guard rolled-back strikethrough survives serialization (#322)

### DIFF
--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/render/ResultRendererTest.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.medievalrp.spyglass.api.SpyglassApi;
 import net.medievalrp.spyglass.api.event.BlockUseRecord;
@@ -620,6 +621,65 @@ class ResultRendererTest {
         }
         // The count is still rendered, just muted.
         assertThat(PlainTextComponentSerializer.plainText().serialize(rendered)).contains("x5");
+    }
+
+    /**
+     * #322 regression guard. The reported symptom was that a rolled-back row
+     * reached a live 1.21.11 client gray + italic but NOT struck through -
+     * "strikethrough dropped on the wire while italic survives". That turned
+     * out to be a false alarm in the styling proof (its {@code struck}
+     * predicate wrongly required the deliberately-unstruck "= " marker to be
+     * struck), not a serialization loss: {@code muteDeep} sets STRIKETHROUGH
+     * and ITALIC together on every content node, and the network serializer
+     * keeps both.
+     *
+     * <p>This pins that at the serialization boundary. Adventure's gson
+     * serializer shares the {@code StyleSerializer} the NBT network path uses,
+     * so a decoration it keeps is a decoration the client receives. The two
+     * decorations must appear the same number of times (set together, never
+     * one without the other), and after a round-trip the content stays struck
+     * while the marker stays normal.
+     */
+    @Test
+    void rolledBackRowStrikethroughSurvivesSerialization() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        when(api.displayRenderer("sculk")).thenReturn(Optional.empty());
+        ResultRenderer renderer = new ResultRenderer(api, configWithVerb("sculk", "triggered"));
+
+        Component rendered = renderer.renderSingle(
+                useRecord(), EnumSet.noneOf(Flag.class), true, true);
+        String json = GsonComponentSerializer.gson().serialize(rendered);
+
+        // The exact #322 hypothesis, refuted: strikethrough is not dropped
+        // while italic is kept. muteDeep sets them together, so they serialize
+        // the same number of times.
+        assertThat(json).contains("\"strikethrough\":true");
+        assertThat(countOf(json, "\"strikethrough\":true"))
+                .as("strikethrough must survive serialization exactly as often as italic")
+                .isEqualTo(countOf(json, "\"italic\":true"));
+
+        // Round-trip and confirm the whole contract survives: the "= " marker
+        // stays unstruck, every content node stays struck.
+        Component roundTripped = GsonComponentSerializer.gson().deserialize(json);
+        Component marker = roundTripped.children().get(0);
+        assertThat(PlainTextComponentSerializer.plainText().serialize(marker)).isEqualTo("= ");
+        assertThat(marker.decoration(TextDecoration.STRIKETHROUGH))
+                .isNotEqualTo(TextDecoration.State.TRUE);
+        for (int index = 1; index < roundTripped.children().size(); index++) {
+            forEachNode(roundTripped.children().get(index), node ->
+                    assertThat(node.decoration(TextDecoration.STRIKETHROUGH))
+                            .isEqualTo(TextDecoration.State.TRUE));
+        }
+    }
+
+    private static int countOf(String haystack, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
     }
 
     private static void forEachNode(Component component, java.util.function.Consumer<Component> check) {


### PR DESCRIPTION
Resolves #322.

## TL;DR - not a product bug

#322 reported that on a live Paper 1.21.11 client the #319 mute rendered rolled-back rows gray + italic but **not** struck through, i.e. "strikethrough dropped on the wire while italic survives." Investigated end to end: the renderer is correct and strikethrough **is** on the wire. The failure was a false negative in the untracked styling proof (`regression/bot/_rolledback-styling-proof.mjs`), not a serialization loss.

## Diagnosis

1. **Component is correct.** `muteDeep` sets `STRIKETHROUGH` and `ITALIC` together on every content node; the existing `rolledBackRecordIsGrayStruckThroughAndItalic` test already pins that, and the marker "= " is intentionally left normal.
2. **Serialization keeps it.** Serialized the real rolled-back row through Adventure's `GsonComponentSerializer` (same `StyleSerializer` the NBT network path uses): every content span carries `"italic":true` **and** `"strikethrough":true` - paired 4/4. Nothing is dropped.
3. **The client decodes it.** Ran that exact component through prismarine-chat 1.13.0 (the decoder mineflayer's `bot.on('message')` uses on 1.21.11). Content spans decode `strike:true`; the "= " marker decodes `strike:false`.
4. **The proof's predicate was wrong.** Its `struck` = *every* span struck, but the marker span is deliberately gray-and-unstruck. So `grayOnly` passed (marker is gray) while `struck` failed (marker is not struck) - exactly the "gray arrives, strike doesn't" shape. Fixed the local harness to check the content spans, excluding the marker.

## This PR

Test-only. Adds `rolledBackRowStrikethroughSurvivesSerialization` - a serialization-boundary regression guard that refutes the #322 hypothesis directly: strikethrough serializes exactly as often as italic, and after a gson round-trip the content stays struck while the "= " marker stays normal. The `StyleSerializer` gson shares with the NBT network path makes it a faithful proxy for the wire.

`./gradlew check build` green with Docker up (store ITs ran). No runtime code changed.