### PR TITLE
fix(rollback): missing-container skip tells the operator what to do (#335)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/rollback/RollbackEngine.java
@@ -278,6 +278,15 @@ public final class RollbackEngine {
     public static final String CONTAINERS_SKIP =
             "Containers are skipped by default (pass --containers to include them)";
 
+    /**
+     * Skip message when a container transaction's target block no longer
+     * holds a container (#335). We do NOT restore the block here - it comes
+     * back when the operator rolls back the area - so the transaction just
+     * skips and tells them how to give the reversal something to write into.
+     */
+    public static final String MISSING_CONTAINER_SKIP =
+            "Container is missing. Please place a container or roll back the area first.";
+
     /** Skip message for entity work withheld by default (#287). */
     public static final String ENTITIES_SKIP =
             "Entities are skipped by default (pass --entities to include them)";
@@ -2018,7 +2027,7 @@ public final class RollbackEngine {
             return new SurfaceOrSkip(null, "Transactions on " + containerType
                     + " entities cannot be reversed yet.");
         }
-        return new SurfaceOrSkip(null, "Target is no longer a container.");
+        return new SurfaceOrSkip(null, MISSING_CONTAINER_SKIP);
     }
 
     private static EntityType entityContainerType(String containerType) {

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackInclusionFlagsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/rollback/RollbackInclusionFlagsTest.java
@@ -106,6 +106,39 @@ class RollbackInclusionFlagsTest {
     }
 
     @Test
+    void missingContainerSkipTellsTheOperatorWhatToDo() {
+        // #335: the target cell no longer holds a container (it was broken).
+        // Include-everything engine so the #287 gate is not what skips here.
+        RollbackEngine engine = new RollbackEngine();
+
+        World world = mock(World.class);
+        when(world.getUID()).thenReturn(WORLD_ID);
+        when(world.getName()).thenReturn("world");
+        Block block = mock(Block.class);
+        when(block.getState()).thenReturn(mock(org.bukkit.block.BlockState.class));
+        when(world.getBlockAt(1, 64, 2)).thenReturn(block);
+
+        PluginManager pm = mock(PluginManager.class);
+        when(pm.getPlugin("FastAsyncWorldEdit")).thenReturn(null);
+        when(pm.getPlugin("WorldEdit")).thenReturn(null);
+
+        RollbackResult result;
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+            bukkit.when(Bukkit::getPluginManager).thenReturn(pm);
+            bukkit.when(() -> Bukkit.getWorld(WORLD_ID)).thenReturn(world);
+            bukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
+            result = engine.applyAll(List.of(depositRevert()), mock(CommandSender.class)).get(0);
+        }
+
+        assertThat(result).isInstanceOf(RollbackResult.Skipped.class);
+        assertThat(((RollbackReason.NotSupported) ((RollbackResult.Skipped) result).reason()).detail())
+                .isEqualTo(RollbackEngine.MISSING_CONTAINER_SKIP)
+                .contains("place a container")
+                .contains("roll back the area");
+    }
+
+    @Test
     void entityWorkSkipsWithoutTheFlagAndNamesIt() {
         RollbackEngine engine = new RollbackEngine();
         engine.includeInRollback(false, false);


### PR DESCRIPTION
Closes #335.

A container-transaction rollback (a:deposit,withdraw ... --containers) whose container block was broken skips every slot reversal - there is no inventory to write the items back into. The reason line stated a dead-end fact, 'Target is no longer a container.', which a live operator read as the rollback silently doing nothing (incident thread on #333).

Decision (per operator): do NOT restore the block from the transaction path - it comes back when the area is rolled back anyway. Just skip and say what to do. The reason line is now:

    Skip Reason: Container is missing. Please place a container or roll back the area first.

Either recovery path then gives the withdrawal-reversal a container to write into: place one manually and re-run, or roll back the area (which restores the broken block) and re-run. No behavior change - the transaction still skips and never touches the block. Unit test drives the real engine apply path with a non-container block state and pins the message; full ./gradlew check green.