### PR TITLE
feat(worldedit): config toggle to disable the WorldEdit/FAWE hook (#332)

### DIFF
--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -727,7 +727,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 config.commands().sAlias());
         commands.register();
 
-        if (isWorldEditInstalled()) {
+        if (config.worldedit().enabled() && isWorldEditInstalled()) {
             try {
                 worldEditSubscriber = new WorldEditSubscriber(recorder, support, queryExecutor, this, getLogger());
                 worldEditSubscriber.register();
@@ -735,14 +735,19 @@ public final class SpyglassPlugin extends JavaPlugin {
                 getLogger().warning("Spyglass: WorldEdit integration failed to initialize: " + thrown);
                 worldEditSubscriber = null;
             }
+        } else if (!config.worldedit().enabled() && isWorldEditInstalled()) {
+            getLogger().info("Spyglass: WorldEdit logging disabled (worldedit.enabled = false);"
+                    + " WorldEdit and FAWE edits are not recorded.");
         }
         // Always register the lifecycle listener so WE hot-load (e.g.
         // /plugman load) can wire up recording mid-session without a
         // server restart. If WE is already running, the existing
         // subscriber is handed in and the listener only acts on a
-        // future disable.
+        // future disable. The gate is read live so the #332 toggle (and a
+        // later /sg reload of it) governs hot-load registration too.
         worldEditLifecycle = new WorldEditLifecycleListener(
-                recorder, support, queryExecutor, this, getLogger(), worldEditSubscriber);
+                recorder, support, queryExecutor, this, getLogger(), worldEditSubscriber,
+                () -> config.worldedit().enabled());
         getServer().getPluginManager().registerEvents(worldEditLifecycle, this);
 
         // bStats anonymous usage metrics. The org.bstats package is relocated

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -23,7 +23,8 @@ public record SpyglassConfig(
         Server server,
         Metrics metrics,
         Analytics analytics,
-        Commands commands) {
+        Commands commands,
+        WorldEdit worldedit) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -233,7 +234,15 @@ public record SpyglassConfig(
                 // /s as a third root alias next to /spyglass and /sg. On by
                 // default (#279, reversing #250's opt-in); an operator whose
                 // server has another plugin claiming /s sets s-alias = false.
-                new Commands(root.node("commands", "s-alias").getBoolean(true)));
+                new Commands(root.node("commands", "s-alias").getBoolean(true)),
+                // WorldEdit/FAWE logging hook. On by default (#332); an
+                // absent key reads true so upgrades keep recording. When
+                // false, the subscriber and FAWE hook are never registered,
+                // so large //set / //replace ops build no records and run at
+                // native speed. NOT the same as events.place/break, which
+                // only gate hand place/break - flipping those does nothing
+                // to a WorldEdit op.
+                new WorldEdit(root.node("worldedit", "enabled").getBoolean(true)));
     }
 
     /**
@@ -552,6 +561,16 @@ public record SpyglassConfig(
      * to {@code "default"} for a single-server deployment.
      */
     public record Commands(boolean sAlias) {
+    }
+
+    /**
+     * The WorldEdit/FAWE logging hook (#332). {@code enabled} defaults to
+     * {@code true}; set {@code worldedit.enabled = false} to stop Spyglass
+     * recording WorldEdit and FAWE edits. Distinct from the
+     * {@code events.place}/{@code events.break} toggles, which only gate the
+     * Bukkit hand-place/break listeners and have no effect on a WorldEdit op.
+     */
+    public record WorldEdit(boolean enabled) {
     }
 
     public record Server(String name) {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditLifecycleListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/worldedit/WorldEditLifecycleListener.java
@@ -30,22 +30,31 @@ public final class WorldEditLifecycleListener implements Listener {
     private final Executor asyncExecutor;
     private final org.bukkit.plugin.Plugin plugin;
     private final Logger logger;
+    private final java.util.function.BooleanSupplier enabledGate;
     private WorldEditSubscriber subscriber;
 
     public WorldEditLifecycleListener(Recorder recorder, RecordingSupport support,
                                       Executor asyncExecutor, org.bukkit.plugin.Plugin plugin,
-                                      Logger logger, @Nullable WorldEditSubscriber existing) {
+                                      Logger logger, @Nullable WorldEditSubscriber existing,
+                                      java.util.function.BooleanSupplier enabledGate) {
         this.recorder = recorder;
         this.support = support;
         this.asyncExecutor = asyncExecutor;
         this.plugin = plugin;
         this.logger = logger;
+        this.enabledGate = enabledGate;
         this.subscriber = existing;
     }
 
     @EventHandler
     public void onPluginEnable(PluginEnableEvent event) {
         if (!isWorldEdit(event.getPlugin().getName())) {
+            return;
+        }
+        // Respect the #332 toggle: a WE hot-load must not silently re-arm
+        // logging the operator turned off. Read live so a later /sg reload
+        // that flips worldedit.enabled back on takes effect here too.
+        if (!enabledGate.getAsBoolean()) {
             return;
         }
         if (subscriber != null) {

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -210,6 +210,18 @@ commands {
   s-alias = true
 }
 
+worldedit {
+  # Log WorldEdit and FAWE edits (//set, //replace, //paste, brushes, ...).
+  # On by default. Set false to stop recording WorldEdit/FAWE entirely: a
+  # large //set or //replace then builds no records and runs at native
+  # speed - useful during big staff terraform sessions.
+  #
+  # NOTE: this is the ONLY switch for WorldEdit logging. The events.place /
+  # events.break toggles below gate hand place/break only; turning them off
+  # does nothing to a WorldEdit op.
+  enabled = true
+}
+
 server {
   # Name stamped onto every event; what srv: filters on when several servers
   # share one store.

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
@@ -92,6 +92,26 @@ class LazyOperatorConfigTest {
     }
 
     @Test
+    void worldEditHookDefaultsOnWhenTheKeyIsAbsent(@TempDir Path dataFolder) throws Exception {
+        // #332: an upgraded config with no worldedit block keeps recording
+        // WorldEdit/FAWE - the absent key must read true.
+        write(dataFolder, "database {\n  backend = \"sqlite\"\n}\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.worldedit().enabled()).isTrue();
+    }
+
+    @Test
+    void worldEditHookReadsExplicitFalse(@TempDir Path dataFolder) throws Exception {
+        write(dataFolder, "worldedit {\n  enabled = false\n}\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.worldedit().enabled()).isFalse();
+    }
+
+    @Test
     void handEditedFutureVersionSkipsMigrationAndStillBoots(@TempDir Path dataFolder)
             throws Exception {
         write(dataFolder, "config-version = 99\n"


### PR DESCRIPTION
Closes #332.

## What

Adds a `worldedit.enabled` config toggle (default `true`) that turns Spyglass's WorldEdit/FAWE logging on or off. When `false`, a large `//set` / `//replace` builds **no** records and runs at native FAWE speed. Motivated by a real prod incident: a single staff WorldEdit op logged ~305M block changes and overflowed 67M records to disk, and there was no way to turn WE logging off short of removing the plugin.

## How

- `SpyglassConfig` gains a `WorldEdit(enabled)` record, read with default `true` (absent key => on, so upgrades keep recording; no migration/version bump needed for an additive key).
- `SpyglassPlugin` gates the `WorldEditSubscriber` registration on the toggle. Since `FaweHook.tryInstall` is only reached from inside the subscriber, not registering it gates the FAWE fast-path too.
- The gate is threaded through `WorldEditLifecycleListener` as a live `BooleanSupplier`, so a WE hot-load (`/plugman load`) respects it - and a future `/sg reload` of the toggle takes effect without a restart.
- Documented in the reference `config.conf`, with a note that this is distinct from `events.place`/`events.break` (the common wrong guess - those only gate hand place/break).

## Verified

- Unit: config loads the toggle (default-on when absent, explicit false).
- Live (1.21.11 + WorldEdit 7.4): `worldedit.enabled=false` => boot logs 'WorldEdit logging disabled', a 100-block console `//set` produces **0** records; `=true` => subscriber registers, same `//set` logs. Full `./gradlew check` green.

## Scope

Global manual override only, per the issue. Out of scope (possible follow-ups): a `spyglass.worldedit.bypass` permission or an op-size threshold.