### PR TITLE
fix(command): smart-punctuation dashes read as flag markers (#333)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -9,6 +9,7 @@ Upgrading from 1.0.8 or 1.0.9: on first boot Spyglass rewrites config.conf to th
 - A cell with several logged changes now rolls back with one write and one receipt instead of replaying every event, so a block broken and re-placed twice no longer reports broke x2 for one restored block.
 - Rolling back a broken double chest re-pairs the halves into one 54-slot inventory; they previously came back as a mismatched left + single pair.
 - Crafter output serialization moved off the main thread, same pattern as the other container listeners. With crafter farms active it was most of Spyglass's main-thread cost.
+- Flags survive phone-keyboard smart punctuation: an em or en dash typed for -- reads as the flag marker instead of silently turning the flag into a player filter that matches nothing.
 - Rollbacks bounded by before: warn when newer history above the ceiling is left unrolled.
 - /s is registered as a root alias by default (it was opt-in when introduced in 1.0.9); set commands.s-alias = false if another plugin owns /s.
 - The inspector wand looks back tool.lookback (default 26w) instead of a hidden 7 days, and the results header now names the window.

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -81,7 +81,7 @@ public final class SpyglassSuggestions {
     private List<String> suggestFor(CommandSender sender, String token) {
         if (token.startsWith("-")) {
             String lower = token.toLowerCase(java.util.Locale.ROOT);
-            // After the dash there may be `=value` — split on first
+            // After the dash there may be `=value` - split on first
             // `=` so that completion against a custom flag's value-side
             // works the same as for built-ins.
             int eq = lower.indexOf('=');
@@ -97,7 +97,7 @@ public final class SpyglassSuggestions {
                     }
                     return prefixed;
                 }
-                // Fall through — built-in flags (`-ord=`, `-nod=`)
+                // Fall through - built-in flags (`-ord=`, `-nod=`)
                 // already appear in FLAGS with their values prefilled.
             }
             List<String> all = new ArrayList<>(FLAGS);
@@ -143,7 +143,7 @@ public final class SpyglassSuggestions {
             }
             return prefixed;
         }
-        // No alias yet — suggest every alias with ':' suffix plus the flag starters.
+        // No alias yet - suggest every alias with ':' suffix plus the flag starters.
         List<String> out = new ArrayList<>();
         for (QueryParamHandler handler : api.queryParams()) {
             for (String alias : handler.aliases()) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParser.java
@@ -91,10 +91,15 @@ public final class QueryStringParser {
                 if (token.isEmpty()) {
                     continue;
                 }
-                if (token.startsWith("-")) {
+                if (startsWithFlagDash(token)) {
                     // Accept GNU-style double dashes too: --containers and
-                    // -containers are the same flag (#287).
-                    String name = token.substring(token.startsWith("--") ? 2 : 1)
+                    // -containers are the same flag (#287). Phone keyboards
+                    // and chat bridges substitute smart punctuation for a
+                    // typed "--" (iOS sends one em dash), so the Unicode dash
+                    // family marks a flag as well; without this the bare-token
+                    // fallback below rewrites a mangled flag into p:<token>
+                    // and the query silently matches nothing (#333).
+                    String name = stripLeadingFlagDashes(token)
                             .toLowerCase(java.util.Locale.ROOT);
                     // Value separator: '=' or ':', whichever comes first.
                     // The docs and the rest of the query language use ':';
@@ -188,7 +193,7 @@ public final class QueryStringParser {
                                     + " blocks - add r:N or -g for global)",
                             net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY));
                 }
-                // defaultRadius == 0 means "global default" — no predicate
+                // defaultRadius == 0 means "global default" - no predicate
                 // added, no reminder shown. The whole-DB scan is what the
                 // operator opted into.
             }
@@ -265,7 +270,7 @@ public final class QueryStringParser {
         };
     }
 
-    /** Reserved flag aliases — {@link #applyFlag} handles these
+    /** Reserved flag aliases - {@link #applyFlag} handles these
      *  directly and a custom {@link FlagHandler} cannot shadow them. */
     private static boolean isBuiltinFlag(String alias) {
         return switch (alias) {
@@ -281,11 +286,37 @@ public final class QueryStringParser {
         };
     }
 
+    /**
+     * True when {@code c} is a hyphen for flag purposes: the ASCII hyphen or
+     * the smart-punctuation substitutes (U+2010 hyphen through U+2015
+     * horizontal bar, and the U+2212 minus sign).
+     */
+    private static boolean isFlagDash(char c) {
+        return c == '-' || (c >= '\u2010' && c <= '\u2015') || c == '\u2212';
+    }
+
+    private static boolean startsWithFlagDash(String token) {
+        return !token.isEmpty() && isFlagDash(token.charAt(0));
+    }
+
+    /**
+     * Strip the leading dash run, capped at two marks so ASCII semantics are
+     * unchanged ({@code ---x} still yields the unknown flag {@code -x}). A
+     * single em dash IS the typed {@code --}, so one mark strips like two.
+     */
+    private static String stripLeadingFlagDashes(String token) {
+        int i = 0;
+        while (i < token.length() && i < 2 && isFlagDash(token.charAt(i))) {
+            i++;
+        }
+        return token.substring(i);
+    }
+
     private void applyFlag(String name, String flagValue, CommandSender sender,
                            QueryParamHandler.ParamContext context, ParseState state)
             throws ParamParseException {
         // Built-ins win over custom flags. A third-party plugin can't
-        // shadow `-g` by registering a `g` FlagHandler — the parser
+        // shadow `-g` by registering a `g` FlagHandler - the parser
         // checks the switch below first and the lookup never runs.
         if (!isBuiltinFlag(name)) {
             Optional<FlagHandler> handler = api.flag(name);

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/param/QueryStringParserTest.java
@@ -133,6 +133,50 @@ class QueryStringParserTest {
                         net.medievalrp.spyglass.api.query.Flag.INCLUDE_ENTITIES);
     }
 
+    // ---- #333: smart-punctuation dashes still read as flags ----
+
+    @Test
+    void smartPunctuationDashesParseAsFlags() throws Exception {
+        SpyglassApi api = mock(SpyglassApi.class);
+        // iOS converts a typed "--" into a single em dash. Under the old
+        // classifier this token fell through to the p: fallback and failed
+        // as "Unknown parameter: p" on this bare mock.
+        QueryRequest em = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "\u2014containers", 0);
+        assertThat(em.flags())
+                .contains(net.medievalrp.spyglass.api.query.Flag.INCLUDE_CONTAINERS);
+
+        // En dash and non-breaking hyphen variants behave like "-".
+        QueryRequest en = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "\u2013ng \u2011g", 0);
+        assertThat(en.flags())
+                .contains(net.medievalrp.spyglass.api.query.Flag.NO_GROUP,
+                        net.medievalrp.spyglass.api.query.Flag.GLOBAL);
+
+        // Value separators survive the normalization.
+        QueryRequest ord = new QueryStringParser(api, configNoDefaults())
+                .parse(null, "\u2014ord=asc", 0);
+        assertThat(ord.sort()).isEqualTo(net.medievalrp.spyglass.api.query.Sort.OLDEST_FIRST);
+    }
+
+    @Test
+    void mangledUnknownFlagFailsAsAFlagNotAsAPlayerFilter() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        assertThatThrownBy(() -> new QueryStringParser(api, configNoDefaults())
+                .parse(null, "\u2014sideways", 0))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Unknown flag");
+    }
+
+    @Test
+    void tripleAsciiDashKeepsItsOldUnknownFlagShape() {
+        SpyglassApi api = mock(SpyglassApi.class);
+        assertThatThrownBy(() -> new QueryStringParser(api, configNoDefaults())
+                .parse(null, "---containers", 0))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Unknown flag");
+    }
+
     // ---- #150: ip: pre-resolution off the main thread ----
 
     @Test


### PR DESCRIPTION
Closes #333.

A live operator's /spyglass rollback t:2d -we --containers reached the parser with --containers as one em dash (iOS smart punctuation over a Discord bridge). The em-dash token failed ASCII flag classification, fell into the bare-token p: fallback, and the whole query intersected with a nonexistent player: (Error) No results, scope flag silently unapplied.

QueryStringParser now classifies the Unicode dash family (U+2010..U+2015, U+2212) at token start as a flag marker and strips the leading run capped at two marks, so an em dash behaves exactly like the typed double hyphen it replaced. ASCII behavior is byte-identical (---x still errors as the unknown flag -x). A mangled unknown flag now fails loudly as 'Unknown flag' instead of silently matching nothing. Also sweeps five stray comment em dashes in the two touched files and adds the release-notes bullet.

Tests: em/en/non-breaking-hyphen forms parse to the right flags, value separators survive (ord=asc), unknown mangled flags error as flags, triple-ASCII-dash keeps its old shape. Firsthand security pass on the parser delta: flag names feed a fixed switch + registry lookup, permission-gated flags run the same checks regardless of dash form, and MC's [A-Za-z0-9_] name alphabet means no legitimate bare player token can start with a dash-family char. Full ./gradlew check green.