### PR TITLE
fix(command): a:<event> filters also match rolled-<event> receipts (#330)

### DIFF
--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/RolledSynthesisTest.java
@@ -572,6 +572,29 @@ class RolledSynthesisTest {
     }
 
     @Test
+    void expandedBreakFilterSurfacesRolledBreak() {
+        MemoryStore store = new MemoryStore();
+        // A place rolled back becomes a rolled-break (block -> air), the
+        // exact shape of the #330 report (magenta placed, then removed).
+        store.save(List.of(dirtPlace(1, GRIEF_TIME)));
+        store.save(List.of(op(grieferQuery(), "ROLLBACK", OP_TIME)));
+        RolledSynthesis synthesis = new RolledSynthesis(store);
+
+        // #330: EventParam now parses a:break to In(event, [break,
+        // rolled-break]); that filter must surface the rollback's rolled-break.
+        List<EventRecord> expanded = synthesis.synthesize(request(
+                new QueryPredicate.In("event", List.of("break", "rolled-break"))));
+        assertThat(expanded).hasSize(1);
+        assertThat(expanded.get(0).event()).isEqualTo("rolled-break");
+        assertThat(expanded.get(0).target()).isEqualTo("DIRT");
+
+        // A bare a:break (no expansion) still suppresses it - the synthesis
+        // contract itself is unchanged; the fix is the filter EventParam builds.
+        assertThat(synthesis.synthesize(request(
+                new QueryPredicate.Eq("event", "break")))).isEmpty();
+    }
+
+    @Test
     void synthesizedIdsAreDeterministicAcrossSearches() {
         MemoryStore store = new MemoryStore();
         store.save(List.of(griefBreak(1)));

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/EventParam.java
@@ -1,6 +1,7 @@
 package net.medievalrp.spyglass.plugin.command.param;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import net.medievalrp.spyglass.api.param.ParamParseException;
 import net.medievalrp.spyglass.api.param.QueryParamHandler;
@@ -8,6 +9,19 @@ import net.medievalrp.spyglass.api.query.QueryPredicate;
 import org.bukkit.command.CommandSender;
 
 public final class EventParam implements QueryParamHandler {
+
+    // A rollback never persists per-block receipts; searches synthesize
+    // rolled-<event> entries from the rollback-op record (#22, RolledSynthesis).
+    // Those carry the rolled-* event names, so a bare a:break would filter out
+    // the rollback that BROKE (removed) a block - the operator sees the original
+    // but not its reversal (#330). Expanding a:break to also match rolled-break
+    // (and place/deposit/withdraw likewise) surfaces both. The In(event, [...])
+    // this produces flows through the synthesis gate and post-filter unchanged.
+    private static final Map<String, String> ROLLED_COUNTERPART = Map.of(
+            "break", "rolled-break",
+            "place", "rolled-place",
+            "deposit", "rolled-deposit",
+            "withdraw", "rolled-withdraw");
 
     private final Set<String> enabledEvents;
 
@@ -40,7 +54,7 @@ public final class EventParam implements QueryParamHandler {
             if (!enabledEvents.contains(name)) {
                 throw new ParamParseException("Unknown or disabled event: " + name);
             }
-            (negated ? excludes : includes).add(name);
+            addWithRolledCounterpart(negated ? excludes : includes, name);
         }
         if (includes.isEmpty() && excludes.isEmpty()) {
             throw new ParamParseException("Event parameter requires at least one name.");
@@ -53,6 +67,23 @@ public final class EventParam implements QueryParamHandler {
             clauses.add(new QueryPredicate.Not(membership(excludes)));
         }
         return clauses.size() == 1 ? clauses.getFirst() : new QueryPredicate.And(clauses);
+    }
+
+    /**
+     * Add {@code name} to the bucket, plus its rollback counterpart when that
+     * rolled event is enabled (#330). Dedupes so {@code a:break,rolled-break}
+     * or a base/rolled pair typed together stays a clean membership. Gating on
+     * {@link #enabledEvents} means an operator who disabled the rolled audit
+     * keeps the old bare-name behavior.
+     */
+    private void addWithRolledCounterpart(List<String> bucket, String name) {
+        if (!bucket.contains(name)) {
+            bucket.add(name);
+        }
+        String rolled = ROLLED_COUNTERPART.get(name);
+        if (rolled != null && enabledEvents.contains(rolled) && !bucket.contains(rolled)) {
+            bucket.add(rolled);
+        }
     }
 
     private static QueryPredicate membership(List<String> names) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/EventParamTest.java
@@ -20,6 +20,11 @@ import org.junit.jupiter.api.Test;
 class EventParamTest {
 
     private static final Set<String> ENABLED = Set.of("break", "place", "say", "death", "deposit");
+    // As shipped: the rolled-* audit events are enabled by default, so a:break
+    // expands to include the rollback's own rolled-break receipts (#330).
+    private static final Set<String> ENABLED_WITH_ROLLED = Set.of(
+            "break", "place", "deposit", "withdraw", "say",
+            "rolled-break", "rolled-place", "rolled-deposit", "rolled-withdraw");
 
     @Test
     void singleKnownEventProducesEq() throws Exception {
@@ -155,6 +160,76 @@ class EventParamTest {
 
         QueryPredicate predicate = param.parse("a", "voice", ctx());
         assertThat(((QueryPredicate.Eq) predicate).value()).isEqualTo("voice");
+    }
+
+    // ---- #330: a:<event> also matches the rollback's rolled-<event> receipts ----
+
+    @Test
+    void breakExpandsToIncludeRolledBreakWhenEnabled() throws Exception {
+        // The headline case: a:break must surface the rollback that removed a
+        // block (a synthesized rolled-break), not just genuine player breaks.
+        QueryPredicate predicate = new EventParam(ENABLED_WITH_ROLLED).parse("a", "break", ctx());
+
+        assertThat(predicate).isInstanceOf(QueryPredicate.In.class);
+        assertThat(((QueryPredicate.In) predicate).values().toArray())
+                .containsExactly("break", "rolled-break");
+    }
+
+    @Test
+    void placeDepositWithdrawEachExpandToTheirRolledCounterpart() throws Exception {
+        EventParam param = new EventParam(ENABLED_WITH_ROLLED);
+        assertThat(((QueryPredicate.In) param.parse("a", "place", ctx())).values().toArray())
+                .containsExactly("place", "rolled-place");
+        assertThat(((QueryPredicate.In) param.parse("a", "deposit", ctx())).values().toArray())
+                .containsExactly("deposit", "rolled-deposit");
+        assertThat(((QueryPredicate.In) param.parse("a", "withdraw", ctx())).values().toArray())
+                .containsExactly("withdraw", "rolled-withdraw");
+    }
+
+    @Test
+    void expansionSkippedWhenRolledEventDisabled() throws Exception {
+        // ENABLED has no rolled-* events (operator disabled the audit): a:break
+        // stays a bare Eq, preserving the old behavior.
+        QueryPredicate predicate = new EventParam(ENABLED).parse("a", "break", ctx());
+        assertThat(predicate).isInstanceOf(QueryPredicate.Eq.class);
+        assertThat(((QueryPredicate.Eq) predicate).value()).isEqualTo("break");
+    }
+
+    @Test
+    void eventWithoutARolledCounterpartIsNotExpanded() throws Exception {
+        // "say" has no rollback shape, so it stays a bare Eq even with the
+        // rolled audit enabled.
+        QueryPredicate predicate = new EventParam(ENABLED_WITH_ROLLED).parse("a", "say", ctx());
+        assertThat(predicate).isInstanceOf(QueryPredicate.Eq.class);
+        assertThat(((QueryPredicate.Eq) predicate).value()).isEqualTo("say");
+    }
+
+    @Test
+    void explicitRolledEventIsNotDoubleExpanded() throws Exception {
+        // rolled-break is not itself a base name, so a:rolled-break stays exact.
+        QueryPredicate predicate = new EventParam(ENABLED_WITH_ROLLED).parse("a", "rolled-break", ctx());
+        assertThat(predicate).isInstanceOf(QueryPredicate.Eq.class);
+        assertThat(((QueryPredicate.Eq) predicate).value()).isEqualTo("rolled-break");
+    }
+
+    @Test
+    void baseAndRolledTypedTogetherDoNotDuplicate() throws Exception {
+        // a:break,rolled-break must not yield [break, rolled-break, rolled-break].
+        QueryPredicate predicate = new EventParam(ENABLED_WITH_ROLLED)
+                .parse("a", "break,rolled-break", ctx());
+        assertThat(((QueryPredicate.In) predicate).values().toArray())
+                .containsExactly("break", "rolled-break");
+    }
+
+    @Test
+    void excludingAnEventAlsoExcludesItsRolledCounterpart() throws Exception {
+        // a:!break must hide the rollback-caused breaks too, symmetric with
+        // the include side.
+        QueryPredicate predicate = new EventParam(ENABLED_WITH_ROLLED).parse("a", "!break", ctx());
+
+        QueryPredicate inner = ((QueryPredicate.Not) predicate).predicate();
+        assertThat(((QueryPredicate.In) inner).values().toArray())
+                .containsExactly("break", "rolled-break");
     }
 
     private static ParamContext ctx() {


### PR DESCRIPTION
Closes #330.

## Problem

A live operator searched `a:break` after a staff rollback removed a block and saw no removal, even though the rollback clearly took it. Rollbacks don't persist per-block receipts; searches synthesize `rolled-break`/`rolled-place`/`rolled-deposit`/`rolled-withdraw` entries from the rollback-op record (#22). A bare `a:break` parses to `event == "break"`, which both trips the synthesis gate off and, in the post-filter, can't match a `rolled-break` row - so the rollback's own effect is hidden behind an explicit `a:rolled-break` nobody thinks to type.

## Fix

`EventParam` now expands an event name to include its rollback counterpart when that rolled event is enabled: `break -> {break, rolled-break}`, and place/deposit/withdraw likewise. The resulting `In(event, [...])` flows through the existing synthesis gate (`eventFilterMightIncludeRolled` already accepts an `In` naming a rolled event) and the in-memory post-filter unchanged, so no synthesis code changes. Excludes expand symmetrically, so `a:!break` also hides rolled-break. Gated on the rolled event being enabled in config, so disabling the rolled audit keeps the old bare-name behavior.

Deduped, so `a:break,rolled-break` (or a base/rolled pair typed together) stays a clean membership.

## Behavior

| Search | Before | After |
|---|---|---|
| `a:break` | genuine breaks only | breaks + rollback-caused breaks (`rolled-break`) |
| `a:!break` | hid breaks, showed rollback breaks | hides both |
| `a:rolled-break` | rollback breaks only | unchanged |
| no `a:` filter | already showed everything | unchanged |

Cost note: `a:break`-style searches now trigger the rollback-op scan they used to skip. It's the same bounded work a no-filter search already does (box-intersection and source-feasibility prunes, capped op count), and only over ops whose bounding box intersects the searched area.

## Tests

- `EventParamTest`: base->rolled expansion for all four events, no expansion when the rolled event is disabled or the event has no rollback shape, explicit `a:rolled-break` not double-expanded, base+rolled dedup, exclude side expands too.
- `RolledSynthesisTest.expandedBreakFilterSurfacesRolledBreak`: end-to-end - the `In(event, [break, rolled-break])` filter surfaces the synthesized `rolled-break` where a bare `Eq(event, break)` still suppresses it.
- `./gradlew check build` green with Docker up (store ITs ran).

Command-layer only; no event added, no storage/parity change.