### PR TITLE
feat(snapshot): /sg snapshot - past-instant inventory and container views with audited takes (#341)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -18,6 +18,7 @@ Root command is `/spyglass`, aliased to `/sg` and (on by default) the single-let
 | `/sg rbqueue [...]` | `queue`, `rbq` | `spyglass.rollback` | List, cancel, or resume rollback jobs |
 | `/sg inventory` | `inv`, `salvage` | `spyglass.salvage` | Recover items a rollback destroyed (GUI, or a listing where there is no GUI) |
 | `/sg inventory <id>` | `inv`, `salvage` | `spyglass.salvage` | Recover a container's items by id, via command |
+| `/sg snapshot <params>` | `snap` | `spyglass.snapshot` | View a player inventory or container as of a past instant (GUI, or a listing where there is no GUI) |
 | `/sg tool` | `t`, `inspect` | `spyglass.tool` | Toggle the inspection wand |
 | `/sg import <file \| mysql <source>>` | - | `spyglass.import` | Import a CoreProtect database: a SQLite file from `plugins/Spyglass/import/`, or a live MySQL source defined in `import.conf` |
 | `/sg migrate <backend>` | - | `spyglass.migrate` | Copy every record from the active backend into another configured backend |
@@ -33,6 +34,8 @@ All default to `op`.
 | `spyglass.search.ip` | reveals join IPs in results and unlocks the `ip:` key. Without it, IPs render as `(ip hidden)` and `ip:` errors. Applies on Paper and the proxy |
 | `spyglass.rollback` | rollback, restore, undo, rbqueue |
 | `spyglass.salvage` | `/sg inventory` container salvage (recover items a rollback destroyed). Independent of `spyglass.rollback` |
+| `spyglass.snapshot` | `/sg snapshot` - view a player inventory or container as of a past instant |
+| `spyglass.snapshot.take` | Take a copy of an item out of a snapshot view (GUI click or text-fallback `take`). Independent of `spyglass.snapshot` - view-only access is a legitimate grant |
 | `spyglass.tool` | inspection wand |
 | `spyglass.tele` | teleport (used by clickable result rows) |
 | `spyglass.worldedit` | allows the `-we` flag to use your WorldEdit selection as the search region |
@@ -95,6 +98,17 @@ Flags start with `-` and take no value unless noted.
 ### Time formats
 
 `30s`, `15m`, `4h`, `2d`, `1w`, `1mo`. Combine them: `t:1d12h`.
+
+### Snapshot keys
+
+`/sg snapshot` does not use the query language above - it takes a small, restricted key set, and injects no default radius or time. Any other key or flag is an error.
+
+| Key | Aliases | Example | Notes |
+|---|---|---|---|
+| `t:` | `since:` | `t:1h` | Required. The instant to reconstruct: now minus the duration |
+| `p:` | `player:` | `p:Steve` | View this player's inventory as of `t:`. Exactly one bare name - no `!` or commas. Present = player mode; absent = container mode |
+| `trg:` | `target:` | `trg:100,64,200` | Exact container coordinates. Omit to use the block you're looking at (same reach as the inspection wand). Cannot be combined with `p:` |
+| `w:` | `world:` | `w:world_nether` | World for `trg:`, when running from the console (a player defaults to their current world). Requires `trg:` |
 
 ## Explosion attribution
 
@@ -166,6 +180,24 @@ On Minecraft 1.21.x, `/sg inventory` (alias `inv`) opens a paginated GUI, groupe
 On servers without the GUI (Minecraft 26.x) and from the console or RCON, `/sg inventory` prints a text listing instead. Each captured container shows an id; recover it with `/sg inventory <id>` (in-game players only), or click the `[Recover]` prompt next to a listing line. The command withdraws that container's items straight into your inventory server-side, with no inventory-drag surface. Either way, every withdrawal is logged as a `salvage-withdraw` event (find them with `/sg search a:salvage-withdraw`).
 
 Only containers the rollback *actually* destroys are salvaged - a chest in the rolled region that the rollback leaves untouched is never captured, so items are never duplicated. Salvage snapshots are kept for 30 days.
+
+## Snapshot
+
+`/sg snapshot` (alias `snap`) shows what a player was carrying, or what a container held, at a past instant. It is read-only - nothing about the live player or container changes just from viewing it:
+
+```
+/sg snapshot p:Steve t:1h          # Steve's inventory as of 1 hour ago
+/sg snapshot t:30m                 # the container you're looking at, as of 30 minutes ago
+/sg snapshot t:6h trg:100,64,200   # a specific container by coordinates
+```
+
+**Player mode** (`p:`) reads the subject's newest captured inventory at or before `t:`. Player inventories are captured on join, quit, death, world change, and a periodic sweep - crafting, consuming, trading, and plugin-given items leave no event trail a rollback could replay from, so a dedicated capture is the only honest source for "what were they carrying".
+
+**Container mode** (no `p:`) reconstructs the container from the deposit/withdraw log: it reverse-applies every recorded change back to `t:`, then forward-replays to check the result matches the container's current contents. A reconstruction that reproduces the live container exactly is marked **certain**; one the log can't fully account for - a legacy pre-slot-logging row, a self-mutating block (furnace, brewing stand, campfire), the container's shape having changed, or a change the log never captured - is marked **uncertain**, with the specific reason named. A double chest reconstructs both halves and merges them into one 54-slot view.
+
+On Minecraft 1.21.x, the result opens in a GUI - extract-only, click a slot to take a copy. Elsewhere (26.x, console/RCON), it prints a text listing with a `[take]` link per occupied slot running `/sg snapshot take <token> <slot>`; the token expires after 15 minutes, so re-run `/sg snapshot` if you see "snapshot expired".
+
+A take is a **copy**: the live inventory or container is never touched, and a destination inventory that cannot fit the whole stack refuses the take rather than placing part of it or dropping the rest on the ground. `spyglass.snapshot.take` gates every take, in both the GUI and the text fallback; grant `spyglass.snapshot` without it for view-only access. Every take is logged as a `snapshot-take` event (`/sg search a:snapshot-take`).
 
 ## Importing and migrating
 

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/EventCatalog.java
@@ -92,6 +92,11 @@ public final class EventCatalog {
         // snapshot via /sg inventory (#76). Reuses the withdraw record shape,
         // so both storage backends already persist it.
         m.put("salvage-withdraw", ContainerWithdrawRecord.class);
+        // Emitted when an operator takes an item out of a /sg snapshot view
+        // (a past-instant player inventory or container, #341). Reuses the
+        // pickup record shape - already persisted by every backend - with
+        // its extensions channel naming the snapshot subject and as-of time.
+        m.put("snapshot-take", ItemPickupRecord.class);
         m.put("bookshelf-insert", ContainerDepositRecord.class);
         m.put("bookshelf-remove", ContainerWithdrawRecord.class);
         m.put("pot-insert", ContainerDepositRecord.class);

--- a/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemPickupRecord.java
+++ b/spyglass-api/src/main/java/net/medievalrp/spyglass/api/event/ItemPickupRecord.java
@@ -1,9 +1,18 @@
 package net.medievalrp.spyglass.api.event;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.util.BlockLocation;
 
+/**
+ * {@code extensions} is the opt-in metadata channel from {@link RecordContext}
+ * (see {@link EventRecord#extensions()}). Added for {@code snapshot-take}
+ * (#341): a take out of {@code /sg snapshot} reuses this record shape (the
+ * {@code salvage-withdraw} precedent) and needs to name the snapshot subject
+ * and the as-of instant without overloading {@code target}, which already
+ * carries the item material.
+ */
 public record ItemPickupRecord(
         UUID id,
         String event,
@@ -15,7 +24,29 @@ public record ItemPickupRecord(
         String server,
         String target,
         int amount,
-        StoredItem item) implements EventRecord {
+        StoredItem item,
+        Map<String, String> extensions) implements EventRecord {
+
+    public ItemPickupRecord {
+        extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+    }
+
+    /** Back-compat constructor for call sites that predate the {@code extensions}
+     *  channel (#341). Leaves {@code extensions} empty. */
+    public ItemPickupRecord(
+            UUID id,
+            String event,
+            Instant occurred,
+            Instant expiresAt,
+            Origin origin,
+            Source source,
+            BlockLocation location,
+            String server,
+            String target,
+            int amount,
+            StoredItem item) {
+        this(id, event, occurred, expiresAt, origin, source, location, server, target, amount, item, Map.of());
+    }
 
     public static ItemPickupRecord of(RecordContext ctx, String target, int amount, StoredItem item) {
         return of(ctx, "pickup", target, amount, item);
@@ -24,13 +55,15 @@ public record ItemPickupRecord(
     /**
      * Same shape with an explicit event name, for events that reuse the pickup
      * record without being a world "pickup" - e.g. the destination side of an
-     * automated hopper/dropper transfer ("transfer-in", #226). Keeps
+     * automated hopper/dropper transfer ("transfer-in", #226), or an operator
+     * take out of {@code /sg snapshot} ("snapshot-take", #341). Keeps
      * EventCatalog's name to record-class mapping honest with no codec change.
      */
     public static ItemPickupRecord of(RecordContext ctx, String event, String target, int amount,
             StoredItem item) {
         return new ItemPickupRecord(
                 ctx.id(), event, ctx.occurred(), ctx.expiresAt(),
-                ctx.origin(), ctx.source(), ctx.location(), ctx.server(), target, amount, item);
+                ctx.origin(), ctx.source(), ctx.location(), ctx.server(), target, amount, item,
+                ctx.extensions());
     }
 }

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStore.java
@@ -1028,7 +1028,8 @@ public final class ClickHouseRecordStore implements RecordStore {
             return new ItemPickupRecord(id, event, occurred, expiresAt,
                     origin, source, location, server, target,
                     row.getInteger("amount"),
-                    BsonBlobs.decodeStoredItem(row.getString("item")));
+                    BsonBlobs.decodeStoredItem(row.getString("item")),
+                    readStringMap(row, "extensions"));
         }
         if (clazz == TeleportRecord.class) {
             BlockLocation from = readOptionalLocation(row, "teleport_from_");

--- a/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
+++ b/spyglass-core/src/main/java/net/medievalrp/spyglass/plugin/storage/ClickHouseSchema.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * DDL for the ClickHouse-backed Spyglass deployment.
  *
- * <p>Three tables in one database:
+ * <p>Five tables in one database:
  *
  * <ul>
  *   <li>{@code event_records} — the primary forensic event log.
@@ -28,6 +28,16 @@ import org.jetbrains.annotations.ApiStatus;
  *       engine: a CH table backed by RocksDB key-value, designed
  *       exactly for "small mutable lookup table next to a MergeTree
  *       analytics table".</li>
+ *   <li>{@code player_snapshots} - captured player inventories (#341).
+ *       ReplacingMergeTree sorted by {@code (player_uuid, occurred,
+ *       id)} for point "latest at or before T" lookups; parallel slot
+ *       arrays hold interned {@code snapshot_items} hash refs, not the
+ *       item blobs. Retention is enforced by {@code prune}'s lightweight
+ *       DELETE, not a TTL, so it stays uniform across backends.</li>
+ *   <li>{@code snapshot_items} - content-addressed item payload store
+ *       for {@code player_snapshots}. ReplacingMergeTree keyed on the
+ *       16-byte content hash, so a re-intern of the same payload is a
+ *       natural insert-or-get that collapses on the next merge.</li>
  * </ul>
  *
  * <h2>event_records column strategy</h2>
@@ -131,6 +141,8 @@ final class ClickHouseSchema {
         }
         execute(client, buildUndoHistoryTable(database));
         execute(client, buildToolStatesTable(database));
+        execute(client, buildPlayerSnapshotsTable(database));
+        execute(client, buildSnapshotItemsTable(database));
     }
 
     /**
@@ -206,6 +218,14 @@ final class ClickHouseSchema {
 
     static String toolStatesTable(String database) {
         return qualifiedTable(database, "tool_states");
+    }
+
+    static String playerSnapshotsTable(String database) {
+        return qualifiedTable(database, "player_snapshots");
+    }
+
+    static String snapshotItemsTable(String database) {
+        return qualifiedTable(database, "snapshot_items");
     }
 
     // ---------------------------------------------------------------
@@ -386,6 +406,59 @@ final class ClickHouseSchema {
                 + "    enabled_at DateTime64(3, 'UTC')\n"
                 + ") ENGINE = EmbeddedRocksDB\n"
                 + "PRIMARY KEY player_id";
+    }
+
+    // ---------------------------------------------------------------
+    // player_snapshots / snapshot_items (#341)
+    // ---------------------------------------------------------------
+
+    private static String buildPlayerSnapshotsTable(String database) {
+        // Keyframe player-inventory snapshots. Slots are three parallel
+        // arrays (the CH idiom the wide event_records schema follows for
+        // its repeated fields) rather than a packed blob, so a slot's
+        // interned payload is a 16-byte hash ref into snapshot_items, not
+        // the item bytes. The table is tiny (one row per capture, and the
+        // dirty-check upstream drops unchanged captures), so no partition
+        // key; retention is prune()'s lightweight DELETE, kept uniform
+        // with the other backends instead of a TTL. ReplacingMergeTree on
+        // (player_uuid, occurred, id) means a re-save of the same capture
+        // id collapses on merge while distinct captures coexist. The id is
+        // the EventIds sequence stored as UInt64 (same Delta treatment as
+        // event_records.id), reconstructed to the public UUID on read.
+        // content_hash is the capture service's 64-bit digest, signed here
+        // because Java hands it over as a long; kind is the reserved
+        // keyframe/delta discriminator, always 0 in v1.
+        return "CREATE TABLE IF NOT EXISTS " + playerSnapshotsTable(database) + " (\n"
+                + "    id UInt64 CODEC(Delta, ZSTD(1)),\n"
+                + "    player_uuid UUID,\n"
+                + "    player_name String,\n"
+                + "    occurred DateTime64(3, 'UTC'),\n"
+                + "    cause LowCardinality(String),\n"
+                + "    kind UInt8,\n"
+                + "    content_hash Int64,\n"
+                + "    slots_slot Array(UInt8),\n"
+                + "    slots_hash Array(FixedString(16)),\n"
+                + "    slots_count Array(UInt16)\n"
+                + ") ENGINE = ReplacingMergeTree\n"
+                + "ORDER BY (player_uuid, occurred, id)\n"
+                + "SETTINGS index_granularity = 8192";
+    }
+
+    private static String buildSnapshotItemsTable(String database) {
+        // Content-addressed intern table for the item payloads referenced
+        // by player_snapshots.slots_hash. The 16-byte SHA-256/16 of the
+        // raw serializeAsBytes payload is the sort key, so ReplacingMergeTree
+        // makes a re-intern of the same item a natural insert-or-get that
+        // collapses on merge (no upsert, no throw). data holds the base64
+        // payload under ZSTD(3): a CH String column stores text cleanly, and
+        // the same kit carried for a week costs one row, not one per capture.
+        return "CREATE TABLE IF NOT EXISTS " + snapshotItemsTable(database) + " (\n"
+                + "    hash FixedString(16),\n"
+                + "    material LowCardinality(String),\n"
+                + "    data String CODEC(ZSTD(3))\n"
+                + ") ENGINE = ReplacingMergeTree\n"
+                + "ORDER BY hash\n"
+                + "SETTINGS index_granularity = 8192";
     }
 
     private static String quoteIdentifier(String identifier) {

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/ClickHouseRecordStoreIT.java
@@ -16,6 +16,7 @@ import net.medievalrp.spyglass.api.event.ChatRecord;
 import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
 import net.medievalrp.spyglass.api.event.EntityDeathRecord;
 import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
 import net.medievalrp.spyglass.api.event.Origin;
 import net.medievalrp.spyglass.api.event.Source;
 import net.medievalrp.spyglass.api.event.StoredItem;
@@ -430,6 +431,38 @@ class ClickHouseRecordStoreIT {
         assertThat(store.query(byContent).records())
                 .as("m:/content: (OR message,commandLine) must match the message column")
                 .hasSize(1);
+    }
+
+    @Test
+    void roundTripsSnapshotTakeWithExtensions() {
+        // #341: snapshot-take reuses ItemPickupRecord with its extensions
+        // channel (snapshot-subject / snapshot-at). The pickup decode branch
+        // used to skip the extensions column entirely (unlike Chat/Custom),
+        // so this pins that it now reads it back on a real ClickHouse.
+        Instant now = Instant.now().minusSeconds(60);
+        BlockLocation loc = new BlockLocation(WORLD, "world", 1, 64, 2);
+        StoredItem projection = new StoredItem(3, "DIAMOND_SWORD", null, "Excaliblur", List.of(), List.of());
+        ItemPickupRecord rec = new ItemPickupRecord(
+                UUID.randomUUID(), "snapshot-take", now, now.plusSeconds(3600),
+                Origin.player(), Source.player(ALICE, "Alice"), loc, "test",
+                "DIAMOND_SWORD", 1, projection,
+                Map.of("snapshot-subject", "Bob", "snapshot-at", now.minusSeconds(120).toString()));
+        store.save(List.of(rec));
+        flushAsyncInserts();
+
+        QueryRequest byEvent = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "snapshot-take")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        ItemPickupRecord back = (ItemPickupRecord) store.query(byEvent).records().get(0);
+        assertThat(back.extensions()).containsEntry("snapshot-subject", "Bob");
+        assertThat(back.extensions()).containsKey("snapshot-at");
+        assertThat(back.item().name()).isEqualTo("Excaliblur");
+
+        QueryRequest bySubject = new QueryRequest(
+                List.of(new QueryPredicate.Eq("event", "snapshot-take"),
+                        new QueryPredicate.Eq("extensions.snapshot-subject", "Bob")),
+                Sort.NEWEST_FIRST, 10, EnumSet.noneOf(Flag.class), false);
+        assertThat(store.query(bySubject).records()).hasSize(1);
     }
 
     @Test

--- a/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
+++ b/spyglass-core/src/test/java/net/medievalrp/spyglass/plugin/storage/EventRecordCodecTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.mongodb.MongoClientSettings;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import net.medievalrp.spyglass.api.event.BlockBreakRecord;
 import net.medievalrp.spyglass.api.event.BlockSnapshot;
@@ -334,6 +335,47 @@ class EventRecordCodecTest {
         assertThat(item.name()).isEqualTo("Excaliblur");
         assertThat(item.lore()).containsExactly("Forged in fire");
         assertThat(item.enchants()).containsExactly("sharpness=5");
+    }
+
+    @Test
+    void roundTripsSnapshotTakeWithExtensions() {
+        // #341: snapshot-take reuses ItemPickupRecord with its new
+        // extensions channel (snapshot-subject / snapshot-at). Mongo's
+        // RecordCodecProvider is generic over record components, so this
+        // only needs to prove the new component actually rides the wire -
+        // no codec change was required to support it.
+        StoredItem projection = new StoredItem(3, "DIAMOND_SWORD", null);
+        ItemPickupRecord original = new ItemPickupRecord(
+                UUID.randomUUID(), "snapshot-take", WHEN, WHEN.plusSeconds(3600),
+                Origin.player(), Source.player(ALICE, "Alice"),
+                new BlockLocation(WORLD, "world", 1, 64, 2),
+                "test", "DIAMOND_SWORD", 1, projection,
+                Map.of("snapshot-subject", "Bob", "snapshot-at", WHEN.minusSeconds(120).toString()));
+
+        EventRecord decoded = decode(encode(original));
+
+        assertThat(decoded).isInstanceOf(ItemPickupRecord.class).isEqualTo(original);
+        ItemPickupRecord back = (ItemPickupRecord) decoded;
+        assertThat(back.extensions())
+                .containsEntry("snapshot-subject", "Bob")
+                .containsEntry("snapshot-at", WHEN.minusSeconds(120).toString());
+    }
+
+    @Test
+    void backCompatItemPickupConstructorLeavesExtensionsEmptyAndStillRoundTrips() {
+        // Pre-#341 call sites (CoreProtectMapper, CreativeCloneListener) still
+        // use the 11-arg constructor. It must leave extensions empty (same as
+        // an explicit Map.of()) and the resulting record must still round-trip.
+        StoredItem projection = new StoredItem(0, "STONE", null);
+        ItemPickupRecord viaBackCompat = new ItemPickupRecord(
+                UUID.randomUUID(), "pickup", WHEN, WHEN.plusSeconds(3600),
+                Origin.player(), Source.player(ALICE, "Alice"),
+                new BlockLocation(WORLD, "world", 0, 64, 0),
+                "test", "STONE", 1, projection);
+
+        assertThat(viaBackCompat.extensions()).isEmpty();
+        EventRecord decoded = decode(encode(viaBackCompat));
+        assertThat(decoded).isInstanceOf(ItemPickupRecord.class).isEqualTo(viaBackCompat);
     }
 
     @Test

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/SpyglassPlugin.java
@@ -130,6 +130,19 @@ import net.medievalrp.spyglass.plugin.salvage.SalvageViews;
 import net.medievalrp.spyglass.plugin.salvage.SalvageWithdrawLogger;
 import net.medievalrp.spyglass.plugin.salvage.SalvageWithdrawals;
 import net.medievalrp.spyglass.plugin.command.service.SalvageService;
+import net.medievalrp.spyglass.plugin.command.service.SnapshotService;
+import net.medievalrp.spyglass.plugin.snapshot.ClickHousePlayerSnapshotStore;
+import net.medievalrp.spyglass.plugin.snapshot.MariaDbPlayerSnapshotStore;
+import net.medievalrp.spyglass.plugin.snapshot.MongoPlayerSnapshotStore;
+import net.medievalrp.spyglass.plugin.snapshot.PlayerSnapshotListener;
+import net.medievalrp.spyglass.plugin.snapshot.PlayerSnapshotService;
+import net.medievalrp.spyglass.plugin.snapshot.PlayerSnapshotStore;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSessions;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotTakeLogger;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotTakes;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotView;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotViews;
+import net.medievalrp.spyglass.plugin.snapshot.SqlitePlayerSnapshotStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.ClickHouseToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.MariaDbToolStateStore;
 import net.medievalrp.spyglass.plugin.command.service.tool.MongoToolStateStore;
@@ -179,6 +192,13 @@ public final class SpyglassPlugin extends JavaPlugin {
     private UndoStack undoStack;
     private ToolStateStore toolStateStore;
     private SalvageStore salvageStore;
+    /** Per-backend store for player-inventory snapshots (#341); built next to
+     *  {@link #salvageStore} for every backend, closed in onDisable after the
+     *  capture service that writes to it is stopped. */
+    private PlayerSnapshotStore playerSnapshotStore;
+    /** Periodic + event-driven inventory capture (#341); null when
+     *  {@code snapshot.players.enabled} is false. */
+    private PlayerSnapshotService playerSnapshotService;
     private Executor queryExecutor;
     /**
      * Off-main serialization stage for the item-heavy listeners. Item
@@ -223,6 +243,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                             mongoStore.database(), getLogger());
                     salvageStore = new MongoSalvageStore(
                             mongoStore.database(), mongoStore.codecRegistry(), 30L);
+                    playerSnapshotStore = new MongoPlayerSnapshotStore(
+                            mongoStore.database(), mongoStore.codecRegistry());
                 }
                 case CLICKHOUSE -> {
                     SpyglassConfig.ClickHouse ch = config.database().clickhouse();
@@ -236,6 +258,8 @@ public final class SpyglassPlugin extends JavaPlugin {
                             chStore.client(), ch.database());
                     salvageStore = new ClickHouseSalvageStore(
                             chStore.client(), ch.database(), 30L);
+                    playerSnapshotStore = new ClickHousePlayerSnapshotStore(
+                            chStore.client(), ch.database());
                 }
                 case SQLITE -> {
                     // One embedded file holds every store. A relative path
@@ -254,6 +278,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                     undoStack = new SqliteUndoStack(sqliteStore);
                     toolStateStore = new SqliteToolStateStore(sqliteStore);
                     salvageStore = new SqliteSalvageStore(sqliteStore, 30L);
+                    playerSnapshotStore = new SqlitePlayerSnapshotStore(sqliteStore);
                 }
                 case MARIADB -> {
                     // Client-server SQL backend: records, undo ledger, wand
@@ -269,6 +294,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                     undoStack = new MariaDbUndoStack(mariaStore);
                     toolStateStore = new MariaDbToolStateStore(mariaStore);
                     salvageStore = new MariaDbSalvageStore(mariaStore, 30L);
+                    playerSnapshotStore = new MariaDbPlayerSnapshotStore(mariaStore);
                 }
             }
             // #22: searches synthesize per-block rolled-* entries
@@ -554,6 +580,26 @@ public final class SpyglassPlugin extends JavaPlugin {
         } else {
             getLogger().info("Spyglass: container salvage capture disabled for this backend.");
         }
+        // Player-inventory snapshots (#341): the capture service (periodic sweep +
+        // join/quit/death/world-change listener) is gated by snapshot.players.enabled,
+        // NOT the events map (PlayerSnapshotListener is a plain Listener, not a
+        // RecordingListener). The store itself is always built above so viewing and
+        // taking stay available even when capture is off.
+        if (config.snapshot().players().enabled()) {
+            playerSnapshotService = new PlayerSnapshotService(
+                    playerSnapshotStore,
+                    config.snapshot().players().interval(),
+                    config.snapshot().players().retention(),
+                    getLogger());
+            playerSnapshotService.start(this);
+            getServer().getPluginManager().registerEvents(
+                    new PlayerSnapshotListener(playerSnapshotService, this), this);
+            getLogger().info("Spyglass: player snapshot capture enabled (every "
+                    + config.snapshot().players().interval().seconds() + "s, retained "
+                    + config.snapshot().players().retention().seconds() + "s).");
+        } else {
+            getLogger().info("Spyglass: player snapshot capture disabled (snapshot.players.enabled=false).");
+        }
         ServiceSupport serviceSupport = ServiceSupport.bukkit(this);
 
         QueryStringParser parser = new QueryStringParser(apiImpl, config);
@@ -702,6 +748,23 @@ public final class SpyglassPlugin extends JavaPlugin {
                         config.limits().searchResult(), getLogger());
         SalvageService salvageService = new SalvageService(
                 salvageStore, salvageView, salvageWithdrawals, config.limits().searchResult(), serviceSupport);
+
+        // /sg snapshot (#341): view a player inventory or container as of a past
+        // instant and take copies out. Every take is audited onto snapshot-take
+        // (reusing ItemPickupRecord + the extensions channel, the salvage-withdraw
+        // precedent). SnapshotViews.guiOrNull returns the InvUI GUI on 1.x and null
+        // on 26.x, where the service falls back to a clickable text listing - the
+        // same split SalvageViews draws. The take permission gates both surfaces.
+        SnapshotTakeLogger snapshotTakeLogger =
+                new SnapshotTakeLogger(apiImpl, support, getLogger());
+        SnapshotSessions snapshotSessions = new SnapshotSessions();
+        getServer().getPluginManager().registerEvents(snapshotSessions, this);
+        SnapshotTakes snapshotTakes = new SnapshotTakes(snapshotTakeLogger);
+        SnapshotView snapshotView = SnapshotViews.guiOrNull(
+                this, getServer().getBukkitVersion(), snapshotTakes, getLogger());
+        SnapshotService snapshotService = new SnapshotService(
+                playerSnapshotStore, recordStore, recorder, config, serviceSupport,
+                snapshotSessions, snapshotTakes, snapshotView, getLogger());
         // #168: /spyglass stats. Null ingestStats (analytics off) => the command
         // explains how to enable it.
         StatsService statsService = new StatsService(ingestStats, recorder::spillSnapshot);
@@ -718,6 +781,7 @@ public final class SpyglassPlugin extends JavaPlugin {
                 toolService,
                 teleportService,
                 salvageService,
+                snapshotService,
                 statsService,
                 suggestions,
                 importService,
@@ -838,6 +902,22 @@ public final class SpyglassPlugin extends JavaPlugin {
                 active.unregister();
             } catch (Throwable ignored) {
             }
+        }
+        // Stop player-snapshot capture before any store is torn down (#341):
+        // the capture executor writes to playerSnapshotStore, which for the
+        // SQLite/MariaDB backends shares the record store's connection, so its
+        // in-flight captures must drain before recordStore.close() below.
+        // Service stop first, then the store (mirrors salvage/tool teardown).
+        if (playerSnapshotService != null) {
+            playerSnapshotService.stop();
+            playerSnapshotService = null;
+        }
+        if (playerSnapshotStore != null) {
+            try {
+                playerSnapshotStore.close();
+            } catch (Exception ignored) {
+            }
+            playerSnapshotStore = null;
         }
         // Drain the off-thread serialization stage BEFORE the recorder,
         // so any in-flight snapshots (deferred item pickups) finish

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassCommands.java
@@ -13,6 +13,7 @@ import net.medievalrp.spyglass.plugin.command.service.RollbackMode;
 import net.medievalrp.spyglass.plugin.command.service.RollbackService;
 import net.medievalrp.spyglass.plugin.command.service.SalvageService;
 import net.medievalrp.spyglass.plugin.command.service.SearchService;
+import net.medievalrp.spyglass.plugin.command.service.SnapshotService;
 import net.medievalrp.spyglass.plugin.command.service.StatsService;
 import net.medievalrp.spyglass.plugin.command.service.TeleportService;
 import net.medievalrp.spyglass.plugin.command.service.ToolService;
@@ -54,6 +55,7 @@ public final class SpyglassCommands {
     private final ToolService tool;
     private final TeleportService teleport;
     private final SalvageService salvage;
+    private final SnapshotService snapshot;
     private final StatsService stats;
     private final SpyglassSuggestions suggestions;
     private final ImportService imports;
@@ -72,6 +74,7 @@ public final class SpyglassCommands {
                         ToolService tool,
                         TeleportService teleport,
                         SalvageService salvage,
+                        SnapshotService snapshot,
                         StatsService stats,
                         SpyglassSuggestions suggestions,
                         ImportService imports,
@@ -90,6 +93,7 @@ public final class SpyglassCommands {
         this.tool = tool;
         this.teleport = teleport;
         this.salvage = salvage;
+        this.snapshot = snapshot;
         this.stats = stats;
         this.suggestions = suggestions;
         this.imports = imports;
@@ -113,6 +117,7 @@ public final class SpyglassCommands {
     private static final List<String> EVENTS_ALIASES = List.of("events", "e");
     private static final List<String> HELP_ALIASES = List.of("help", "h", "?");
     private static final List<String> INVENTORY_ALIASES = List.of("inventory", "inv", "salvage");
+    private static final List<String> SNAPSHOT_ALIASES = List.of("snapshot", "snap");
     private static final List<String> VERSION_ALIASES = List.of("version", "ver");
     private static final List<String> STATS_ALIASES = List.of("stats", "analytics");
 
@@ -222,6 +227,31 @@ public final class SpyglassCommands {
                         .required("id", StringParser.stringParser())
                         .permission("spyglass.salvage")
                         .handler(ctx -> salvage.withdraw(ctx.sender(), ctx.get("id"))));
+            }
+
+            for (String name : SNAPSHOT_ALIASES) {
+                // /sg snapshot <params>: view a player inventory or container as
+                // of a past instant (#341). Greedy params (t:/p:/trg:/w:), the
+                // house style; whole-span suggestions keep multi-key completion
+                // alive (#55). Gated on spyglass.snapshot - viewing without the
+                // take grant is legitimate.
+                manager.command(manager.commandBuilder(root).literal(name)
+                        .required("params", suggestions.snapshotParamsParser(),
+                                suggestions.snapshotParamsProvider())
+                        .permission("spyglass.snapshot")
+                        .handler(ctx -> snapshot.execute(ctx.sender(), ctx.get("params"))));
+                // /sg snapshot take <token> <slot>: the text-fallback take path
+                // (the GUI clicks reach the same SnapshotService.take). Gated on
+                // spyglass.snapshot.take, which the GUI re-checks per click. The
+                // literal "take" child is matched before the greedy params above,
+                // the same literal-before-variable routing /sg import mysql relies
+                // on. Hidden from help - it exists for the listing's [take] links.
+                manager.command(manager.commandBuilder(root).literal(name).literal("take")
+                        .required("token", StringParser.stringParser())
+                        .required("slot", IntegerParser.integerParser())
+                        .permission("spyglass.snapshot.take")
+                        .handler(ctx -> snapshot.take(ctx.sender(),
+                                ctx.get("token"), ctx.get("slot"))));
             }
 
             // /spyglass tele <world> <x> <y> <z> — wired to search-result click

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/SpyglassSuggestions.java
@@ -56,8 +56,38 @@ public final class SpyglassSuggestions {
                 .map(Suggestion::suggestion).toList();
     }
 
+    // The restricted key set /sg snapshot accepts (#341): a point-in-time
+    // snapshot has no radius/action/time-window keys, so this is deliberately
+    // NOT the full query-param set the search/rollback params share.
+    private static final List<String> SNAPSHOT_KEYS = List.of("t:", "p:", "trg:", "w:");
+
     public ParserDescriptor<CommandSender, String> paramsParser() {
         return StringParser.greedyStringParser();
+    }
+
+    public ParserDescriptor<CommandSender, String> snapshotParamsParser() {
+        return StringParser.greedyStringParser();
+    }
+
+    /**
+     * Whole-span completion for {@code /sg snapshot <params>}. The params
+     * argument is greedy, so Cloud hands us the entire remaining span and then
+     * filters our output down to suggestions that start with it; a bare
+     * {@code p:} would fail that filter the moment {@code t:} is already typed.
+     * Prepend the already-typed prefix so each suggestion spans the whole
+     * argument and survives, exactly as {@link #paramsProvider} does (#55).
+     */
+    public BlockingSuggestionProvider<CommandSender> snapshotParamsProvider() {
+        return (ctx, input) -> {
+            String remaining = input.remainingInput();
+            String lastToken = lastToken(remaining);
+            String prefix = remaining.substring(0, remaining.length() - lastToken.length());
+            return SNAPSHOT_KEYS.stream()
+                    .filter(key -> key.startsWith(lastToken))
+                    .map(key -> prefix + key)
+                    .map(Suggestion::suggestion)
+                    .toList();
+        };
     }
 
     public BlockingSuggestionProvider<CommandSender> paramsProvider() {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SnapshotService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/command/service/SnapshotService.java
@@ -1,0 +1,684 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.api.query.Flag;
+import net.medievalrp.spyglass.api.query.QueryPredicate;
+import net.medievalrp.spyglass.api.query.QueryRequest;
+import net.medievalrp.spyglass.api.query.QueryResult;
+import net.medievalrp.spyglass.api.query.Sort;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.command.render.Feedback;
+import net.medievalrp.spyglass.plugin.config.SpyglassConfig;
+import net.medievalrp.spyglass.plugin.pipeline.Recorder;
+import net.medievalrp.spyglass.plugin.snapshot.PlayerSnapshot;
+import net.medievalrp.spyglass.plugin.snapshot.PlayerSnapshotStore;
+import net.medievalrp.spyglass.plugin.snapshot.Reconstruction;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotReconstructor;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSession;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSessions;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSlot;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotTakes;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotView;
+import net.medievalrp.spyglass.plugin.storage.RecordStore;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.BrewingStand;
+import org.bukkit.block.Campfire;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Container;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.block.Furnace;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Backs {@code /sg snapshot} (#341): view a player inventory or container
+ * as of a past instant, and take copies out of what is shown.
+ *
+ * <p>Two modes, switched on whether {@code p:} is present:
+ *
+ * <ul>
+ *   <li><b>Player mode</b> ({@code p:<name>}) reads the subject's newest
+ *       {@code PlayerSnapshot} at or before T straight from the
+ *       {@link PlayerSnapshotStore} - always {@link SnapshotSession.Certainty#CERTAIN},
+ *       since a capture is exact (only {@code capturedAt} tells the
+ *       operator how close to T it actually landed).</li>
+ *   <li><b>Container mode</b> (no {@code p:}) resolves a target block -
+ *       {@code trg:x,y,z} or the block the sending player is looking at -
+ *       and reconstructs it via {@link SnapshotReconstructor} against the
+ *       deposit/withdraw/shulker/crafter log in {@code [T, now]}.</li>
+ * </ul>
+ *
+ * <p>This class does not open a GUI itself; it hands a resolved
+ * {@link SnapshotSession} to the injected {@link SnapshotView} when one is
+ * present and the sender is a player, and falls back to a text listing
+ * otherwise (26.x, console/RCON, or no GUI wired) - the same split
+ * {@code SalvageService} draws for {@code /sg inventory}.
+ *
+ * <p>Every store/query call and every {@link Block#getState()} /
+ * {@link org.bukkit.inventory.Inventory} read is thread-sensitive: parsing,
+ * target resolution, and live-content cloning run on the calling (main)
+ * thread; the store reads, the recorder flush, and the reconstruction
+ * itself run via {@link ServiceSupport#onAsyncThread}; the session is
+ * built and handed to the view back on {@link ServiceSupport#onMainThread}.
+ */
+@ApiStatus.Internal
+public final class SnapshotService {
+
+    /** Reach for the look-at fallback when {@code trg:} is omitted - matches
+     *  the inspection wand's short-range use (a player standing at a
+     *  container, not sniping one across a room). */
+    private static final int LOOK_REACH = 6;
+
+    /** Defensive cap on how many container-family records one snapshot
+     *  query pulls back. A single container's deposit/withdraw history
+     *  inside one snapshot window is not expected to approach this; it
+     *  exists to bound a pathological case (a hopper farm's output chest)
+     *  rather than to reflect a real limit an operator would hit. */
+    private static final int MAX_CONTAINER_RECORDS = 50_000;
+
+    /** Slot bound used when the live block at {@code trg:} is no longer a
+     *  container at all (destroyed or replaced since T): big enough to
+     *  cover a double chest's worth of slots so a legitimate record slot
+     *  is never dropped as out-of-range just because the original size is
+     *  unknown. */
+    private static final int MAX_UNKNOWN_SIZE = 54;
+
+    private static final int PLAYER_CONTAINER_ROWS = 6;
+
+    /** Container-family events {@link SnapshotReconstructor} can reason
+     *  about - the deposit/withdraw log, plus its shulker and crafter
+     *  aliases (same event names {@code ContainerTransactionListener} and
+     *  friends emit; see {@code EventCatalog}). */
+    private static final List<String> CONTAINER_EVENTS =
+            List.of("deposit", "withdraw", "shulker-deposit", "shulker-withdraw", "crafter");
+
+    private static final Pattern COORDS =
+            Pattern.compile("^(-?\\d{1,8})\\s*,\\s*(-?\\d{1,8})\\s*,\\s*(-?\\d{1,8})$");
+
+    private final PlayerSnapshotStore playerStore;
+    private final RecordStore recordStore;
+    private final Recorder recorder;
+    private final Duration flushTimeout;
+    private final ServiceSupport support;
+    private final SnapshotSessions sessions;
+    private final SnapshotTakes takes;
+    @Nullable
+    private final SnapshotView view;
+    private final Logger logger;
+
+    public SnapshotService(PlayerSnapshotStore playerStore,
+                           RecordStore recordStore,
+                           Recorder recorder,
+                           SpyglassConfig config,
+                           ServiceSupport support,
+                           SnapshotSessions sessions,
+                           SnapshotTakes takes,
+                           @Nullable SnapshotView view,
+                           Logger logger) {
+        this.playerStore = playerStore;
+        this.recordStore = recordStore;
+        this.recorder = recorder;
+        // Reused rather than adding a dedicated snapshot.* flush-timeout
+        // knob: same "close the read-your-writes gap before a point-in-time
+        // read" need the rollback path already solved (#205).
+        this.flushTimeout = config.limits().rollbackFlushTimeout();
+        this.support = support;
+        this.sessions = sessions;
+        this.takes = takes;
+        this.view = view;
+        this.logger = logger;
+    }
+
+    // ---- /sg snapshot <params> ------------------------------------------
+
+    public void execute(CommandSender sender, String rawParams) {
+        ParsedQuery parsed;
+        try {
+            parsed = parse(rawParams, Instant.now());
+        } catch (ParamParseException ex) {
+            sender.sendMessage(Feedback.error(ex.getMessage()));
+            return;
+        }
+        if (parsed.playerMode()) {
+            executePlayerMode(sender, parsed);
+        } else {
+            executeContainerMode(sender, parsed);
+        }
+    }
+
+    // ---- /sg snapshot take <token> <slot> --------------------------------
+
+    public void take(CommandSender sender, String rawToken, int slot) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Feedback.error("Take items in-game as a player."));
+            return;
+        }
+        UUID token;
+        try {
+            token = UUID.fromString(rawToken.trim());
+        } catch (IllegalArgumentException ex) {
+            player.sendMessage(Feedback.error("That snapshot has expired - re-run /sg snapshot."));
+            return;
+        }
+        Optional<SnapshotSession> session = sessions.resolve(player, token);
+        if (session.isEmpty()) {
+            player.sendMessage(Feedback.error("That snapshot has expired - re-run /sg snapshot."));
+            return;
+        }
+        SnapshotTakes.Result result = takes.take(player, session.get(), slot);
+        player.sendMessage(describeTake(result));
+    }
+
+    private static Component describeTake(SnapshotTakes.Result result) {
+        return switch (result) {
+            case TAKEN -> Feedback.success("Took a copy.");
+            case INVENTORY_FULL -> Feedback.warn("That whole stack won't fit in your inventory - nothing taken.");
+            case NO_PERMISSION -> Feedback.error("You don't have permission to take from snapshots.");
+            case SLOT_EMPTY -> Feedback.error("Nothing to take in that slot.");
+        };
+    }
+
+    // ---- player mode ------------------------------------------------------
+
+    private void executePlayerMode(CommandSender sender, ParsedQuery parsed) {
+        String name = parsed.playerName();
+        UUID viaBukkit = resolveViaBukkit(name);
+        support.onAsyncThread(() -> {
+            try {
+                UUID uuid = viaBukkit != null ? viaBukkit : recordStore.resolvePlayerId(name);
+                if (uuid == null) {
+                    support.onMainThread(() ->
+                            sender.sendMessage(Feedback.error("Unknown player: " + name)));
+                    return;
+                }
+                Optional<PlayerSnapshot> found = playerStore.latestAtOrBefore(uuid, parsed.asOf());
+                support.onMainThread(() -> {
+                    if (found.isEmpty()) {
+                        sender.sendMessage(Feedback.error("No snapshot for " + name + " at or before "
+                                + formatInstant(parsed.asOf()) + "."));
+                        return;
+                    }
+                    PlayerSnapshot snapshot = found.get();
+                    SnapshotSession session = new SnapshotSession(
+                            UUID.randomUUID(), SnapshotSession.Kind.PLAYER, snapshot.playerName(),
+                            parsed.asOf(), snapshot.capturedAt(), snapshot.cause(),
+                            SnapshotSession.Certainty.CERTAIN, List.of(), PLAYER_CONTAINER_ROWS,
+                            snapshot.slots());
+                    sessions.store(sender, session);
+                    openOrList(sender, session);
+                });
+            } catch (RuntimeException ex) {
+                logger.warning("Spyglass snapshot player lookup failed for " + name + ": " + ex.getMessage());
+                support.onMainThread(() ->
+                        sender.sendMessage(Feedback.error("Snapshot lookup failed - see the console.")));
+            }
+        });
+    }
+
+    /**
+     * Bukkit-cache-first resolution, deliberately the same shape as
+     * {@code PlayerParam.resolveViaBukkit}: an online exact match, then the
+     * local offline-player cache. NEVER {@code Bukkit.getOfflinePlayer(String)}
+     * - that overload does a blocking Mojang HTTP round-trip on a cache
+     * miss, and this runs on the command (main) thread.
+     */
+    private static @Nullable UUID resolveViaBukkit(String name) {
+        Player online = Bukkit.getPlayerExact(name);
+        if (online != null) {
+            return online.getUniqueId();
+        }
+        var cached = Bukkit.getOfflinePlayerIfCached(name);
+        return cached == null ? null : cached.getUniqueId();
+    }
+
+    // ---- container mode -----------------------------------------------
+
+    private void executeContainerMode(CommandSender sender, ParsedQuery parsed) {
+        ResolvedContainer target = resolveContainerTarget(sender, parsed);
+        if (target == null) {
+            return; // resolveContainerTarget already sent the error
+        }
+        Instant t = parsed.asOf();
+        support.onAsyncThread(() -> {
+            try {
+                recorder.flush(flushTimeout);
+                recordStore.flushPendingWrites();
+                Reconstruction result = reconstructTarget(target, t);
+                support.onMainThread(() -> {
+                    SnapshotSession session = buildContainerSession(target, t, result);
+                    sessions.store(sender, session);
+                    openOrList(sender, session);
+                });
+            } catch (RuntimeException ex) {
+                logger.warning("Spyglass snapshot container reconstruction failed at "
+                        + target.label() + ": " + ex.getMessage());
+                support.onMainThread(() ->
+                        sender.sendMessage(Feedback.error("Snapshot reconstruction failed - see the console.")));
+            }
+        });
+    }
+
+    /** MAIN THREAD: resolve the target block and clone its live contents. */
+    private @Nullable ResolvedContainer resolveContainerTarget(CommandSender sender, ParsedQuery parsed) {
+        Block block;
+        boolean viaTrg = parsed.hasTrg();
+        if (viaTrg) {
+            World world = resolveTrgWorld(sender, parsed.worldName());
+            if (world == null) {
+                return null; // error already sent
+            }
+            block = world.getBlockAt(parsed.x(), parsed.y(), parsed.z());
+        } else {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(Feedback.error(
+                        "Container snapshot needs a player (to look at a block), or trg:x,y,z."));
+                return null;
+            }
+            Block targeted = player.getTargetBlockExact(LOOK_REACH);
+            if (targeted == null) {
+                player.sendMessage(Feedback.error("No block in reach - look at a container, or use trg:x,y,z."));
+                return null;
+            }
+            block = targeted;
+        }
+        return describeTarget(sender, block, viaTrg);
+    }
+
+    private @Nullable World resolveTrgWorld(CommandSender sender, @Nullable String worldName) {
+        if (worldName != null) {
+            World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                sender.sendMessage(Feedback.error("Unknown world: " + worldName));
+            }
+            return world;
+        }
+        if (sender instanceof Player player) {
+            return player.getWorld();
+        }
+        sender.sendMessage(Feedback.error("trg: needs w: when run from the console."));
+        return null;
+    }
+
+    /** MAIN THREAD: identify what kind of container (if any) stands at
+     *  {@code block} and clone its live contents. {@code allowMissing} is
+     *  true only for the explicit {@code trg:} path, where the operator is
+     *  asserting a container used to be here even if it is gone now. */
+    private @Nullable ResolvedContainer describeTarget(CommandSender sender, Block block, boolean allowMissing) {
+        BlockState state = block.getState();
+        boolean selfMutating = state instanceof Furnace
+                || state instanceof BrewingStand
+                || state instanceof Campfire;
+        String label = block.getWorld().getName() + " " + block.getX() + "," + block.getY() + "," + block.getZ()
+                + " " + state.getType().name();
+
+        if (state instanceof Chest chest) {
+            InventoryHolder topHolder = chest.getInventory().getHolder();
+            if (topHolder instanceof DoubleChest doubleChest
+                    && doubleChest.getLeftSide() instanceof Chest left
+                    && doubleChest.getRightSide() instanceof Chest right) {
+                Half leftHalf = buildHalf(left.getBlock(), left.getBlockInventory(), left.getBlock().getType().name());
+                Half rightHalf = buildHalf(right.getBlock(), right.getBlockInventory(), right.getBlock().getType().name());
+                return new ResolvedContainer(leftHalf, rightHalf, selfMutating, label + " (double)");
+            }
+            return new ResolvedContainer(buildHalf(block, chest.getBlockInventory(), state.getType().name()),
+                    null, selfMutating, label);
+        }
+        if (state instanceof Container container) {
+            return new ResolvedContainer(buildHalf(block, container.getInventory(), state.getType().name()),
+                    null, selfMutating, label);
+        }
+        if (state instanceof Campfire campfire) {
+            int size = campfire.getSize();
+            ItemStack[] contents = new ItemStack[size];
+            for (int i = 0; i < size; i++) {
+                contents[i] = campfire.getItem(i);
+            }
+            Half half = new Half(BlockLocations.fromBlock(block), state.getType().name(),
+                    cloneContents(contents), size, true);
+            return new ResolvedContainer(half, null, true, label);
+        }
+        if (allowMissing) {
+            // trg: named an exact cell but nothing there is currently a
+            // container - it may have been broken or replaced since T.
+            // Reconstruct anyway from whatever the log shows, against an
+            // empty base (#341 point 6): MAX_UNKNOWN_SIZE covers up to a
+            // double chest's worth of slots since the original size is
+            // unknown.
+            Half half = new Half(BlockLocations.fromBlock(block), state.getType().name(),
+                    new ItemStack[MAX_UNKNOWN_SIZE], MAX_UNKNOWN_SIZE, false);
+            return new ResolvedContainer(half, null, false,
+                    block.getWorld().getName() + " " + block.getX() + "," + block.getY() + "," + block.getZ()
+                            + " (container no longer present)");
+        }
+        sender.sendMessage(Feedback.error("Not a container: " + state.getType().name()));
+        return null;
+    }
+
+    private static Half buildHalf(Block block, Inventory inventory, String containerType) {
+        return new Half(BlockLocations.fromBlock(block), containerType,
+                cloneContents(inventory.getContents()), inventory.getSize(), true);
+    }
+
+    private static ItemStack[] cloneContents(ItemStack[] live) {
+        ItemStack[] out = new ItemStack[live.length];
+        for (int i = 0; i < live.length; i++) {
+            out[i] = live[i] == null ? null : live[i].clone();
+        }
+        return out;
+    }
+
+    /** OFF MAIN: query + reconstruct one or both halves. */
+    private Reconstruction reconstructTarget(ResolvedContainer target, Instant t) {
+        Reconstruction primary = reconstructHalf(target.primary(), t, target.selfMutating());
+        if (!target.doubleChest()) {
+            return primary;
+        }
+        Reconstruction secondary = reconstructHalf(target.secondary(), t, target.selfMutating());
+        return mergeHalves(primary, target.primary().size(), secondary);
+    }
+
+    private Reconstruction reconstructHalf(Half half, Instant t, boolean selfMutating) {
+        QueryRequest request = buildRequest(half.location(), t);
+        QueryResult queried = recordStore.query(request);
+        StoredItem[] storedLive = new StoredItem[half.liveContents().length];
+        for (int i = 0; i < storedLive.length; i++) {
+            storedLive[i] = ItemSerialization.storedItem(i, half.liveContents()[i]);
+        }
+        return SnapshotReconstructor.reconstruct(queried.records(), storedLive, half.size(), t,
+                half.containerPresent(), selfMutating);
+    }
+
+    private static QueryRequest buildRequest(BlockLocation location, Instant t) {
+        List<QueryPredicate> predicates = List.of(
+                new QueryPredicate.Eq("location.worldId", location.worldId()),
+                new QueryPredicate.Range("location.x", location.x(), location.x()),
+                new QueryPredicate.Range("location.y", location.y(), location.y()),
+                new QueryPredicate.Range("location.z", location.z(), location.z()),
+                new QueryPredicate.Range("occurred", t, Instant.now()),
+                new QueryPredicate.In("event", CONTAINER_EVENTS));
+        return new QueryRequest(predicates, Sort.NEWEST_FIRST, MAX_CONTAINER_RECORDS,
+                EnumSet.noneOf(Flag.class), false);
+    }
+
+    /**
+     * Merge two half-reconstructions into one view: the second half's
+     * slots (and mismatch indices) are offset by {@code leftSize} - the
+     * same 0-26 / 27-53 re-basing {@code ContainerTransactionListener}'s
+     * {@code resolveSlotTarget} performs in reverse for a double chest's
+     * combined inventory. Certainty is the worst of the two halves; notes
+     * are kept, each prefixed with which half it came from since a bare
+     * "slot 5" in a half's note means a local (pre-offset) slot index.
+     *
+     * <p>Package-private static and pure (no Bukkit types) so it is
+     * directly unit-testable - extracted for exactly that reason.
+     */
+    static Reconstruction mergeHalves(Reconstruction left, int leftSize, Reconstruction right) {
+        List<SnapshotSlot> slots = new ArrayList<>(left.slots().size() + right.slots().size());
+        slots.addAll(left.slots());
+        for (SnapshotSlot slot : right.slots()) {
+            slots.add(new SnapshotSlot(slot.slot() + leftSize, slot.count(), slot.item()));
+        }
+        List<String> notes = new ArrayList<>(left.notes().size() + right.notes().size());
+        for (String note : left.notes()) {
+            notes.add("left half: " + note);
+        }
+        for (String note : right.notes()) {
+            notes.add("right half: " + note);
+        }
+        List<Reconstruction.Mismatch> mismatches =
+                new ArrayList<>(left.mismatches().size() + right.mismatches().size());
+        mismatches.addAll(left.mismatches());
+        for (Reconstruction.Mismatch mismatch : right.mismatches()) {
+            mismatches.add(new Reconstruction.Mismatch(
+                    mismatch.slot() + leftSize, mismatch.kind(), mismatch.expected(), mismatch.actual()));
+        }
+        SnapshotSession.Certainty certainty = (left.certain() && right.certain())
+                ? SnapshotSession.Certainty.CERTAIN
+                : SnapshotSession.Certainty.UNCERTAIN;
+        return new Reconstruction(slots, certainty, notes, mismatches);
+    }
+
+    private static SnapshotSession buildContainerSession(ResolvedContainer target, Instant t, Reconstruction result) {
+        int size = target.doubleChest()
+                ? target.primary().size() + target.secondary().size()
+                : target.primary().size();
+        int rows = Math.max(1, (int) Math.ceil(size / 9.0));
+        return new SnapshotSession(UUID.randomUUID(), SnapshotSession.Kind.CONTAINER, target.label(), t, t,
+                null, result.certainty(), result.notes(), rows, result.slots());
+    }
+
+    private record Half(BlockLocation location, String containerType, ItemStack[] liveContents, int size,
+                        boolean containerPresent) {
+    }
+
+    private record ResolvedContainer(Half primary, @Nullable Half secondary, boolean selfMutating, String label) {
+        boolean doubleChest() {
+            return secondary != null;
+        }
+    }
+
+    // ---- opening the result ---------------------------------------------
+
+    private void openOrList(CommandSender sender, SnapshotSession session) {
+        if (view != null && sender instanceof Player player) {
+            view.open(player, session);
+            return;
+        }
+        renderListing(sender, session);
+    }
+
+    // ---- text listing ----------------------------------------------------
+
+    private void renderListing(CommandSender sender, SnapshotSession session) {
+        sender.sendMessage(header(session));
+        for (String note : session.notes()) {
+            sender.sendMessage(Feedback.bonus("- " + note));
+        }
+        if (session.slots().isEmpty()) {
+            sender.sendMessage(Feedback.bonus("Nothing in it."));
+            return;
+        }
+        boolean canTake = sender.hasPermission(SnapshotTakes.PERMISSION);
+        for (SnapshotSlot slot : session.slots()) {
+            sender.sendMessage(slotLine(session, slot, canTake));
+        }
+    }
+
+    private static Component header(SnapshotSession session) {
+        long elapsedSeconds = Math.max(0L,
+                Instant.now().getEpochSecond() - session.asOf().getEpochSecond());
+        String ago = new Duration(elapsedSeconds).compact();
+        Component line = Feedback.info(session.subjectLabel() + " as of " + ago + " ago");
+        if (session.certainty() == SnapshotSession.Certainty.UNCERTAIN) {
+            line = line.append(Component.text(" (uncertain)", NamedTextColor.YELLOW));
+        }
+        return line;
+    }
+
+    private static Component slotLine(SnapshotSession session, SnapshotSlot slot, boolean canTake) {
+        StoredItem item = slot.item();
+        int count = displayCount(session, slot);
+        var builder = Component.text()
+                .append(Component.text("[" + slot.slot() + "] ", NamedTextColor.GRAY))
+                .append(Component.text(item.material() + " x" + count, NamedTextColor.AQUA));
+        if (item.name() != null && !item.name().isBlank()) {
+            builder.hoverEvent(HoverEvent.showText(Component.text(item.name(), NamedTextColor.GRAY)));
+        }
+        if (canTake) {
+            builder.append(Component.text(" [take]", NamedTextColor.GREEN)
+                    .clickEvent(ClickEvent.runCommand(
+                            "/spyglass snapshot take " + session.token() + " " + slot.slot()))
+                    .hoverEvent(HoverEvent.showText(Component.text("Take a copy", NamedTextColor.GRAY))));
+        }
+        return builder.asComponent();
+    }
+
+    private static int displayCount(SnapshotSession session, SnapshotSlot slot) {
+        if (session.kind() == SnapshotSession.Kind.PLAYER) {
+            return slot.count();
+        }
+        // Container-mode slots leave the real amount inside the blob
+        // (SnapshotReconstructor.COUNT_IN_BLOB) - decode to read it.
+        ItemStack decoded = ItemSerialization.decode(slot.item().data());
+        return decoded == null ? 0 : decoded.getAmount();
+    }
+
+    private static String formatInstant(Instant instant) {
+        return instant.atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    // ---- parsing ----------------------------------------------------------
+
+    /**
+     * The restricted {@code /sg snapshot} key set: {@code t:} (required),
+     * {@code p:}, {@code trg:}, {@code w:}. No default radius or time is
+     * ever injected, and any other key or flag is rejected outright - this
+     * is deliberately NOT {@code QueryStringParser}: that parser injects
+     * search's defaults and accepts the full query language, neither of
+     * which belongs on a point-in-time snapshot.
+     */
+    record ParsedQuery(Instant asOf, @Nullable String playerName, @Nullable Integer x, @Nullable Integer y,
+                       @Nullable Integer z, @Nullable String worldName) {
+        boolean playerMode() {
+            return playerName != null;
+        }
+
+        boolean hasTrg() {
+            return x != null;
+        }
+    }
+
+    static ParsedQuery parse(String raw, Instant now) throws ParamParseException {
+        Duration since = null;
+        String playerName = null;
+        Integer x = null;
+        Integer y = null;
+        Integer z = null;
+        String worldName = null;
+
+        if (raw != null && !raw.isBlank()) {
+            for (String token : raw.trim().split("\\s+")) {
+                if (token.isEmpty()) {
+                    continue;
+                }
+                int colon = token.indexOf(':');
+                if (colon < 0) {
+                    throw new ParamParseException("not a snapshot key: " + token);
+                }
+                String key = token.substring(0, colon).toLowerCase(Locale.ROOT);
+                String value = token.substring(colon + 1);
+                switch (key) {
+                    case "t", "since" -> {
+                        if (since != null) {
+                            throw new ParamParseException("Duplicate parameter: " + key);
+                        }
+                        since = parseDuration(value);
+                    }
+                    case "p", "player" -> {
+                        if (playerName != null) {
+                            throw new ParamParseException("Duplicate parameter: " + key);
+                        }
+                        playerName = parsePlayerName(value);
+                    }
+                    case "trg", "target" -> {
+                        if (x != null) {
+                            throw new ParamParseException("Duplicate parameter: " + key);
+                        }
+                        int[] coords = parseCoords(value);
+                        x = coords[0];
+                        y = coords[1];
+                        z = coords[2];
+                    }
+                    case "w", "world" -> {
+                        if (worldName != null) {
+                            throw new ParamParseException("Duplicate parameter: " + key);
+                        }
+                        if (value.isBlank()) {
+                            throw new ParamParseException("w: requires a world name.");
+                        }
+                        worldName = value;
+                    }
+                    default -> throw new ParamParseException("not a snapshot key: " + key);
+                }
+            }
+        }
+
+        if (since == null) {
+            throw new ParamParseException("t: is required, e.g. t:1h (snapshot as of 1 hour ago).");
+        }
+        if (worldName != null && x == null) {
+            throw new ParamParseException("w: requires trg:x,y,z.");
+        }
+        if (playerName != null && x != null) {
+            throw new ParamParseException(
+                    "p: and trg: cannot be combined - snapshot is either a player or a container.");
+        }
+
+        return new ParsedQuery(since.before(now), playerName, x, y, z, worldName);
+    }
+
+    private static Duration parseDuration(String value) throws ParamParseException {
+        try {
+            return Duration.parse(value);
+        } catch (IllegalArgumentException | ArithmeticException ex) {
+            throw new ParamParseException("Invalid duration: " + value, ex);
+        }
+    }
+
+    /** {@code p:} takes exactly one bare name - no {@code PlayerParam}
+     *  comma lists and no {@code !} excludes; a snapshot has exactly one
+     *  subject. */
+    private static String parsePlayerName(String value) throws ParamParseException {
+        if (value == null || value.isBlank()) {
+            throw new ParamParseException("p: requires a player name.");
+        }
+        if (value.indexOf(',') >= 0 || value.indexOf('!') >= 0) {
+            throw new ParamParseException("p: takes exactly one player name - no commas or !.");
+        }
+        return value.trim();
+    }
+
+    private static int[] parseCoords(String value) throws ParamParseException {
+        if (value == null || value.isBlank()) {
+            throw new ParamParseException("trg: requires x,y,z coordinates, e.g. trg:100,64,200.");
+        }
+        Matcher matcher = COORDS.matcher(value.trim());
+        if (!matcher.matches()) {
+            throw new ParamParseException("trg: requires x,y,z coordinates, e.g. trg:100,64,200.");
+        }
+        return new int[] {
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3))
+        };
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/config/SpyglassConfig.java
@@ -24,7 +24,8 @@ public record SpyglassConfig(
         Metrics metrics,
         Analytics analytics,
         Commands commands,
-        WorldEdit worldedit) {
+        WorldEdit worldedit,
+        Snapshot snapshot) {
 
     /**
      * Default heads for {@code events.command.redact} (#47): the common
@@ -242,7 +243,8 @@ public record SpyglassConfig(
                 // native speed. NOT the same as events.place/break, which
                 // only gate hand place/break - flipping those does nothing
                 // to a WorldEdit op.
-                new WorldEdit(root.node("worldedit", "enabled").getBoolean(true)));
+                new WorldEdit(root.node("worldedit", "enabled").getBoolean(true)),
+                parseSnapshot(root));
     }
 
     /**
@@ -295,6 +297,38 @@ public record SpyglassConfig(
             interval = Duration.parse("5s");
         }
         return new Analytics(enabled, interval);
+    }
+
+    /**
+     * Player-inventory snapshot capture (#341): periodic + event-driven
+     * snapshots of what a player is carrying, independent of the event log -
+     * crafting, consuming, trades, and plugin-given items leave no event
+     * trail a rollback could replay from, so this is the only honest source
+     * for "what was this player carrying at time T". Purely additive; no
+     * {@link #CONFIG_VERSION} bump.
+     *
+     * <p>{@code enabled} defaults to {@code true} - an absent key on an
+     * upgraded install starts capturing rather than silently doing nothing,
+     * matching the {@code worldedit.enabled} precedent. {@code interval} is
+     * the periodic sweep period (default {@code 5m}), parsed like any other
+     * plain duration (e.g. {@code tool.lookback}) - a malformed value hard-
+     * fails config load. {@code retention} is independent of {@code
+     * storage.retention} (default {@code 30d}) and is parsed with {@link
+     * #parseGlobalRetention} so it accepts the same keep-forever tokens
+     * ({@code "0"}/{@code "never"}/{@code "forever"}/{@code "off"}); a
+     * malformed value hard-fails the same way {@code storage.retention} does
+     * - deliberate, since retention drives deletion and guessing a default
+     * risks purging history the operator meant to keep (mirrors {@link
+     * #parseGlobalRetention}'s own javadoc). Static + package-visible so it's
+     * unit-testable headless, like {@link #parseAnalytics}.
+     */
+    static Snapshot parseSnapshot(ConfigurationNode root) {
+        boolean enabled = root.node("snapshot", "players", "enabled").getBoolean(true);
+        Duration interval = Duration.parse(
+                root.node("snapshot", "players", "interval").getString("5m"));
+        Duration retention = parseGlobalRetention(
+                root.node("snapshot", "players", "retention").getString("30d"));
+        return new Snapshot(new SnapshotPlayers(enabled, interval, retention));
     }
 
     public boolean enabled(String eventName) {
@@ -598,6 +632,26 @@ public record SpyglassConfig(
      * answers {@code /spyglass stats}.
      */
     public record Analytics(boolean enabled, Duration interval) {
+    }
+
+    /**
+     * Player-inventory snapshot capture (#341). See {@link #parseSnapshot}.
+     * A top-level wrapper (rather than folding {@code players} straight into
+     * {@link SpyglassConfig}) so a future non-player snapshot knob has
+     * somewhere to live without another top-level config key.
+     */
+    public record Snapshot(SnapshotPlayers players) {
+    }
+
+    /**
+     * @param enabled   capture join/quit/death/world-change/periodic-sweep
+     *                  snapshots of player inventories. Defaults to {@code true}.
+     * @param interval  periodic sweep period (default {@code 5m}).
+     * @param retention how long snapshot rows are kept, independent of {@code
+     *                  storage.retention} (default {@code 30d}); accepts the
+     *                  same keep-forever tokens as {@code storage.retention}.
+     */
+    public record SnapshotPlayers(boolean enabled, Duration interval, Duration retention) {
     }
 
     private static ConfigurationNode loadBundledDefaults(JavaPlugin plugin) throws IOException {

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/ClickHousePlayerSnapshotStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/ClickHousePlayerSnapshotStore.java
@@ -1,0 +1,263 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.command.CommandResponse;
+import com.clickhouse.client.api.query.GenericRecord;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * ClickHouse-backed {@link PlayerSnapshotStore}. Two ReplacingMergeTree tables
+ * created by {@code ClickHouseSchema.ensure} (not here): {@code player_snapshots}
+ * holds one keyframe row per capture with the slots as parallel arrays of
+ * {@code snapshot_items} hash refs, and {@code snapshot_items} interns the item
+ * payloads content-addressed by the 16-byte SHA-256/16 of their raw bytes.
+ * Modeled on {@code ClickHouseSalvageStore}; shares the record store's
+ * {@link Client}.
+ *
+ * <p>Writes go through {@code client.execute} INSERT statements, which are
+ * synchronous and do not enable {@code async_insert}: snapshot volume is tiny,
+ * and the interface requires {@link #latestAtOrBefore} right after {@link #save}
+ * to see the row, so the row must be queryable the instant the INSERT acks.
+ * Hashes cross the SQL boundary as uppercase hex through {@code hex}/{@code unhex}
+ * so no binary ever sits inside a statement literal.
+ */
+@ApiStatus.Internal
+public final class ClickHousePlayerSnapshotStore implements PlayerSnapshotStore {
+
+    private static final DateTimeFormatter CH_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final HexFormat HEX = HexFormat.of().withUpperCase();
+
+    private final Client client;
+    private final String snapshotsTable;
+    private final String itemsTable;
+
+    public ClickHousePlayerSnapshotStore(Client client, String database) {
+        this.client = client;
+        this.snapshotsTable = "`" + database + "`.`player_snapshots`";
+        this.itemsTable = "`" + database + "`.`snapshot_items`";
+    }
+
+    @Override
+    public void save(PlayerSnapshot snapshot) {
+        List<String> slotSlots = new ArrayList<>();
+        List<String> slotHashes = new ArrayList<>();
+        List<String> slotCounts = new ArrayList<>();
+        // Intern once per distinct payload in this capture: a snapshot that
+        // stacks the same item across slots would otherwise re-INSERT the
+        // identical intern row several times (harmless under the merge, but
+        // wasteful to send).
+        Set<String> internedThisSave = new HashSet<>();
+        for (SnapshotSlot slot : snapshot.slots()) {
+            StoredItem item = slot.item();
+            if (item == null || item.data() == null) {
+                continue;
+            }
+            String hex = hashHex(item.data());
+            if (internedThisSave.add(hex)) {
+                execute("INSERT INTO " + itemsTable + " (hash, material, data) VALUES ("
+                        + fixedHash(hex) + ", " + escape(item.material()) + ", "
+                        + escape(item.data()) + ")");
+            }
+            slotSlots.add(Integer.toString(slot.slot()));
+            slotHashes.add(fixedHash(hex));
+            slotCounts.add(Integer.toString(slot.count()));
+        }
+        execute("INSERT INTO " + snapshotsTable + " (id, player_uuid, player_name, occurred, "
+                + "cause, kind, content_hash, slots_slot, slots_hash, slots_count) VALUES ("
+                + Long.toUnsignedString(EventIds.sequenceOf(snapshot.id())) + ", "
+                + "toUUID('" + snapshot.player() + "'), "
+                + escape(snapshot.playerName()) + ", "
+                + chTimestamp(snapshot.capturedAt()) + ", "
+                + escape(snapshot.cause()) + ", 0, "
+                + snapshot.contentHash() + ", "
+                + "[" + String.join(", ", slotSlots) + "], "
+                + "[" + String.join(", ", slotHashes) + "], "
+                + "[" + String.join(", ", slotCounts) + "])");
+    }
+
+    @Override
+    public Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant) {
+        // FINAL collapses any not-yet-merged duplicate of the same capture
+        // id; the ORDER BY + LIMIT 1 then picks the newest row at or before T.
+        // The slot/count arrays come back cast to Array(Int32) so the driver
+        // yields plain Integers regardless of how it maps UInt8/UInt16; the
+        // hash array crosses as uppercase hex strings (hex() of each element).
+        List<GenericRecord> rows = client.queryAll(
+                "SELECT id, player_name, occurred, cause, content_hash, "
+                        + "CAST(slots_slot AS Array(Int32)) AS slots_slot, "
+                        + "CAST(slots_count AS Array(Int32)) AS slots_count, "
+                        + "arrayMap(x -> hex(x), slots_hash) AS slots_hash_hex "
+                        + "FROM " + snapshotsTable + " FINAL "
+                        + "WHERE player_uuid = toUUID('" + player + "') "
+                        + "AND occurred <= " + chTimestamp(instant) + " "
+                        + "ORDER BY occurred DESC, id DESC LIMIT 1");
+        if (rows.isEmpty()) {
+            return Optional.empty();
+        }
+        GenericRecord row = rows.get(0);
+        List<Integer> slotIndexes = intList(row.getList("slots_slot"));
+        List<Integer> slotCounts = intList(row.getList("slots_count"));
+        List<String> slotHashes = stringList(row.getList("slots_hash_hex"));
+        Map<String, GenericRecord> blobs = fetchBlobs(new LinkedHashSet<>(slotHashes));
+
+        List<SnapshotSlot> slots = new ArrayList<>(slotIndexes.size());
+        for (int i = 0; i < slotIndexes.size(); i++) {
+            String hex = slotHashes.get(i);
+            GenericRecord blob = blobs.get(hex);
+            if (blob == null) {
+                // The referenced payload is gone (should not happen: prune
+                // leaves snapshot_items orphans, never live refs). Skip the
+                // slot rather than emit a StoredItem with no data.
+                continue;
+            }
+            StoredItem item = new StoredItem(
+                    slotIndexes.get(i), blob.getString("material"),
+                    blob.getString("data"), null, null, null, null);
+            slots.add(new SnapshotSlot(slotIndexes.get(i), slotCounts.get(i), item));
+        }
+        return Optional.of(new PlayerSnapshot(
+                EventIds.uuidOf(row.getLong("id")),
+                player,
+                row.getString("player_name"),
+                row.getInstant("occurred"),
+                row.getString("cause"),
+                row.getLong("content_hash"),
+                slots));
+    }
+
+    @Override
+    public OptionalLong lastContentHash(UUID player) {
+        List<GenericRecord> rows = client.queryAll(
+                "SELECT content_hash FROM " + snapshotsTable + " FINAL "
+                        + "WHERE player_uuid = toUUID('" + player + "') "
+                        + "ORDER BY occurred DESC, id DESC LIMIT 1");
+        if (rows.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(rows.get(0).getLong("content_hash"));
+    }
+
+    @Override
+    public int prune(Instant cutoff) {
+        String bound = chTimestamp(cutoff);
+        List<GenericRecord> counted = client.queryAll(
+                "SELECT count() AS c FROM " + snapshotsTable + " FINAL WHERE occurred < " + bound);
+        int removed = counted.isEmpty() ? 0 : (int) counted.get(0).getLong("c");
+        execute("DELETE FROM " + snapshotsTable + " WHERE occurred < " + bound);
+        // Orphaned snapshot_items rows are deliberately left behind: they are
+        // ZSTD'd, content-addressed crumbs that cost almost nothing to keep,
+        // and a later re-capture of the same item reuses the interned row
+        // instead of rewriting it. Sweeping them would mean a full anti-join
+        // over the intern table on every prune for no measurable disk win.
+        return removed;
+    }
+
+    private Map<String, GenericRecord> fetchBlobs(Set<String> hexHashes) {
+        if (hexHashes.isEmpty()) {
+            return Map.of();
+        }
+        StringBuilder in = new StringBuilder();
+        for (String hex : hexHashes) {
+            if (in.length() > 0) {
+                in.append(", ");
+            }
+            in.append('\'').append(hex).append('\'');
+        }
+        Map<String, GenericRecord> blobs = new HashMap<>();
+        for (GenericRecord row : client.queryAll(
+                "SELECT hex(hash) AS h, material, data FROM " + itemsTable + " FINAL "
+                        + "WHERE hex(hash) IN (" + in + ")")) {
+            blobs.put(row.getString("h"), row);
+        }
+        return blobs;
+    }
+
+    private void execute(String sql) {
+        try (CommandResponse ignored = client.execute(sql).get(30, TimeUnit.SECONDS)) {
+            // ack received
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Snapshot command interrupted", ie);
+        } catch (Exception ex) {
+            throw new RuntimeException("Snapshot command failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /** Uppercase hex SHA-256/16 of the raw (base64-decoded) item payload. */
+    private static String hashHex(String base64Payload) {
+        byte[] raw = Base64.getDecoder().decode(base64Payload);
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(raw);
+            return HEX.formatHex(Arrays.copyOf(digest, 16));
+        } catch (NoSuchAlgorithmException ex) {
+            // SHA-256 is a required JCA algorithm on every JVM.
+            throw new IllegalStateException("SHA-256 unavailable", ex);
+        }
+    }
+
+    // Hash refs travel as uppercase hex and become a FixedString(16) via
+    // unhex(); toFixedString pins the width so the array literal types as
+    // Array(FixedString(16)) rather than Array(String).
+    private static String fixedHash(String hex) {
+        return "toFixedString(unhex('" + hex + "'),16)";
+    }
+
+    private static List<Integer> intList(List<?> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> out = new ArrayList<>(raw.size());
+        for (Object element : raw) {
+            if (element instanceof Number number) {
+                out.add(number.intValue());
+            } else if (element != null) {
+                out.add(Integer.parseInt(element.toString()));
+            }
+        }
+        return out;
+    }
+
+    private static List<String> stringList(List<?> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>(raw.size());
+        for (Object element : raw) {
+            out.add(element == null ? "" : element.toString());
+        }
+        return out;
+    }
+
+    private static String chTimestamp(Instant instant) {
+        return "'" + CH_TIMESTAMP.format(instant.atOffset(ZoneOffset.UTC)) + "'";
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "''";
+        }
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/InvUiSnapshotView.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/InvUiSnapshotView.java
@@ -78,8 +78,16 @@ final class InvUiSnapshotView implements SnapshotView {
         this.takes = takes;
         this.logger = logger;
         // InvUI resolves its scheduler/listeners from the owning plugin; must be
-        // set before any Window is built.
-        InvUI.getInstance().setPlugin(plugin);
+        // set before any Window is built. The singleton accepts exactly one
+        // setPlugin for the plugin's lifetime, and InvUiSalvageView (constructed
+        // earlier in onEnable) has usually claimed it already with the same
+        // plugin - that state is expected, not an error (caught live on the
+        // first #341 boot; unit tests cannot reach the relocated singleton).
+        try {
+            InvUI.getInstance().setPlugin(plugin);
+        } catch (IllegalStateException alreadySet) {
+            // Same plugin either way; nothing to do.
+        }
     }
 
     @Override

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/InvUiSnapshotView.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/InvUiSnapshotView.java
@@ -1,0 +1,395 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper;
+import xyz.xenondevs.invui.InvUI;
+import xyz.xenondevs.invui.gui.Gui;
+import xyz.xenondevs.invui.item.Item;
+import xyz.xenondevs.invui.item.ItemProvider;
+import xyz.xenondevs.invui.item.ItemWrapper;
+import xyz.xenondevs.invui.item.impl.AbstractItem;
+import xyz.xenondevs.invui.item.impl.SimpleItem;
+import xyz.xenondevs.invui.window.Window;
+
+/**
+ * InvUI-backed {@code /sg snapshot} viewer for the Minecraft versions InvUI
+ * 1.49 supports (1.x). A single non-paged {@link Gui} lays out either a
+ * captured container (its content rows, 1:1 by slot index) or a captured
+ * player inventory (armor/offhand/main/hotbar, mirroring how a player reads
+ * their own inventory), plus an info cell describing the capture. On versions
+ * InvUI does not support (26.x) there is no GUI at all (see
+ * {@link SnapshotViews}), matching the salvage split exactly.
+ *
+ * <p>Unlike {@code InvUiSalvageView}, the {@link SnapshotSession} handed to
+ * {@link #open} is already fully resolved (the reconstructor or the player
+ * snapshot store already ran, off-thread, before this was called) - there is
+ * no further store read here, so the window is built and opened synchronously
+ * on the calling (main) thread, exactly as {@link SnapshotView#open} requires.
+ *
+ * <p>Every occupied slot is a click item: a click takes a <b>copy</b> into the
+ * viewer's inventory (never depletes the session, since the session is a
+ * read of the past, not a live container). The take itself - the permission
+ * re-check, the whole-stack-or-refuse fit rule, and the audit record - is
+ * {@link SnapshotTakes#take}, the exact engine the text-fallback
+ * {@code /sg snapshot take <token> <slot>} command calls, so the two surfaces
+ * cannot drift apart (the {@code SalvageWithdrawals} precedent). InvUI content
+ * slots are click-cancelled by default (see {@code InvUiSalvageView}'s
+ * javadoc), so the GUI is inherently extract-only.
+ *
+ * <p>This class is only instantiated on supported versions (see
+ * {@link SnapshotViews}), so a 26.x server never loads any InvUI class.
+ */
+final class InvUiSnapshotView implements SnapshotView {
+
+    private static final int WIDTH = 9;
+
+    private static final DateTimeFormatter TIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
+
+    // 36-39: boots, leggings, chestplate, helmet (CraftBukkit's armor-array
+    // order), matching how PlayerInventory#getContents() lays them out and
+    // therefore how PlayerSnapshotService captured them.
+    private static final String[] ARMOR_LABELS = {"Boots", "Leggings", "Chestplate", "Helmet"};
+
+    private final SnapshotTakes takes;
+    private final Logger logger;
+
+    InvUiSnapshotView(Plugin plugin, SnapshotTakes takes, Logger logger) {
+        this.takes = takes;
+        this.logger = logger;
+        // InvUI resolves its scheduler/listeners from the owning plugin; must be
+        // set before any Window is built.
+        InvUI.getInstance().setPlugin(plugin);
+    }
+
+    @Override
+    public void open(Player viewer, SnapshotSession session) {
+        if (session.kind() == SnapshotSession.Kind.PLAYER) {
+            openPlayer(viewer, session);
+        } else {
+            openContainer(viewer, session);
+        }
+    }
+
+    // ---- window builders -------------------------------------------------
+
+    private void openContainer(Player viewer, SnapshotSession session) {
+        int rows = Math.max(1, session.containerRows());
+        int height = rows + 1;
+        Gui gui = Gui.empty(WIDTH, height);
+        fillAll(gui, height);
+
+        Map<Integer, SnapshotSlot> bySlot = indexBySlot(session);
+        int contentCells = rows * WIDTH;
+        for (int slot = 0; slot < contentCells; slot++) {
+            SnapshotSlot snapshotSlot = bySlot.get(slot);
+            if (snapshotSlot != null) {
+                gui.setItem(slot, contentItem(viewer, session, snapshotSlot));
+            }
+        }
+        // Bottom row, centered: filler already covers it, overlay the info cell.
+        gui.setItem(contentCells + 4, infoItem(session));
+
+        openWindow(viewer, gui, session);
+    }
+
+    private void openPlayer(Player viewer, SnapshotSession session) {
+        int height = 6;
+        Gui gui = Gui.empty(WIDTH, height);
+        fillAll(gui, height);
+
+        Map<Integer, SnapshotSlot> bySlot = indexBySlot(session);
+        Item info = infoItem(session);
+
+        // Row 0: armor (cols 0-3, slots 36-39), offhand (col 5, slot 40), info (col 8).
+        for (int col = 0; col < ARMOR_LABELS.length; col++) {
+            int invSlot = 36 + col;
+            gui.setItem(col, armorOrOffhandItem(viewer, session, bySlot.get(invSlot), ARMOR_LABELS[col]));
+        }
+        gui.setItem(5, armorOrOffhandItem(viewer, session, bySlot.get(40), "Off Hand"));
+        gui.setItem(8, info);
+
+        // Rows 1-3: main inventory, slots 9-35 (27 slots), 1:1 in reading order.
+        for (int i = 0; i < 27; i++) {
+            int invSlot = 9 + i;
+            SnapshotSlot snapshotSlot = bySlot.get(invSlot);
+            if (snapshotSlot != null) {
+                gui.setItem(WIDTH + i, contentItem(viewer, session, snapshotSlot));
+            }
+        }
+
+        // Row 4: hotbar, slots 0-8.
+        for (int col = 0; col < WIDTH; col++) {
+            SnapshotSlot snapshotSlot = bySlot.get(col);
+            if (snapshotSlot != null) {
+                gui.setItem(4 * WIDTH + col, contentItem(viewer, session, snapshotSlot));
+            }
+        }
+
+        // Row 5: filler, plus a second info cell in the same column as row 0's
+        // (the nav-row convention every other InvUI view in this codebase uses).
+        gui.setItem(5 * WIDTH + 8, info);
+
+        openWindow(viewer, gui, session);
+    }
+
+    private void openWindow(Player viewer, Gui gui, SnapshotSession session) {
+        Window.single()
+                .setViewer(viewer)
+                .setTitle(new AdventureComponentWrapper(
+                        Component.text(session.subjectLabel(), NamedTextColor.GOLD)))
+                .setGui(gui)
+                .build()
+                .open();
+    }
+
+    private static void fillAll(Gui gui, int rows) {
+        Item filler = new SimpleItem(new ItemWrapper(fillerIcon()));
+        int cells = rows * WIDTH;
+        for (int i = 0; i < cells; i++) {
+            gui.setItem(i, filler);
+        }
+    }
+
+    private static Map<Integer, SnapshotSlot> indexBySlot(SnapshotSession session) {
+        Map<Integer, SnapshotSlot> bySlot = new HashMap<>();
+        for (SnapshotSlot slot : session.slots()) {
+            bySlot.put(slot.slot(), slot);
+        }
+        return bySlot;
+    }
+
+    // ---- content rendering -------------------------------------------------
+
+    /** A plain content cell (container slot, or player main/hotbar slot). */
+    private Item contentItem(Player viewer, SnapshotSession session, SnapshotSlot slot) {
+        ItemStack display = decodeDisplay(session, slot);
+        if (display == null) {
+            return new SimpleItem(new ItemWrapper(barrierIcon(slot)));
+        }
+        return new SlotItem(viewer, session, slot, display);
+    }
+
+    /**
+     * An armor or offhand cell. Occupied slots render the real item with an
+     * extra lore line naming the slot (so the layout reads even out of
+     * position); the label is display-only and is never part of what a take
+     * actually gives the player. Empty slots render a labeled placeholder so
+     * the layout still reads as an inventory.
+     */
+    private Item armorOrOffhandItem(Player viewer, SnapshotSession session, SnapshotSlot slot, String label) {
+        if (slot == null) {
+            return new SimpleItem(new ItemWrapper(labeledPlaceholder(label)));
+        }
+        ItemStack pristine = decodeDisplay(session, slot);
+        if (pristine == null) {
+            ItemStack icon = barrierIcon(slot);
+            appendLore(icon, label);
+            return new SimpleItem(new ItemWrapper(icon));
+        }
+        ItemStack labeledDisplay = pristine.clone();
+        appendLore(labeledDisplay, label);
+        return new SlotItem(viewer, session, slot, labeledDisplay);
+    }
+
+    /**
+     * Decode a slot's stored blob into the exact stack a take would give.
+     * Player-mode blobs are interned at amount 1 ({@link SnapshotSlot}
+     * javadoc), so the real amount is restored from {@code slot.count()};
+     * container-mode blobs already carry their true amount
+     * ({@link SnapshotReconstructor#COUNT_IN_BLOB}), so {@code count} must
+     * <b>not</b> be applied there. Returns {@code null} on a missing or
+     * corrupt blob - the caller renders a barrier fallback instead of
+     * crashing the GUI open.
+     */
+    private ItemStack decodeDisplay(SnapshotSession session, SnapshotSlot slot) {
+        StoredItem item = slot.item();
+        if (item == null || item.data() == null) {
+            return null;
+        }
+        ItemStack decoded;
+        try {
+            decoded = ItemSerialization.decode(item.data());
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass snapshot view: could not decode slot " + slot.slot()
+                    + " (" + item.material() + "): " + ex.getMessage());
+            return null;
+        }
+        if (decoded == null || decoded.getType() == Material.AIR) {
+            return null;
+        }
+        if (session.kind() == SnapshotSession.Kind.PLAYER) {
+            decoded.setAmount(Math.max(1, slot.count()));
+        }
+        return decoded;
+    }
+
+    /**
+     * Delegate a click to the shared take engine and translate the result
+     * into feedback. Slots stay populated after a take (this reads a past
+     * instant, not a live container) - the session never depletes and needs
+     * no in-flight tracker, unlike the salvage withdraw path. Wording matches
+     * the text-fallback path in {@code SnapshotService}.
+     */
+    private void takeCopy(Player viewer, SnapshotSession session, SnapshotSlot slot) {
+        SnapshotTakes.Result result = takes.take(viewer, session, slot.slot());
+        switch (result) {
+            case TAKEN -> {
+                // The audit record is the receipt; no chat spam per click.
+            }
+            case INVENTORY_FULL -> viewer.sendMessage(Component.text(
+                    "That whole stack won't fit in your inventory - nothing taken.", NamedTextColor.YELLOW));
+            case NO_PERMISSION -> viewer.sendMessage(Component.text(
+                    "You don't have permission to take from snapshots.", NamedTextColor.RED));
+            case SLOT_EMPTY -> viewer.sendMessage(Component.text(
+                    "Nothing to take in that slot.", NamedTextColor.RED));
+        }
+    }
+
+    // ---- icons ---------------------------------------------------------
+
+    private Item infoItem(SnapshotSession session) {
+        return new SimpleItem(new ItemWrapper(infoIcon(session)));
+    }
+
+    private static ItemStack infoIcon(SnapshotSession session) {
+        ItemStack icon = new ItemStack(Material.BOOK);
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.displayName(name(session.subjectLabel(), NamedTextColor.GOLD));
+            List<Component> lore = new ArrayList<>();
+            long agoSeconds = Math.max(0L,
+                    Instant.now().getEpochSecond() - session.asOf().getEpochSecond());
+            lore.add(line("as of " + new Duration(agoSeconds).compact() + " ago", NamedTextColor.GRAY));
+            if (session.kind() == SnapshotSession.Kind.PLAYER) {
+                lore.add(line("Captured " + TIME.format(session.capturedAt()), NamedTextColor.DARK_GRAY));
+                String cause = session.cause();
+                if (cause != null && !cause.isBlank()) {
+                    lore.add(line("Cause: " + humanize(cause), NamedTextColor.DARK_GRAY));
+                }
+            } else {
+                boolean certain = session.certainty() == SnapshotSession.Certainty.CERTAIN;
+                lore.add(line(certain ? "CERTAIN" : "UNCERTAIN",
+                        certain ? NamedTextColor.GREEN : NamedTextColor.GOLD));
+                for (String note : session.notes()) {
+                    lore.add(line(note, NamedTextColor.DARK_GRAY));
+                }
+            }
+            meta.lore(lore);
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private static ItemStack barrierIcon(SnapshotSlot slot) {
+        ItemStack icon = new ItemStack(Material.BARRIER);
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.displayName(name("Could not decode", NamedTextColor.RED));
+            StoredItem item = slot.item();
+            String material = item != null && item.material() != null ? item.material() : "unknown";
+            meta.lore(List.of(
+                    line("Material: " + material, NamedTextColor.GRAY),
+                    line("The stored data for this slot is corrupt.", NamedTextColor.DARK_GRAY)));
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private static ItemStack fillerIcon() {
+        ItemStack icon = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.displayName(name(" ", NamedTextColor.GRAY));
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private static ItemStack labeledPlaceholder(String label) {
+        ItemStack icon = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.displayName(name(label, NamedTextColor.DARK_GRAY));
+            meta.lore(List.of(line("(empty)", NamedTextColor.DARK_GRAY)));
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private static void appendLore(ItemStack stack, String label) {
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        List<Component> lore = meta.hasLore() && meta.lore() != null
+                ? new ArrayList<>(meta.lore())
+                : new ArrayList<>();
+        lore.add(line(label, NamedTextColor.DARK_GRAY));
+        meta.lore(lore);
+        stack.setItemMeta(meta);
+    }
+
+    private static String humanize(String cause) {
+        String spaced = cause.replace('-', ' ').replace('_', ' ');
+        if (spaced.isEmpty()) {
+            return spaced;
+        }
+        return Character.toUpperCase(spaced.charAt(0)) + spaced.substring(1);
+    }
+
+    private static Component name(String text, NamedTextColor color) {
+        return Component.text(text, color).decoration(TextDecoration.ITALIC, false);
+    }
+
+    private static Component line(String text, NamedTextColor color) {
+        return Component.text(text, color);
+    }
+
+    // ---- items ---------------------------------------------------------
+
+    /** One occupied content slot: click takes a copy (see {@link #takeCopy}). */
+    private final class SlotItem extends AbstractItem {
+        private final Player viewer;
+        private final SnapshotSession session;
+        private final SnapshotSlot slot;
+        private final ItemStack display;
+
+        SlotItem(Player viewer, SnapshotSession session, SnapshotSlot slot, ItemStack display) {
+            this.viewer = viewer;
+            this.session = session;
+            this.slot = slot;
+            this.display = display;
+        }
+
+        @Override
+        public ItemProvider getItemProvider() {
+            return new ItemWrapper(display.clone());
+        }
+
+        @Override
+        public void handleClick(ClickType clickType, Player who, InventoryClickEvent event) {
+            takeCopy(viewer, session, slot);
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/MariaDbPlayerSnapshotStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/MariaDbPlayerSnapshotStore.java
@@ -1,0 +1,306 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * MariaDB / MySQL-backed {@link PlayerSnapshotStore}. Three InnoDB tables in
+ * the shared Spyglass database, self-created in the constructor:
+ * {@code snapshot_items} interns each distinct item payload once
+ * (content-addressed by the SHA-256/16 of its raw {@code serializeAsBytes}
+ * bytes), {@code player_snapshots} holds one row per capture, and
+ * {@code player_snapshot_slots} maps a capture's occupied slots onto interned
+ * payloads. Interning is what keeps a week of "same kit every sweep" down to
+ * one payload set rather than one per snapshot. Models
+ * {@code SqlitePlayerSnapshotStore}.
+ *
+ * <p>Shares the record store's single write connection and read pool via
+ * {@code withWriteConnection} / {@code withReadConnection}. The intern insert
+ * MUST be an idempotent upsert - {@code INSERT ... ON DUPLICATE KEY UPDATE
+ * hash = hash} - because the recorder-retry path re-interns already-committed
+ * payloads; a plain {@code INSERT} throws Duplicate entry on that retry (a bug
+ * that only ever showed up live). The snapshot row uses {@code REPLACE INTO}
+ * for the same reason.
+ */
+@ApiStatus.Internal
+public final class MariaDbPlayerSnapshotStore implements PlayerSnapshotStore {
+
+    private static final Logger LOGGER = Logger.getLogger(MariaDbPlayerSnapshotStore.class.getName());
+
+    private final MariaDbRecordStore store;
+
+    public MariaDbPlayerSnapshotStore(MariaDbRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS snapshot_items ("
+                        + "hash BINARY(16) NOT NULL PRIMARY KEY, "
+                        + "material VARCHAR(255), "
+                        + "data MEDIUMBLOB) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+                st.execute("CREATE TABLE IF NOT EXISTS player_snapshots ("
+                        + "id BINARY(16) NOT NULL PRIMARY KEY, "
+                        + "player_uuid BINARY(16) NOT NULL, "
+                        + "player_name VARCHAR(255), "
+                        + "occurred BIGINT NOT NULL, "
+                        + "cause VARCHAR(64), "
+                        + "kind TINYINT NOT NULL DEFAULT 0, "
+                        + "content_hash BIGINT NOT NULL, "
+                        + "KEY idx_player_snapshots_player (player_uuid, occurred)) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+                st.execute("CREATE TABLE IF NOT EXISTS player_snapshot_slots ("
+                        + "snapshot_id BINARY(16) NOT NULL, "
+                        + "slot SMALLINT NOT NULL, "
+                        + "item_hash BINARY(16) NOT NULL, "
+                        + "count SMALLINT NOT NULL, "
+                        + "PRIMARY KEY (snapshot_id, slot)) "
+                        + "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void save(PlayerSnapshot snapshot) {
+        List<InternedSlot> prepared = prepare(snapshot);
+        byte[] id = uuidToBytes(snapshot.id());
+        store.withWriteConnection(conn -> {
+            boolean priorAutoCommit = conn.getAutoCommit();
+            try {
+                conn.setAutoCommit(false);
+                try (PreparedStatement intern = conn.prepareStatement(
+                        "INSERT INTO snapshot_items(hash, material, data) VALUES (?, ?, ?) "
+                                + "ON DUPLICATE KEY UPDATE hash = hash")) {
+                    for (InternedSlot s : prepared) {
+                        intern.setBytes(1, s.hash());
+                        intern.setString(2, s.material());
+                        intern.setBytes(3, s.data());
+                        intern.addBatch();
+                    }
+                    intern.executeBatch();
+                }
+                try (PreparedStatement snap = conn.prepareStatement(
+                        "REPLACE INTO player_snapshots"
+                                + "(id, player_uuid, player_name, occurred, cause, kind, content_hash) "
+                                + "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    snap.setBytes(1, id);
+                    snap.setBytes(2, uuidToBytes(snapshot.player()));
+                    snap.setString(3, snapshot.playerName());
+                    snap.setLong(4, snapshot.capturedAt().toEpochMilli());
+                    snap.setString(5, snapshot.cause());
+                    snap.setInt(6, 0); // kind: 0 = keyframe (delta rows reserved)
+                    snap.setLong(7, snapshot.contentHash());
+                    snap.executeUpdate();
+                }
+                // Re-derive the slot set from scratch so a re-save of the same id
+                // never leaves a stale slot row behind.
+                try (PreparedStatement del = conn.prepareStatement(
+                        "DELETE FROM player_snapshot_slots WHERE snapshot_id = ?")) {
+                    del.setBytes(1, id);
+                    del.executeUpdate();
+                }
+                try (PreparedStatement slot = conn.prepareStatement(
+                        "INSERT INTO player_snapshot_slots(snapshot_id, slot, item_hash, count) "
+                                + "VALUES (?, ?, ?, ?)")) {
+                    for (InternedSlot s : prepared) {
+                        slot.setBytes(1, id);
+                        slot.setInt(2, s.slot());
+                        slot.setBytes(3, s.hash());
+                        slot.setInt(4, s.count());
+                        slot.addBatch();
+                    }
+                    slot.executeBatch();
+                }
+                conn.commit();
+            } catch (SQLException ex) {
+                rollbackQuietly(conn);
+                throw ex;
+            } finally {
+                restoreAutoCommit(conn, priorAutoCommit);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant) {
+        Optional<PlayerSnapshot> result = store.withReadConnection(conn -> {
+            Header header;
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT id, player_name, occurred, cause, content_hash "
+                            + "FROM player_snapshots WHERE player_uuid = ? AND occurred <= ? "
+                            + "ORDER BY occurred DESC, id DESC LIMIT 1")) {
+                ps.setBytes(1, uuidToBytes(player));
+                ps.setLong(2, instant.toEpochMilli());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return Optional.<PlayerSnapshot>empty();
+                    }
+                    header = new Header(rs.getBytes("id"), rs.getString("player_name"),
+                            rs.getLong("occurred"), rs.getString("cause"), rs.getLong("content_hash"));
+                }
+            }
+            List<SnapshotSlot> slots = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT s.slot, s.count, i.material, i.data "
+                            + "FROM player_snapshot_slots s "
+                            + "JOIN snapshot_items i ON s.item_hash = i.hash "
+                            + "WHERE s.snapshot_id = ? ORDER BY s.slot")) {
+                ps.setBytes(1, header.id());
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        slots.add(hydrateSlot(rs));
+                    }
+                }
+            }
+            return Optional.of(new PlayerSnapshot(
+                    bytesToUuid(header.id()), player, header.playerName(),
+                    Instant.ofEpochMilli(header.occurred()), header.cause(),
+                    header.contentHash(), slots));
+        });
+        return result;
+    }
+
+    @Override
+    public OptionalLong lastContentHash(UUID player) {
+        return store.withReadConnection(conn -> {
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT content_hash FROM player_snapshots WHERE player_uuid = ? "
+                            + "ORDER BY occurred DESC, id DESC LIMIT 1")) {
+                ps.setBytes(1, uuidToBytes(player));
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? OptionalLong.of(rs.getLong(1)) : OptionalLong.empty();
+                }
+            }
+        });
+    }
+
+    @Override
+    public int prune(Instant cutoff) {
+        long cutoffMs = cutoff.toEpochMilli();
+        return store.withWriteConnection(conn -> {
+            boolean priorAutoCommit = conn.getAutoCommit();
+            try {
+                conn.setAutoCommit(false);
+                try (PreparedStatement delSlots = conn.prepareStatement(
+                        "DELETE FROM player_snapshot_slots WHERE snapshot_id IN "
+                                + "(SELECT id FROM player_snapshots WHERE occurred < ?)")) {
+                    delSlots.setLong(1, cutoffMs);
+                    delSlots.executeUpdate();
+                }
+                int removed;
+                try (PreparedStatement delSnaps = conn.prepareStatement(
+                        "DELETE FROM player_snapshots WHERE occurred < ?")) {
+                    delSnaps.setLong(1, cutoffMs);
+                    removed = delSnaps.executeUpdate();
+                }
+                // Anti-join GC: drop interned payloads no surviving slot references.
+                // The tables are small at prune cadence, so the NOT IN scan is fine.
+                try (PreparedStatement gc = conn.prepareStatement(
+                        "DELETE FROM snapshot_items WHERE hash NOT IN "
+                                + "(SELECT DISTINCT item_hash FROM player_snapshot_slots)")) {
+                    gc.executeUpdate();
+                }
+                conn.commit();
+                return removed;
+            } catch (SQLException ex) {
+                rollbackQuietly(conn);
+                throw ex;
+            } finally {
+                restoreAutoCommit(conn, priorAutoCommit);
+            }
+        });
+    }
+
+    private static SnapshotSlot hydrateSlot(ResultSet rs) throws SQLException {
+        int slot = rs.getInt("slot");
+        int count = rs.getInt("count");
+        String material = rs.getString("material");
+        byte[] data = rs.getBytes("data");
+        StoredItem item = new StoredItem(slot, material,
+                data == null ? null : Base64.getEncoder().encodeToString(data));
+        return new SnapshotSlot(slot, count, item);
+    }
+
+    private List<InternedSlot> prepare(PlayerSnapshot snapshot) {
+        List<InternedSlot> out = new ArrayList<>(snapshot.slots().size());
+        for (SnapshotSlot slot : snapshot.slots()) {
+            StoredItem item = slot.item();
+            if (item == null || item.data() == null || item.data().isBlank()) {
+                LOGGER.log(Level.WARNING,
+                        "Skipping snapshot slot {0} for {1}: no item payload to intern",
+                        new Object[]{slot.slot(), snapshot.player()});
+                continue;
+            }
+            byte[] raw = Base64.getDecoder().decode(item.data());
+            out.add(new InternedSlot(slot.slot(), slot.count(), item.material(), hash16(raw), raw));
+        }
+        return out;
+    }
+
+    private static void rollbackQuietly(Connection conn) {
+        try {
+            conn.rollback();
+        } catch (SQLException ex) {
+            LOGGER.log(Level.WARNING, "MariaDB snapshot rollback failed", ex);
+        }
+    }
+
+    private static void restoreAutoCommit(Connection conn, boolean value) {
+        try {
+            conn.setAutoCommit(value);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.WARNING, "MariaDB snapshot autocommit restore failed", ex);
+        }
+    }
+
+    // SHA-256 truncated to 16 bytes over the raw serializeAsBytes payload. The
+    // truncation is the content address; a 128-bit space makes an accidental
+    // collision between two distinct item stacks not a practical concern.
+    static byte[] hash16(byte[] raw) {
+        try {
+            byte[] full = MessageDigest.getInstance("SHA-256").digest(raw);
+            byte[] out = new byte[16];
+            System.arraycopy(full, 0, out, 0, 16);
+            return out;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    static byte[] uuidToBytes(UUID uuid) {
+        byte[] out = new byte[16];
+        ByteBuffer.wrap(out).putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+        return out;
+    }
+
+    static UUID bytesToUuid(byte[] bytes) {
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        return new UUID(bb.getLong(), bb.getLong());
+    }
+
+    /** One captured slot resolved to its interned payload, for the save path. */
+    private record InternedSlot(int slot, int count, String material, byte[] hash, byte[] data) {
+    }
+
+    /** The {@code player_snapshots} header row, read before its slots. */
+    private record Header(byte[] id, String playerName, long occurred, String cause, long contentHash) {
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/MongoPlayerSnapshotStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/MongoPlayerSnapshotStore.java
@@ -1,0 +1,216 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.Sorts;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.Binary;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Mongo-backed {@link PlayerSnapshotStore}. Two collections decoded with the
+ * shared Spyglass codec registry: {@code player_snapshots} holds one document
+ * per capture with an embedded thin slot array (slot, count, and a 16-byte hash
+ * ref - never the item bytes), and {@code snapshot_items} interns the item
+ * payloads content-addressed by the {@code _id} hash. Modeled on
+ * {@code MongoSalvageStore}; shares the record store's database and client.
+ *
+ * <p>There is no TTL index: {@link #prune} is the single retention mechanism
+ * across every backend, and it also garbage-collects the intern rows a deleted
+ * snapshot was the last to reference. Interning is a {@code replaceOne} upsert,
+ * so re-interning a payload already on disk is a no-op that never throws.
+ */
+@ApiStatus.Internal
+public final class MongoPlayerSnapshotStore implements PlayerSnapshotStore {
+
+    private static final String SNAPSHOTS = "player_snapshots";
+    private static final String ITEMS = "snapshot_items";
+    private static final HexFormat HEX = HexFormat.of();
+
+    private final MongoCollection<Document> snapshots;
+    private final MongoCollection<Document> items;
+
+    public MongoPlayerSnapshotStore(MongoDatabase database, CodecRegistry codecRegistry) {
+        MongoDatabase db = database.withCodecRegistry(codecRegistry);
+        ensureZstdCollection(db, SNAPSHOTS);
+        ensureZstdCollection(db, ITEMS);
+        this.snapshots = db.getCollection(SNAPSHOTS);
+        this.items = db.getCollection(ITEMS);
+        // (player asc, occurred desc) serves the only read: the newest capture
+        // at or before T for one player. No expireAfter - prune() owns retention.
+        this.snapshots.createIndex(Indexes.compoundIndex(
+                Indexes.ascending("player"), Indexes.descending("occurred")));
+    }
+
+    @Override
+    public void save(PlayerSnapshot snapshot) {
+        List<Document> slotDocs = new ArrayList<>();
+        Set<String> internedThisSave = new HashSet<>();
+        for (SnapshotSlot slot : snapshot.slots()) {
+            StoredItem item = slot.item();
+            if (item == null || item.data() == null) {
+                continue;
+            }
+            byte[] raw = Base64.getDecoder().decode(item.data());
+            byte[] hash = hash16(raw);
+            if (internedThisSave.add(HEX.formatHex(hash))) {
+                // Upsert keyed by the content hash: a payload already on disk
+                // is rewritten identically, so a double-intern cannot throw.
+                items.replaceOne(Filters.eq("_id", new Binary(hash)),
+                        new Document("_id", new Binary(hash))
+                                .append("material", item.material())
+                                .append("data", new Binary(raw)),
+                        new ReplaceOptions().upsert(true));
+            }
+            slotDocs.add(new Document("slot", slot.slot())
+                    .append("count", slot.count())
+                    .append("hash", new Binary(hash)));
+        }
+        Document doc = new Document("_id", snapshot.id())
+                .append("player", snapshot.player())
+                .append("playerName", snapshot.playerName())
+                .append("occurred", Date.from(snapshot.capturedAt()))
+                .append("cause", snapshot.cause())
+                .append("contentHash", snapshot.contentHash())
+                .append("slots", slotDocs);
+        // Upsert by _id so a re-save of the same capture id is idempotent,
+        // matching the ClickHouse ReplacingMergeTree behaviour.
+        snapshots.replaceOne(Filters.eq("_id", snapshot.id()), doc,
+                new ReplaceOptions().upsert(true));
+    }
+
+    @Override
+    public Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant) {
+        Document snap = snapshots.find(Filters.and(
+                        Filters.eq("player", player),
+                        Filters.lte("occurred", Date.from(instant))))
+                .sort(Sorts.orderBy(Sorts.descending("occurred"), Sorts.descending("_id")))
+                .first();
+        if (snap == null) {
+            return Optional.empty();
+        }
+        List<Document> slotDocs = snap.getList("slots", Document.class, List.of());
+        Set<Binary> hashes = new HashSet<>();
+        for (Document slotDoc : slotDocs) {
+            hashes.add(slotDoc.get("hash", Binary.class));
+        }
+        Map<String, Document> blobs = fetchBlobs(hashes);
+
+        List<SnapshotSlot> slots = new ArrayList<>(slotDocs.size());
+        for (Document slotDoc : slotDocs) {
+            Binary hash = slotDoc.get("hash", Binary.class);
+            Document blob = blobs.get(HEX.formatHex(hash.getData()));
+            if (blob == null) {
+                // Referenced payload vanished (never expected: prune leaves
+                // snapshot_items orphans, never live refs). Skip the slot.
+                continue;
+            }
+            byte[] data = blob.get("data", Binary.class).getData();
+            StoredItem item = new StoredItem(
+                    slotDoc.getInteger("slot"), blob.getString("material"),
+                    Base64.getEncoder().encodeToString(data), null, null, null, null);
+            slots.add(new SnapshotSlot(slotDoc.getInteger("slot"),
+                    slotDoc.getInteger("count"), item));
+        }
+        return Optional.of(new PlayerSnapshot(
+                snap.get("_id", UUID.class),
+                player,
+                snap.getString("playerName"),
+                snap.getDate("occurred").toInstant(),
+                snap.getString("cause"),
+                snap.getLong("contentHash"),
+                slots));
+    }
+
+    @Override
+    public OptionalLong lastContentHash(UUID player) {
+        Document snap = snapshots.find(Filters.eq("player", player))
+                .sort(Sorts.orderBy(Sorts.descending("occurred"), Sorts.descending("_id")))
+                .projection(new Document("contentHash", 1))
+                .first();
+        if (snap == null) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(snap.getLong("contentHash"));
+    }
+
+    @Override
+    public int prune(Instant cutoff) {
+        long removed = snapshots.deleteMany(
+                Filters.lt("occurred", Date.from(cutoff))).getDeletedCount();
+        // Orphan-GC the intern table: gather every hash still referenced by a
+        // surviving snapshot, then delete the payloads nothing points at. The
+        // collections are small, so the anti-join is cheap at prune cadence.
+        // An empty live set (every snapshot pruned) drops all payloads.
+        List<Binary> live = new ArrayList<>();
+        snapshots.distinct("slots.hash", Binary.class).into(live);
+        items.deleteMany(Filters.nin("_id", live));
+        return (int) removed;
+    }
+
+    private Map<String, Document> fetchBlobs(Set<Binary> hashes) {
+        if (hashes.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Document> blobs = new HashMap<>();
+        for (Document blob : items.find(Filters.in("_id", hashes))) {
+            blobs.put(HEX.formatHex(blob.get("_id", Binary.class).getData()), blob);
+        }
+        return blobs;
+    }
+
+    /** SHA-256/16 of the raw (base64-decoded) item payload. */
+    private static byte[] hash16(byte[] raw) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(raw);
+            return Arrays.copyOf(digest, 16);
+        } catch (NoSuchAlgorithmException ex) {
+            // SHA-256 is a required JCA algorithm on every JVM.
+            throw new IllegalStateException("SHA-256 unavailable", ex);
+        }
+    }
+
+    /**
+     * Create a collection with WiredTiger's zstd block compressor when it does
+     * not exist yet, ignoring NamespaceExists (48). Same rationale and race
+     * handling as {@code MongoRecordStore}: the compressor is fixed at creation
+     * time, so we create eagerly (first write would auto-create with the server
+     * default) and let a concurrent creator win harmlessly.
+     */
+    private static void ensureZstdCollection(MongoDatabase database, String collection) {
+        try {
+            database.createCollection(collection, new CreateCollectionOptions()
+                    .storageEngineOptions(new BsonDocument("wiredTiger",
+                            new BsonDocument("configString", new BsonString("block_compressor=zstd")))));
+        } catch (MongoCommandException ex) {
+            if (ex.getErrorCode() != 48) {
+                throw ex;
+            }
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshot.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshot.java
@@ -1,0 +1,38 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+/**
+ * A player inventory captured at an instant, persisted to the
+ * {@link PlayerSnapshotStore}. Snapshots are the only honest source for "what
+ * was this player carrying at time T" - the event log does not cover crafting,
+ * consuming, trades, or plugin-given items, so no delta chain can reconstruct
+ * an inventory (#341).
+ *
+ * <p>Empty slots are absent from {@code slots}. {@code contentHash} is the
+ * capture service's 64-bit digest over the occupied (slot, count, payload)
+ * tuples; an unchanged hash means the sweep skips the write entirely.
+ */
+public record PlayerSnapshot(
+        @BsonProperty("_id") UUID id,
+        UUID player,
+        String playerName,
+        Instant capturedAt,
+        String cause,
+        long contentHash,
+        List<SnapshotSlot> slots) {
+
+    /** Capture causes, stored as short strings so new ones need no migration. */
+    public static final String CAUSE_JOIN = "join";
+    public static final String CAUSE_QUIT = "quit";
+    public static final String CAUSE_DEATH = "death";
+    public static final String CAUSE_WORLD_CHANGE = "world-change";
+    public static final String CAUSE_SWEEP = "sweep";
+
+    public PlayerSnapshot {
+        slots = slots == null ? List.of() : List.copyOf(slots);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotListener.java
@@ -1,0 +1,79 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Bukkit listener for the event-driven capture points {@link PlayerSnapshotService}
+ * does not schedule itself - join, quit, death, and world change. The periodic
+ * sweep is the service's own repeating task, installed by {@link
+ * PlayerSnapshotService#start}, not this listener.
+ *
+ * <p>A plain {@link Listener}, deliberately NOT a {@code RecordingListener}:
+ * this listener is gated by {@code snapshot.players.enabled}
+ * ({@code SpyglassConfig}), not by the {@code events} map. The plugin's
+ * per-{@code RecordingListener} registration loop only registers a listener
+ * whose {@code events()} intersects the enabled-events set - an EMPTY set
+ * there means never registered, the opposite of what {@code RecordingListener}'s
+ * own javadoc promises for config-agnostic listeners (SpyglassPlugin.java's
+ * gating loop). Implementing that interface here would silently wire this
+ * listener to the wrong knob. Registration against the real gate is the
+ * integration phase's job, not this class's.
+ */
+@ApiStatus.Internal
+public final class PlayerSnapshotListener implements Listener {
+
+    private final PlayerSnapshotService service;
+    private final JavaPlugin plugin;
+
+    public PlayerSnapshotListener(PlayerSnapshotService service, JavaPlugin plugin) {
+        this.service = service;
+        this.plugin = plugin;
+    }
+
+    /**
+     * One tick after join, not during {@link PlayerJoinEvent} itself: a
+     * starter kit or other join-time inventory grant from another plugin
+     * isn't guaranteed to have landed yet when this event fires, so capturing
+     * immediately risks logging a transient pre-kit state. {@link
+     * Player#isOnline()} guards a quit that races the one-tick delay.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                service.capture(player, PlayerSnapshot.CAUSE_JOIN);
+            }
+        }, 1L);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onQuit(PlayerQuitEvent event) {
+        service.capture(event.getPlayer(), PlayerSnapshot.CAUSE_QUIT);
+    }
+
+    /**
+     * Captured during the death event itself, before Bukkit clears the live
+     * inventory into the drop list - this is the last point the pre-death
+     * contents are readable from {@link Player#getInventory()}.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDeath(PlayerDeathEvent event) {
+        service.capture(event.getEntity(), PlayerSnapshot.CAUSE_DEATH);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onWorldChange(PlayerChangedWorldEvent event) {
+        service.capture(event.getPlayer(), PlayerSnapshot.CAUSE_WORLD_CHANGE);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotService.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotService.java
@@ -1,0 +1,307 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.Duration;
+import net.medievalrp.spyglass.api.util.EventIds;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Captures a player's inventory into a {@link PlayerSnapshot} (#341). Snapshots
+ * are the only honest source for "what was this player carrying at time T" -
+ * crafting, consuming, trades, and plugin-given items have no event trail a
+ * rollback could replay from.
+ *
+ * <p>Capture is split the same way {@code SalvageCapturer} splits a container
+ * capture: the live-world read ({@code getContents()}, the player's name/uuid,
+ * and the capture instant) happens on the caller's thread - always the main
+ * thread in production, since it touches the live {@code PlayerInventory} -
+ * and is cheap, the same cost class as a container's per-chunk read. Every
+ * per-slot clone, {@code serializeAsBytes}, hash, and the store write itself
+ * run on this service's own single-thread executor, so a join/quit/death/
+ * world-change/sweep capture never costs main-thread time beyond the array
+ * read.
+ *
+ * <h2>Dirty check</h2>
+ *
+ * <p>An in-memory per-player last-content-hash cache (not the store) is
+ * consulted on the hot path: a capture whose 64-bit content hash matches the
+ * cached value writes nothing - the previous snapshot already is that state,
+ * and {@code cause} is a label, not a reason to duplicate a row (join/quit/
+ * death captures on an unmodified inventory are the common case). The cache
+ * entry is warmed lazily on the first capture attempt for a player (one
+ * {@link PlayerSnapshotStore#lastContentHash} read), then kept current from
+ * every subsequent write. A quit evicts the entry (below) so the map does not
+ * grow for players who left for good.
+ *
+ * <h2>Content hash</h2>
+ *
+ * <p>Hashing the full concatenated payload bytes of every occupied slot would
+ * mean holding a buffer sized to the whole inventory's serialized NBT. Instead
+ * each slot's normalized (count-stripped) payload is first reduced to a fixed
+ * 16-byte SHA-256 prefix, and the outer digest streams over the small,
+ * fixed-size (slot, count, 16-byte payload hash) tuples in slot order. The
+ * result is the first 8 bytes of that outer digest, read as a big-endian long.
+ */
+@ApiStatus.Internal
+public final class PlayerSnapshotService {
+
+    private final PlayerSnapshotStore store;
+    private final Duration interval;
+    private final Duration retention;
+    private final ExecutorService executor;
+    private final Function<ItemStack, byte[]> serializer;
+    private final Logger logger;
+
+    // Confined to the executor thread: every read and write of this map
+    // happens inside a task submitted to `executor`, which is single-threaded,
+    // so no external synchronization is needed. A plain HashMap (not a
+    // ConcurrentHashMap) documents that confinement rather than papering over
+    // it with a lock nobody needs.
+    private final Map<UUID, Long> lastHash = new HashMap<>();
+
+    private volatile BukkitTask sweepTask;
+    private volatile BukkitTask pruneTask;
+
+    /** Upper bound on how long {@link #stop} waits for in-flight captures to
+     *  finish before forcing the executor down. */
+    private static final long SHUTDOWN_AWAIT_SECONDS = 5L;
+
+    /** Once-per-hour prune cadence (#341): snapshot volume is low enough that
+     *  a finer cadence buys nothing, and an hourly sweep keeps the anti-join
+     *  orphan-payload cleanup (SQLite/MariaDB) or TTL bookkeeping (Mongo/CH)
+     *  cheap per run. */
+    private static final long PRUNE_PERIOD_TICKS = 20L * 60L * 60L;
+
+    public PlayerSnapshotService(PlayerSnapshotStore store, Duration interval, Duration retention,
+            Logger logger) {
+        this(store, interval, retention, defaultExecutor(), ItemStack::serializeAsBytes, logger);
+    }
+
+    /** Visible for tests: inject a deterministic executor and a serializer
+     *  that doesn't call the real (CraftBukkit-only) {@code serializeAsBytes}. */
+    PlayerSnapshotService(PlayerSnapshotStore store, Duration interval, Duration retention,
+            ExecutorService executor, Function<ItemStack, byte[]> serializer, Logger logger) {
+        this.store = store;
+        this.interval = interval;
+        this.retention = retention;
+        this.executor = executor;
+        this.serializer = serializer;
+        this.logger = logger;
+    }
+
+    private static ExecutorService defaultExecutor() {
+        ThreadFactory factory = runnable -> {
+            Thread thread = new Thread(runnable, "spyglass-snapshot");
+            thread.setDaemon(true);
+            return thread;
+        };
+        return Executors.newSingleThreadExecutor(factory);
+    }
+
+    /**
+     * Capture {@code player}'s inventory, labeled with {@code cause} (one of
+     * the {@code PlayerSnapshot.CAUSE_*} constants). Must be called from the
+     * main thread - {@link Player#getInventory()} and {@code getContents()}
+     * are live-world reads. Returns immediately; the serialize/hash/write
+     * work is handed to this service's executor.
+     */
+    public void capture(Player player, String cause) {
+        UUID uuid = player.getUniqueId();
+        String name = player.getName();
+        Instant capturedAt = Instant.now();
+        // MAIN THREAD ONLY: read AND clone the live inventory here.
+        // getContents() hands back a fresh 41-slot array (0-35 main, 36-39
+        // armor, 40 offhand) but the ItemStacks in it can be CraftItemStack
+        // mirrors of the live NMS stacks - touching those off-thread races
+        // player inventory mutation (the #96/#97 snapshot-on-main rule, and
+        // exactly what SalvageCapturer clones on main for). 41 clones is the
+        // same cost class as a container's per-chunk read. Everything after
+        // this - serializeAsBytes, hashing, and the store write - runs off
+        // this thread, on clones only this service can see.
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] != null) {
+                contents[i] = contents[i].clone();
+            }
+        }
+
+        executor.execute(() -> captureOffMain(uuid, name, capturedAt, cause, contents));
+    }
+
+    /** Capture every online player, tagged {@code CAUSE_SWEEP}. Intended to be
+     *  called on the main thread by the repeating task {@link #start} installs. */
+    public void sweep() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            capture(player, PlayerSnapshot.CAUSE_SWEEP);
+        }
+    }
+
+    private void captureOffMain(UUID uuid, String name, Instant capturedAt, String cause,
+            ItemStack[] contents) {
+        try {
+            List<SnapshotSlot> slots = new ArrayList<>();
+            MessageDigest outer = sha256();
+            for (int slot = 0; slot < contents.length; slot++) {
+                ItemStack original = contents[slot];
+                if (original == null || original.getType() == Material.AIR) {
+                    continue; // empty slots are absent from the snapshot
+                }
+                // `original` is already a main-thread clone (capture()); this
+                // second clone only isolates the setAmount(1) normalization,
+                // so the interned payload for "64 cobblestone" and "12
+                // cobblestone" is the same blob (SnapshotSlot javadoc).
+                ItemStack normalized = original.clone();
+                int count = normalized.getAmount();
+                normalized.setAmount(1);
+                byte[] raw = serializer.apply(normalized);
+                byte[] payloadHash = sha256Prefix16(raw);
+                String base64 = Base64.getEncoder().encodeToString(raw);
+                StoredItem item = new StoredItem(slot, normalized.getType().name(), base64);
+                slots.add(new SnapshotSlot(slot, count, item));
+
+                outer.update(intBytes(slot));
+                outer.update(intBytes(count));
+                outer.update(payloadHash);
+            }
+            long contentHash = firstEightBytesAsLong(outer.digest());
+
+            Long cached = lastHash.containsKey(uuid) ? lastHash.get(uuid) : warm(uuid);
+            if (cached != null && cached == contentHash) {
+                // Dirty-equal: the previous snapshot already is this state.
+                // `cause` is a label, not a reason to duplicate the row.
+                return;
+            }
+
+            // EventIds, not randomUUID: the ClickHouse store persists the id as
+            // its embedded 62-bit sequence (EventIds.sequenceOf), which folds a
+            // foreign/random UUID lossily and wrecks the id column's Delta
+            // compression - the same rule every record id follows.
+            PlayerSnapshot snapshot = new PlayerSnapshot(
+                    EventIds.newId(), uuid, name, capturedAt, cause, contentHash, slots);
+            store.save(snapshot);
+            lastHash.put(uuid, contentHash);
+        } catch (RuntimeException ex) {
+            // Structured logging only, matching DeferredSerializer: a poison
+            // item or a store hiccup must not escape to the executor's
+            // default handler, and must not take the executor thread down.
+            logger.warning("Spyglass snapshot capture failed for " + uuid + " (" + cause
+                    + "); capture skipped: " + ex.getMessage());
+        } finally {
+            if (PlayerSnapshot.CAUSE_QUIT.equals(cause)) {
+                // The player is gone; keeping their hash around only grows
+                // the map for good. The next join re-warms from the store.
+                lastHash.remove(uuid);
+            }
+        }
+    }
+
+    /** Lazily warm the cache from the store on the first capture attempt for
+     *  a player. Runs on the executor thread, same as every other cache access. */
+    private Long warm(UUID uuid) {
+        OptionalLong previous = store.lastContentHash(uuid);
+        Long value = previous.isPresent() ? previous.getAsLong() : null;
+        lastHash.put(uuid, value);
+        return value;
+    }
+
+    /**
+     * Start the periodic sweep (every {@code interval}, on the main thread -
+     * capture's main-thread part is cheap) and the hourly async prune (drops
+     * rows older than {@code retention}).
+     */
+    public void start(JavaPlugin plugin) {
+        long sweepTicks = Math.max(20L, interval.seconds() * 20L);
+        this.sweepTask = Bukkit.getScheduler()
+                .runTaskTimer(plugin, this::sweep, sweepTicks, sweepTicks);
+        this.pruneTask = Bukkit.getScheduler()
+                .runTaskTimerAsynchronously(plugin, this::pruneNow, PRUNE_PERIOD_TICKS, PRUNE_PERIOD_TICKS);
+    }
+
+    private void pruneNow() {
+        try {
+            Instant cutoff = Instant.now().minusSeconds(retention.seconds());
+            int removed = store.prune(cutoff);
+            if (removed > 0) {
+                logger.fine("Spyglass snapshot prune removed " + removed
+                        + " row(s) older than " + cutoff);
+            }
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass snapshot prune failed: " + ex.getMessage());
+        }
+    }
+
+    /** Cancel the scheduled tasks and shut down the executor, waiting briefly
+     *  for an in-flight capture to finish (mirrors {@code DeferredSerializer#shutdown}). */
+    public void stop() {
+        if (sweepTask != null) {
+            sweepTask.cancel();
+            sweepTask = null;
+        }
+        if (pruneTask != null) {
+            pruneTask.cancel();
+            pruneTask = null;
+        }
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_AWAIT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            // Every JVM implementation is required to provide SHA-256
+            // (java.security.MessageDigest javadoc); this can't happen.
+            throw new IllegalStateException("SHA-256 unavailable", ex);
+        }
+    }
+
+    private static byte[] sha256Prefix16(byte[] raw) {
+        byte[] digest = sha256().digest(raw);
+        byte[] prefix = new byte[16];
+        System.arraycopy(digest, 0, prefix, 0, 16);
+        return prefix;
+    }
+
+    private static byte[] intBytes(int value) {
+        return new byte[] {
+                (byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) value
+        };
+    }
+
+    private static long firstEightBytesAsLong(byte[] digest) {
+        long result = 0L;
+        for (int i = 0; i < 8; i++) {
+            result = (result << 8) | (digest[i] & 0xFFL);
+        }
+        return result;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotStore.java
@@ -1,0 +1,43 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Durable store for {@link PlayerSnapshot}s. A dedicated store (not the event
+ * log) by the same pattern as {@code SalvageStore}: the rows carry full item
+ * blobs, live under their own retention, and are read by point lookup rather
+ * than the record query surface.
+ *
+ * <p>Implementations intern item payloads content-addressed (SHA-256/16 of the
+ * raw {@code serializeAsBytes} bytes) so a player carrying the same kit for a
+ * week costs one payload set, not one per snapshot. Every method is called off
+ * the main thread. {@code save} must be read-your-writes: a subsequent
+ * {@link #latestAtOrBefore} on any thread sees it (snapshot volume is low, so
+ * ClickHouse uses synchronous inserts here, not the async event path).
+ */
+@ApiStatus.Internal
+public interface PlayerSnapshotStore {
+
+    /** Persist a capture. Interns payloads; idempotent re-intern must not throw. */
+    void save(PlayerSnapshot snapshot);
+
+    /** Newest snapshot with {@code capturedAt <= instant}, slots hydrated. */
+    Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant);
+
+    /** Content hash of the player's newest snapshot, for dirty-cache warmup. */
+    OptionalLong lastContentHash(UUID player);
+
+    /**
+     * Drop snapshots captured before {@code cutoff} and garbage-collect
+     * payloads no snapshot references anymore. Returns removed snapshot rows.
+     */
+    int prune(Instant cutoff);
+
+    /** Best-effort release of any backend resources. */
+    default void close() {
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/Reconstruction.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/Reconstruction.java
@@ -1,0 +1,52 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.util.List;
+
+/**
+ * The output of {@link SnapshotReconstructor}: the container's slots as of the
+ * requested instant, plus how much the #267 forward-replay trusts them.
+ *
+ * <p>{@code slots} holds only the occupied slots of the reconstructed
+ * (reverse-applied) state. {@code certainty} is {@code CERTAIN} only when the
+ * forward-replay reproduced the live container exactly and no hard trigger
+ * (legacy rows, absent container, self-mutating block) fired; otherwise it is
+ * {@code UNCERTAIN} and {@code notes} names, in operator-readable text, every
+ * reason it could not be certain. {@code mismatches} is the same information as
+ * structured data for the view/audit layer: each forward-replay step that did
+ * not line up and each slot whose live contents the records failed to explain.
+ */
+public record Reconstruction(
+        List<SnapshotSlot> slots,
+        SnapshotSession.Certainty certainty,
+        List<String> notes,
+        List<Mismatch> mismatches) {
+
+    public Reconstruction {
+        slots = slots == null ? List.of() : List.copyOf(slots);
+        notes = notes == null ? List.of() : List.copyOf(notes);
+        mismatches = mismatches == null ? List.of() : List.copyOf(mismatches);
+    }
+
+    /** True when the forward-replay verified the reconstruction against live. */
+    public boolean certain() {
+        return certainty == SnapshotSession.Certainty.CERTAIN;
+    }
+
+    /**
+     * One discrepancy the forward-replay found. {@code expected} is the state
+     * the records predict, {@code actual} is what was actually there, both as
+     * material labels ({@code "empty"} for a cleared slot). A pure component
+     * cannot decode blobs, so labels are material-level; the slot index is
+     * always exact.
+     */
+    public record Mismatch(int slot, Kind kind, String expected, String actual) {
+
+        /**
+         * {@code REPLAY_STEP}: a record's recorded before-state did not match
+         * the state the chain had reached at that point (a row out of order or
+         * tampered). {@code END_STATE}: after replaying every record the result
+         * did not equal the live container (a change never written to the log).
+         */
+        public enum Kind { REPLAY_STEP, END_STATE }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotReconstructor.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotReconstructor.java
@@ -1,0 +1,272 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.EventIds;
+
+/**
+ * Reconstructs a single container inventory as of an instant T and reports how
+ * much to trust the result, using the #267 reverse-apply plus forward-replay
+ * verification.
+ *
+ * <p>The algorithm is deliberately pure: it takes records and the live slot
+ * array as plain data and touches no Bukkit type, so it unit-tests without
+ * {@code mockStatic}. Two passes:
+ *
+ * <ol>
+ *   <li><b>Reverse-apply</b> the container-family records newest-first onto a
+ *       copy of the live contents ({@code slot := beforeItem}); the last op
+ *       processed per slot is the oldest, so each slot lands on the state it
+ *       held at T. Deposit and withdraw records both carry the slot's exact
+ *       {@code (before, after)} state pair, so rewind direction does not
+ *       matter.</li>
+ *   <li><b>Forward-replay</b> the same records oldest-first from the
+ *       reconstructed state: at each op the current slot must already equal
+ *       {@code beforeItem}, then it becomes {@code afterItem}. Mismatches are
+ *       collected, not thrown. If the replay reproduces the live container
+ *       exactly and nothing forced doubt, the reconstruction is
+ *       {@link SnapshotSession.Certainty#CERTAIN}; otherwise it is
+ *       {@link SnapshotSession.Certainty#UNCERTAIN} with a note per unexplained
+ *       slot.</li>
+ * </ol>
+ *
+ * <p>Slot states are compared by their serialized payload string, with a null
+ * {@link StoredItem} and an {@code AIR} item both treated as empty - the same
+ * equality the rollback engine's {@code ContainerSlotWrite} guard uses.
+ *
+ * <p><b>One inventory per call.</b> Double chests are the caller's problem: it
+ * resolves the two half locations, reconstructs each half separately against
+ * its own per-half local slots (0-26), and merges the two results into the
+ * 54-slot view. This component never sees a double chest.
+ *
+ * <p><b>Count semantics.</b> The output {@link SnapshotSlot}s carry the record's
+ * {@link StoredItem} as-is and set {@code count} to {@link #COUNT_IN_BLOB}
+ * (see the constant), because for container records the real stack size lives
+ * inside the serialized blob, not in the record's {@code amount} field.
+ */
+public final class SnapshotReconstructor {
+
+    /**
+     * {@code count} value on reconstructed container slots. The container
+     * deposit/withdraw listener serializes the full post-click slot state into
+     * {@code beforeItem}/{@code afterItem} (ContainerTransactionListener,
+     * roughly lines 141-178: the {@code (before, after)} pair is the slot's
+     * exact state, and the record's {@code amount} field is only the
+     * transferred delta - e.g. withdrawing 20 from a stack of 64 records
+     * amount 20 with an after-blob of 44). So the real stack size already lives
+     * in {@link StoredItem#data()}, unlike player snapshots where the interned
+     * blob is normalized to amount 1 and {@link SnapshotSlot#count()} is the
+     * authority. A pure component cannot decode the blob to read that size, so
+     * count is left 0 and callers must take the amount from
+     * {@code decode(item.data())} directly - never {@code setAmount(count)} on a
+     * container-mode slot.
+     */
+    public static final int COUNT_IN_BLOB = 0;
+
+    /**
+     * Chronological order: primary the wall-clock instant, tie-broken by the
+     * id's embedded sequence. Records minted within the same millisecond (a
+     * SWAP_WITH_CURSOR withdraw+deposit pair, a shift-click fan-out) share an
+     * {@code occurred}, so the monotonic id sequence is what keeps their order
+     * stable and reversible.
+     */
+    private static final Comparator<SlotOp> CHRONO = Comparator
+            .comparing(SlotOp::occurred)
+            .thenComparingLong(op -> EventIds.sequenceOf(op.id()));
+
+    private SnapshotReconstructor() {
+    }
+
+    /**
+     * Reconstruct one container inventory as of {@code t}.
+     *
+     * @param windowRecords every record pinned to this container location with
+     *                       {@code occurred} in {@code [t, now]}, in any order;
+     *                       non-container records and records older than
+     *                       {@code t} are ignored
+     * @param liveContents   the container's current contents by slot, null per
+     *                       empty slot, captured on the main thread by the
+     *                       caller; when {@code containerPresent} is false pass
+     *                       an empty (all-null) array
+     * @param size           the container's slot count (the authoritative bound)
+     * @param t              the instant to reconstruct; may be null to skip the
+     *                       defensive window filter
+     * @param containerPresent whether the live container still exists; false
+     *                       forces UNCERTAIN and skips forward-replay (there is
+     *                       no live state to verify against)
+     * @param selfMutating   whether the block mutates its own contents without
+     *                       logging (furnace/brewing/campfire family); the
+     *                       caller decides from the block type, and a true value
+     *                       forces UNCERTAIN
+     */
+    public static Reconstruction reconstruct(
+            List<EventRecord> windowRecords,
+            StoredItem[] liveContents,
+            int size,
+            Instant t,
+            boolean containerPresent,
+            boolean selfMutating) {
+
+        int slots = Math.max(0, size);
+        StoredItem[] live = normalize(liveContents, slots);
+
+        List<SlotOp> ops = new ArrayList<>();
+        boolean legacy = false;     // any slot < 0 row (pre-#268 per-slot logging)
+        boolean outOfRange = false; // a record slot beyond the current size (shape changed)
+        for (EventRecord record : windowRecords == null ? List.<EventRecord>of() : windowRecords) {
+            SlotOp op = SlotOp.of(record);
+            if (op == null) {
+                continue;
+            }
+            if (t != null && op.occurred().isBefore(t)) {
+                continue;
+            }
+            if (op.slot() < 0) {
+                legacy = true;
+                continue;
+            }
+            if (op.slot() >= slots) {
+                outOfRange = true;
+                continue;
+            }
+            ops.add(op);
+        }
+
+        // Pass 1 - reverse-apply newest-first back to the state held at T.
+        StoredItem[] candidate = live.clone();
+        List<SlotOp> newestFirst = new ArrayList<>(ops);
+        newestFirst.sort(CHRONO.reversed());
+        for (SlotOp op : newestFirst) {
+            candidate[op.slot()] = op.before();
+        }
+
+        List<String> notes = new ArrayList<>();
+        List<Reconstruction.Mismatch> mismatches = new ArrayList<>();
+
+        // Pass 2 - forward-replay from the reconstructed state and check it
+        // reproduces live. Skipped when the container is gone: there is no live
+        // state to reconcile against, and the reconstruction is already flagged
+        // UNCERTAIN below.
+        if (containerPresent) {
+            StoredItem[] replay = candidate.clone();
+            List<SlotOp> oldestFirst = new ArrayList<>(ops);
+            oldestFirst.sort(CHRONO);
+            for (SlotOp op : oldestFirst) {
+                if (!sameState(replay[op.slot()], op.before())) {
+                    mismatches.add(new Reconstruction.Mismatch(
+                            op.slot(), Reconstruction.Mismatch.Kind.REPLAY_STEP,
+                            label(op.before()), label(replay[op.slot()])));
+                    notes.add("slot " + op.slot() + ": a record expected " + label(op.before())
+                            + " but the chain had " + label(replay[op.slot()])
+                            + " (record out of order or tampered)");
+                }
+                replay[op.slot()] = op.after();
+            }
+            for (int i = 0; i < slots; i++) {
+                if (!sameState(replay[i], live[i])) {
+                    mismatches.add(new Reconstruction.Mismatch(
+                            i, Reconstruction.Mismatch.Kind.END_STATE,
+                            label(replay[i]), label(live[i])));
+                    notes.add("slot " + i + ": live " + label(live[i])
+                            + " does not match the reconstructed " + label(replay[i])
+                            + " (change not in the log)");
+                }
+            }
+        }
+
+        // Hard triggers - UNCERTAIN regardless of how cleanly the replay ran.
+        if (legacy) {
+            notes.add("history predates per-slot logging (legacy slot < 0 rows); "
+                    + "the reconstruction may be incomplete");
+        }
+        if (outOfRange) {
+            notes.add("a record references a slot beyond the current container size; "
+                    + "the container's shape changed");
+        }
+        if (!containerPresent) {
+            notes.add("container no longer present, reconstructed from records against empty");
+        }
+        if (selfMutating) {
+            notes.add("self-mutating container (furnace/brewing/campfire family); "
+                    + "its contents cannot be verified from records");
+        }
+
+        boolean uncertain = legacy || outOfRange || !containerPresent || selfMutating
+                || !mismatches.isEmpty();
+        SnapshotSession.Certainty certainty = uncertain
+                ? SnapshotSession.Certainty.UNCERTAIN
+                : SnapshotSession.Certainty.CERTAIN;
+
+        List<SnapshotSlot> result = new ArrayList<>();
+        for (int i = 0; i < slots; i++) {
+            StoredItem item = candidate[i];
+            if (isEmpty(item)) {
+                continue;
+            }
+            result.add(new SnapshotSlot(i, COUNT_IN_BLOB, item));
+        }
+        return new Reconstruction(result, certainty, notes, mismatches);
+    }
+
+    private static StoredItem[] normalize(StoredItem[] live, int slots) {
+        StoredItem[] out = new StoredItem[slots];
+        if (live != null) {
+            System.arraycopy(live, 0, out, 0, Math.min(slots, live.length));
+        }
+        return out;
+    }
+
+    /** A cleared slot: a null item, or one whose material is absent or AIR. */
+    private static boolean isEmpty(StoredItem item) {
+        if (item == null) {
+            return true;
+        }
+        String material = item.material();
+        return material == null || material.equals("AIR");
+    }
+
+    /** Two slot states are equal when both are empty or their blobs match. */
+    private static boolean sameState(StoredItem a, StoredItem b) {
+        boolean emptyA = isEmpty(a);
+        boolean emptyB = isEmpty(b);
+        if (emptyA || emptyB) {
+            return emptyA && emptyB;
+        }
+        return Objects.equals(a.data(), b.data());
+    }
+
+    private static String label(StoredItem item) {
+        if (isEmpty(item)) {
+            return "empty";
+        }
+        String material = item.material();
+        return material == null ? "unknown" : material;
+    }
+
+    /**
+     * A container deposit or withdraw flattened to the fields reconstruction
+     * needs. Both record types carry the identical {@code (slot, beforeItem,
+     * afterItem)} state pair; the direction (which way items moved) is
+     * irrelevant to rewinding a slot.
+     */
+    private record SlotOp(UUID id, Instant occurred, int slot, StoredItem before, StoredItem after) {
+
+        static SlotOp of(EventRecord record) {
+            if (record instanceof ContainerDepositRecord d) {
+                return new SlotOp(d.id(), d.occurred(), d.slot(), d.beforeItem(), d.afterItem());
+            }
+            if (record instanceof ContainerWithdrawRecord w) {
+                return new SlotOp(w.id(), w.occurred(), w.slot(), w.beforeItem(), w.afterItem());
+            }
+            return null;
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSession.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSession.java
@@ -1,0 +1,39 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A resolved snapshot ready to show: what {@code /sg snapshot} computed, held
+ * per-sender in a TTL cache so GUI clicks and the text-fallback
+ * {@code /sg snapshot take <token> <slot>} act on exactly the state the
+ * operator was shown. Sessions never write back; takes clone out of them.
+ *
+ * <p>Container sessions come from the reconstructor (certainty is the
+ * forward-replay verdict, notes name what did not reconcile); player sessions
+ * come from the snapshot store (always {@link Certainty#CERTAIN}, the capture
+ * is exact - {@code capturedAt} tells the operator how close to T it landed).
+ */
+public record SnapshotSession(
+        UUID token,
+        Kind kind,
+        String subjectLabel,
+        Instant asOf,
+        Instant capturedAt,
+        String cause,
+        Certainty certainty,
+        List<String> notes,
+        int containerRows,
+        List<SnapshotSlot> slots) {
+
+    public enum Kind { PLAYER, CONTAINER }
+
+    /** The forward-replay verdict from #267: does the chain explain the live state. */
+    public enum Certainty { CERTAIN, UNCERTAIN }
+
+    public SnapshotSession {
+        notes = notes == null ? List.of() : List.copyOf(notes);
+        slots = slots == null ? List.of() : List.copyOf(slots);
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSessions.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSessions.java
@@ -1,0 +1,106 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Per-sender TTL cache of the last {@code /sg snapshot} a sender resolved
+ * (#341), the {@link net.medievalrp.spyglass.plugin.command.PageCache}
+ * idiom applied to snapshots: the GUI and the text-fallback take command
+ * must act on exactly the state the operator was shown, not a fresh
+ * re-read that could have moved on since (a later deposit, another
+ * operator's take, a second snapshot the same sender ran in the
+ * meantime). A sender holds exactly one live session; resolving a new
+ * snapshot replaces it, same as paging replaces the last search.
+ *
+ * <p>15 minute TTL, matching {@code PageCache}. Cleared on quit so the
+ * map does not hold an entry for a player who left for good.
+ */
+@ApiStatus.Internal
+public final class SnapshotSessions implements Listener {
+
+    private static final UUID CONSOLE_ID = new UUID(0L, 0L);
+    private static final long TTL_MILLIS = TimeUnit.MINUTES.toMillis(15);
+
+    private final ConcurrentHashMap<UUID, Entry> sessions = new ConcurrentHashMap<>();
+
+    /** Cache {@code session} for {@code sender}, replacing any previous entry. */
+    public void store(CommandSender sender, SnapshotSession session) {
+        sessions.put(idOf(sender), new Entry(session, System.currentTimeMillis()));
+    }
+
+    /**
+     * The sender's cached session, if any and unexpired - used right after
+     * a fresh resolution, before any token has been shown to anyone, so
+     * there is nothing to check it against yet.
+     */
+    public Optional<SnapshotSession> get(CommandSender sender) {
+        Entry entry = liveEntry(sender);
+        return entry == null ? Optional.empty() : Optional.of(entry.session());
+    }
+
+    /**
+     * Resolve the sender's cached session for a take, requiring
+     * {@code token} to match the one that was cached. A mismatch (a stale
+     * link from a render a newer {@code /sg snapshot} superseded, or a
+     * hand-typed wrong token) is indistinguishable from outright expiry to
+     * the caller - both mean "the state you're pointing at is no longer
+     * the live cached one" - so both report through the same empty
+     * {@link Optional} and the same friendly error at the call site.
+     */
+    public Optional<SnapshotSession> resolve(CommandSender sender, UUID token) {
+        Entry entry = liveEntry(sender);
+        if (entry == null || !entry.session().token().equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(entry.session());
+    }
+
+    /** Drop the sender's cached session, if any. */
+    public void clear(CommandSender sender) {
+        sessions.remove(idOf(sender));
+    }
+
+    private Entry liveEntry(CommandSender sender) {
+        UUID id = idOf(sender);
+        Entry entry = sessions.get(id);
+        if (entry == null) {
+            return null;
+        }
+        if (System.currentTimeMillis() - entry.storedAt() > TTL_MILLIS) {
+            // Remove only the exact expired entry: a store() that raced in
+            // between (a new /sg snapshot on another thread) must not be
+            // clobbered by this cleanup.
+            sessions.remove(id, entry);
+            return null;
+        }
+        return entry;
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        sessions.remove(event.getPlayer().getUniqueId());
+    }
+
+    private static UUID idOf(CommandSender sender) {
+        if (sender instanceof Player player) {
+            return player.getUniqueId();
+        }
+        if (sender instanceof ConsoleCommandSender) {
+            return CONSOLE_ID;
+        }
+        return UUID.nameUUIDFromBytes(sender.getName().getBytes());
+    }
+
+    private record Entry(SnapshotSession session, long storedAt) {
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSlot.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSlot.java
@@ -1,0 +1,15 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import net.medievalrp.spyglass.api.event.StoredItem;
+
+/**
+ * One occupied slot inside a {@link PlayerSnapshot}. The {@code item} blob is
+ * serialized with its amount normalized to 1 and the real amount kept here, so
+ * the interned payload for "64 cobblestone" and "12 cobblestone" is the same
+ * row. Reconstruction is {@code decode(item.data()).setAmount(count)}.
+ *
+ * <p>Slot indices follow {@code PlayerInventory.getContents()}: 0-35 main,
+ * 36-39 armor, 40 offhand.
+ */
+public record SnapshotSlot(int slot, int count, StoredItem item) {
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakeLogger.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakeLogger.java
@@ -1,0 +1,79 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.SpyglassApi;
+import net.medievalrp.spyglass.api.event.ItemPickupRecord;
+import net.medievalrp.spyglass.api.event.RecordContext;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Records an operator taking a copy of an item out of a {@code /sg snapshot}
+ * view (a past-instant player inventory or container), so every take is
+ * auditable ({@code a:snapshot-take}). Same shape as {@code
+ * SalvageWithdrawLogger}: the GUI and the text-fallback {@code take} command
+ * both call {@link #log} after the copy already landed in the taker's
+ * inventory - this only builds the audit record, it never touches inventory
+ * contents itself.
+ *
+ * <p>Reuses {@link ItemPickupRecord} (the {@code salvage-withdraw}
+ * precedent, #76), so both storage backends already persist it - the
+ * {@code extensions} channel this event needs was added to the record
+ * itself (#341) rather than costing a schema change. The item field is the
+ * forensic-only projection ({@link ItemSerialization#storedItemProjection}):
+ * a take is never rolled back or replayed, so the base64 blob would be dead
+ * weight (#103).
+ *
+ * <p>Goes through {@link SpyglassApi#record} rather than the internal
+ * {@code Recorder} directly - that call rejects a null location at the
+ * boundary (#230) instead of failing silently downstream, and a taker's
+ * location is always real (never a global/sentinel event).
+ */
+@ApiStatus.Internal
+public final class SnapshotTakeLogger {
+
+    private final SpyglassApi api;
+    private final RecordingSupport support;
+    private final Logger logger;
+
+    public SnapshotTakeLogger(SpyglassApi api, RecordingSupport support, Logger logger) {
+        this.api = api;
+        this.support = support;
+        this.logger = logger;
+    }
+
+    /**
+     * Log one take. {@code slot} is the source slot in the session's view
+     * (a player-inventory index or a container slot), carried into the
+     * stored item projection so the audit row names where the copy came
+     * from. Never throws - a logging failure must not surface as a failed
+     * take, since the copy has already been placed in the taker's
+     * inventory by the time this runs.
+     */
+    public void log(Player taker, SnapshotSession session, ItemStack takenStack, int slot) {
+        if (takenStack == null || takenStack.getType() == Material.AIR) {
+            return;
+        }
+        try {
+            StoredItem projection = ItemSerialization.storedItemProjection(slot, takenStack);
+            if (projection == null) {
+                return;
+            }
+            BlockLocation location = BlockLocations.fromLocation(taker.getLocation());
+            RecordContext ctx = support.playerContext(taker, location)
+                    .withExtension("snapshot-subject", session.subjectLabel())
+                    .withExtension("snapshot-at", session.asOf().toString());
+            api.record(ItemPickupRecord.of(ctx, "snapshot-take",
+                    takenStack.getType().name(), takenStack.getAmount(), projection));
+        } catch (RuntimeException ex) {
+            logger.warning("Spyglass snapshot take log failed: " + ex.getMessage());
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakes.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakes.java
@@ -1,0 +1,160 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.util.List;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The extract path for {@code /sg snapshot}, shared by the InvUI GUI and
+ * the text-fallback take command (#341) - the same split
+ * {@code SalvageWithdrawals} draws between its two surfaces.
+ *
+ * <p>A take is a COPY, not a withdrawal: the session's slots never change
+ * ({@link SnapshotSession}'s javadoc - "sessions never write back, takes
+ * clone out of them"), so nothing here mutates a session or a store row.
+ * The audit record ({@link SnapshotTakeLogger}) is the only control that
+ * keeps repeated takes honest - by design, the same slot can be taken
+ * again a minute later, and that is fine because every take is logged.
+ *
+ * <p>Unlike {@code SalvageWithdrawals}, a stack that cannot fit whole is
+ * refused outright: no partial placement, no overflow dropped on the
+ * ground. That is the simplest dupe-story available here - a feature
+ * whose entire point is "you can take this again" cannot also reason
+ * about which fraction of a stack a prior partial take already covered.
+ */
+@ApiStatus.Internal
+public final class SnapshotTakes {
+
+    /** Gates every take, in both the GUI and the text fallback. */
+    public static final String PERMISSION = "spyglass.snapshot.take";
+
+    public enum Result {
+        /** The item was cloned into the taker's inventory and the take was logged. */
+        TAKEN,
+        /** The stack would not fit whole; nothing was placed. */
+        INVENTORY_FULL,
+        /** The taker lacks {@link #PERMISSION}. */
+        NO_PERMISSION,
+        /** No occupied slot at that index in the session (already gone, bad index). */
+        SLOT_EMPTY
+    }
+
+    /** Null in tests that don't care about the audit trail (matches
+     *  {@code SalvageWithdrawals}'s own null-logger test idiom). */
+    @Nullable
+    private final SnapshotTakeLogger logger;
+
+    public SnapshotTakes(@Nullable SnapshotTakeLogger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Take a copy of the item at {@code slot} out of {@code session} into
+     * {@code taker}'s inventory. Must run on the main thread - it reads
+     * and writes the taker's live {@link PlayerInventory}.
+     */
+    public Result take(Player taker, SnapshotSession session, int slot) {
+        if (!taker.hasPermission(PERMISSION)) {
+            return Result.NO_PERMISSION;
+        }
+        SnapshotSlot found = findSlot(session.slots(), slot);
+        if (found == null) {
+            return Result.SLOT_EMPTY;
+        }
+        ItemStack stack = decode(session, found);
+        if (stack == null || stack.getType() == Material.AIR) {
+            return Result.SLOT_EMPTY;
+        }
+        PlayerInventory inventory = taker.getInventory();
+        if (!fits(inventory.getStorageContents(), stack)) {
+            return Result.INVENTORY_FULL;
+        }
+        inventory.addItem(stack.clone());
+        if (logger != null) {
+            logger.log(taker, session, stack, slot);
+        }
+        return Result.TAKEN;
+    }
+
+    /**
+     * Decode the slot's stored blob into a live stack, applying the count
+     * semantics that mode uses. Player-mode slots carry the real amount in
+     * {@link SnapshotSlot#count()} - the interned blob is normalized to 1
+     * ({@code PlayerSnapshotService}'s dirty-check trick) - so the decoded
+     * stack's amount must be overwritten. Container-mode slots leave the
+     * real amount inside the blob itself
+     * ({@code SnapshotReconstructor#COUNT_IN_BLOB}) and must NOT have
+     * {@code setAmount} called on them, or the count silently becomes 0.
+     */
+    private static @Nullable ItemStack decode(SnapshotSession session, SnapshotSlot slot) {
+        ItemStack stack = ItemSerialization.decode(slot.item().data());
+        if (stack == null) {
+            return null;
+        }
+        if (session.kind() == SnapshotSession.Kind.PLAYER) {
+            stack.setAmount(slot.count());
+        }
+        return stack;
+    }
+
+    private static @Nullable SnapshotSlot findSlot(List<SnapshotSlot> slots, int slot) {
+        for (SnapshotSlot candidate : slots) {
+            if (candidate.slot() == slot) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether {@code candidate} would fit entirely into
+     * {@code storageContents} - the 36 main-inventory slots
+     * {@link PlayerInventory#addItem} actually fills, never armor or off
+     * hand - without any partial placement.
+     *
+     * <p>Bukkit has no side-effect-free "would this fit" call, and a
+     * scratch-inventory dry run would need a live CraftBukkit
+     * implementation this module cannot spin up in a unit test. This
+     * mirrors {@code Inventory#addItem}'s documented algorithm as a pure
+     * simulation instead: first fill existing similar, non-full stacks,
+     * then empty slots. The one simplification against the real
+     * implementation is the per-slot cap - this uses only
+     * {@code ItemStack#getMaxStackSize()}, not
+     * {@code min(item cap, inventory cap)} - because a player inventory's
+     * own cap is 64 by default and effectively never lowered.
+     */
+    static boolean fits(ItemStack[] storageContents, ItemStack candidate) {
+        int remaining = candidate.getAmount();
+        int maxStack = candidate.getMaxStackSize();
+        for (ItemStack existing : storageContents) {
+            if (remaining <= 0) {
+                return true;
+            }
+            if (isEmpty(existing) || !existing.isSimilar(candidate)) {
+                continue;
+            }
+            int space = existing.getMaxStackSize() - existing.getAmount();
+            if (space > 0) {
+                remaining -= space;
+            }
+        }
+        for (ItemStack existing : storageContents) {
+            if (remaining <= 0) {
+                return true;
+            }
+            if (isEmpty(existing)) {
+                remaining -= maxStack;
+            }
+        }
+        return remaining <= 0;
+    }
+
+    private static boolean isEmpty(@Nullable ItemStack stack) {
+        return stack == null || stack.getType() == Material.AIR;
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotView.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotView.java
@@ -1,0 +1,15 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import org.bukkit.entity.Player;
+
+/**
+ * A way to show a {@link SnapshotSession} to an operator. Same split as
+ * {@code SalvageView}: the InvUI implementation exists on 1.21.x, and where
+ * there is no GUI the service prints the text listing instead, so callers
+ * treat "no view" (null) as command-only.
+ */
+public interface SnapshotView {
+
+    /** Open the session for the viewer. Called on the main thread. */
+    void open(Player viewer, SnapshotSession session);
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotViews.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotViews.java
@@ -1,0 +1,68 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.util.logging.Logger;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Decides whether this server gets the InvUI {@code /sg snapshot} GUI. Same
+ * split as {@code SalvageViews}: the bundled InvUI (1.49) is the last
+ * multi-version line and supports Minecraft 1.x (up to 1.21.x) only; 26.x
+ * needs InvUI 2 (Java 25), which we do not ship. On unsupported versions
+ * there is <b>no GUI</b> - the caller falls back to a text listing instead,
+ * deliberately, so no unverified inventory-click surface ships on a version
+ * we cannot validate it against.
+ *
+ * <p>This gate is also what keeps a 26.x server from loading any InvUI
+ * class: {@link InvUiSnapshotView} is referenced only inside the supported
+ * branch below, so its classes are never resolved on the fallback path.
+ */
+public final class SnapshotViews {
+
+    private SnapshotViews() {
+    }
+
+    /**
+     * The InvUI GUI view for this server, or {@code null} on versions InvUI
+     * does not support (the caller then serves {@code /sg snapshot} through
+     * the text-fallback listing only).
+     *
+     * @param bukkitVersion {@code Bukkit.getBukkitVersion()}, e.g.
+     *                      {@code "1.21.11-R0.1-SNAPSHOT"} or {@code "26.1.2-R0.1-SNAPSHOT"}
+     * @param takes         the shared take engine (permission, whole-stack fit
+     *                      rule, audit) - the same instance the text-fallback
+     *                      command uses, so the two surfaces cannot drift
+     */
+    @Nullable
+    public static SnapshotView guiOrNull(Plugin plugin, String bukkitVersion,
+                                          SnapshotTakes takes, Logger logger) {
+        if (!invUiSupported(bukkitVersion)) {
+            return null;
+        }
+        // Referenced only here: on an unsupported server this line never runs,
+        // so no InvUI class is resolved/loaded.
+        return new InvUiSnapshotView(plugin, takes, logger);
+    }
+
+    /** True if the bundled InvUI 1.49 supports this Minecraft version (major == 1). */
+    public static boolean invUiSupported(String bukkitVersion) {
+        if (bukkitVersion == null || bukkitVersion.isEmpty()) {
+            return false;
+        }
+        // Strip the "-R0.1-SNAPSHOT" suffix, then read the leading major number.
+        // InvUI 1.49 covers 1.14 - 1.21.x; the post-1.21 scheme starts at "26.x",
+        // which it does not support.
+        String v = bukkitVersion;
+        int dash = v.indexOf('-');
+        if (dash > 0) {
+            v = v.substring(0, dash);
+        }
+        int dot = v.indexOf('.');
+        String major = dot > 0 ? v.substring(0, dot) : v;
+        try {
+            return Integer.parseInt(major) == 1;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SqlitePlayerSnapshotStore.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/snapshot/SqlitePlayerSnapshotStore.java
@@ -1,0 +1,301 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * SQLite-backed {@link PlayerSnapshotStore}. Three tables in the shared
+ * Spyglass database, self-created in the constructor:
+ * {@code snapshot_items} interns each distinct item payload once
+ * (content-addressed by the SHA-256/16 of its raw {@code serializeAsBytes}
+ * bytes), {@code player_snapshots} holds one row per capture, and
+ * {@code player_snapshot_slots} maps a capture's occupied slots onto interned
+ * payloads. Interning is what keeps a week of "same kit every sweep" down to
+ * one payload set rather than one per snapshot.
+ *
+ * <p>Shares the record store's single write connection and read pool via
+ * {@code withWriteConnection} / {@code withReadConnection} rather than opening
+ * its own, so connection count stays bounded. Models
+ * {@code SqliteSalvageStore}; the re-intern path (a recorder retry re-saving an
+ * already-committed capture) is idempotent through {@code INSERT OR IGNORE} on
+ * the intern table and {@code INSERT OR REPLACE} on the snapshot row.
+ */
+@ApiStatus.Internal
+public final class SqlitePlayerSnapshotStore implements PlayerSnapshotStore {
+
+    private static final Logger LOGGER = Logger.getLogger(SqlitePlayerSnapshotStore.class.getName());
+
+    private final SqliteRecordStore store;
+
+    public SqlitePlayerSnapshotStore(SqliteRecordStore store) {
+        this.store = store;
+        store.withWriteConnection(conn -> {
+            try (var st = conn.createStatement()) {
+                st.execute("CREATE TABLE IF NOT EXISTS snapshot_items ("
+                        + "hash BLOB NOT NULL PRIMARY KEY, "
+                        + "material TEXT, "
+                        + "data BLOB)");
+                st.execute("CREATE TABLE IF NOT EXISTS player_snapshots ("
+                        + "id BLOB NOT NULL PRIMARY KEY, "
+                        + "player_uuid BLOB NOT NULL, "
+                        + "player_name TEXT, "
+                        + "occurred INTEGER NOT NULL, "
+                        + "cause TEXT, "
+                        + "kind INTEGER NOT NULL DEFAULT 0, "
+                        + "content_hash INTEGER NOT NULL)");
+                st.execute("CREATE INDEX IF NOT EXISTS idx_player_snapshots_player "
+                        + "ON player_snapshots(player_uuid, occurred DESC)");
+                st.execute("CREATE TABLE IF NOT EXISTS player_snapshot_slots ("
+                        + "snapshot_id BLOB NOT NULL, "
+                        + "slot INTEGER NOT NULL, "
+                        + "item_hash BLOB NOT NULL, "
+                        + "count INTEGER NOT NULL, "
+                        + "PRIMARY KEY (snapshot_id, slot))");
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void save(PlayerSnapshot snapshot) {
+        List<InternedSlot> prepared = prepare(snapshot);
+        byte[] id = uuidToBytes(snapshot.id());
+        store.withWriteConnection(conn -> {
+            boolean priorAutoCommit = conn.getAutoCommit();
+            try {
+                conn.setAutoCommit(false);
+                try (PreparedStatement intern = conn.prepareStatement(
+                        "INSERT OR IGNORE INTO snapshot_items(hash, material, data) VALUES (?, ?, ?)")) {
+                    for (InternedSlot s : prepared) {
+                        intern.setBytes(1, s.hash());
+                        intern.setString(2, s.material());
+                        intern.setBytes(3, s.data());
+                        intern.addBatch();
+                    }
+                    intern.executeBatch();
+                }
+                try (PreparedStatement snap = conn.prepareStatement(
+                        "INSERT OR REPLACE INTO player_snapshots"
+                                + "(id, player_uuid, player_name, occurred, cause, kind, content_hash) "
+                                + "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    snap.setBytes(1, id);
+                    snap.setBytes(2, uuidToBytes(snapshot.player()));
+                    snap.setString(3, snapshot.playerName());
+                    snap.setLong(4, snapshot.capturedAt().toEpochMilli());
+                    snap.setString(5, snapshot.cause());
+                    snap.setInt(6, 0); // kind: 0 = keyframe (delta rows reserved)
+                    snap.setLong(7, snapshot.contentHash());
+                    snap.executeUpdate();
+                }
+                // Re-derive the slot set from scratch so a re-save of the same id
+                // never leaves a stale slot row behind.
+                try (PreparedStatement del = conn.prepareStatement(
+                        "DELETE FROM player_snapshot_slots WHERE snapshot_id = ?")) {
+                    del.setBytes(1, id);
+                    del.executeUpdate();
+                }
+                try (PreparedStatement slot = conn.prepareStatement(
+                        "INSERT INTO player_snapshot_slots(snapshot_id, slot, item_hash, count) "
+                                + "VALUES (?, ?, ?, ?)")) {
+                    for (InternedSlot s : prepared) {
+                        slot.setBytes(1, id);
+                        slot.setInt(2, s.slot());
+                        slot.setBytes(3, s.hash());
+                        slot.setInt(4, s.count());
+                        slot.addBatch();
+                    }
+                    slot.executeBatch();
+                }
+                conn.commit();
+            } catch (SQLException ex) {
+                rollbackQuietly(conn);
+                throw ex;
+            } finally {
+                restoreAutoCommit(conn, priorAutoCommit);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant) {
+        Optional<PlayerSnapshot> result = store.withReadConnection(conn -> {
+            Header header;
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT id, player_name, occurred, cause, content_hash "
+                            + "FROM player_snapshots WHERE player_uuid = ? AND occurred <= ? "
+                            + "ORDER BY occurred DESC, id DESC LIMIT 1")) {
+                ps.setBytes(1, uuidToBytes(player));
+                ps.setLong(2, instant.toEpochMilli());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return Optional.<PlayerSnapshot>empty();
+                    }
+                    header = new Header(rs.getBytes("id"), rs.getString("player_name"),
+                            rs.getLong("occurred"), rs.getString("cause"), rs.getLong("content_hash"));
+                }
+            }
+            List<SnapshotSlot> slots = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT s.slot, s.count, i.material, i.data "
+                            + "FROM player_snapshot_slots s "
+                            + "JOIN snapshot_items i ON s.item_hash = i.hash "
+                            + "WHERE s.snapshot_id = ? ORDER BY s.slot")) {
+                ps.setBytes(1, header.id());
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        slots.add(hydrateSlot(rs));
+                    }
+                }
+            }
+            return Optional.of(new PlayerSnapshot(
+                    bytesToUuid(header.id()), player, header.playerName(),
+                    Instant.ofEpochMilli(header.occurred()), header.cause(),
+                    header.contentHash(), slots));
+        });
+        return result;
+    }
+
+    @Override
+    public OptionalLong lastContentHash(UUID player) {
+        return store.withReadConnection(conn -> {
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT content_hash FROM player_snapshots WHERE player_uuid = ? "
+                            + "ORDER BY occurred DESC, id DESC LIMIT 1")) {
+                ps.setBytes(1, uuidToBytes(player));
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? OptionalLong.of(rs.getLong(1)) : OptionalLong.empty();
+                }
+            }
+        });
+    }
+
+    @Override
+    public int prune(Instant cutoff) {
+        long cutoffMs = cutoff.toEpochMilli();
+        return store.withWriteConnection(conn -> {
+            boolean priorAutoCommit = conn.getAutoCommit();
+            try {
+                conn.setAutoCommit(false);
+                try (PreparedStatement delSlots = conn.prepareStatement(
+                        "DELETE FROM player_snapshot_slots WHERE snapshot_id IN "
+                                + "(SELECT id FROM player_snapshots WHERE occurred < ?)")) {
+                    delSlots.setLong(1, cutoffMs);
+                    delSlots.executeUpdate();
+                }
+                int removed;
+                try (PreparedStatement delSnaps = conn.prepareStatement(
+                        "DELETE FROM player_snapshots WHERE occurred < ?")) {
+                    delSnaps.setLong(1, cutoffMs);
+                    removed = delSnaps.executeUpdate();
+                }
+                // Anti-join GC: drop interned payloads no surviving slot references.
+                // The tables are small at prune cadence, so the NOT IN scan is fine.
+                try (PreparedStatement gc = conn.prepareStatement(
+                        "DELETE FROM snapshot_items WHERE hash NOT IN "
+                                + "(SELECT DISTINCT item_hash FROM player_snapshot_slots)")) {
+                    gc.executeUpdate();
+                }
+                conn.commit();
+                return removed;
+            } catch (SQLException ex) {
+                rollbackQuietly(conn);
+                throw ex;
+            } finally {
+                restoreAutoCommit(conn, priorAutoCommit);
+            }
+        });
+    }
+
+    private static SnapshotSlot hydrateSlot(ResultSet rs) throws SQLException {
+        int slot = rs.getInt("slot");
+        int count = rs.getInt("count");
+        String material = rs.getString("material");
+        byte[] data = rs.getBytes("data");
+        StoredItem item = new StoredItem(slot, material,
+                data == null ? null : Base64.getEncoder().encodeToString(data));
+        return new SnapshotSlot(slot, count, item);
+    }
+
+    private List<InternedSlot> prepare(PlayerSnapshot snapshot) {
+        List<InternedSlot> out = new ArrayList<>(snapshot.slots().size());
+        for (SnapshotSlot slot : snapshot.slots()) {
+            StoredItem item = slot.item();
+            if (item == null || item.data() == null || item.data().isBlank()) {
+                LOGGER.log(Level.WARNING,
+                        "Skipping snapshot slot {0} for {1}: no item payload to intern",
+                        new Object[]{slot.slot(), snapshot.player()});
+                continue;
+            }
+            byte[] raw = Base64.getDecoder().decode(item.data());
+            out.add(new InternedSlot(slot.slot(), slot.count(), item.material(), hash16(raw), raw));
+        }
+        return out;
+    }
+
+    private static void rollbackQuietly(Connection conn) {
+        try {
+            conn.rollback();
+        } catch (SQLException ex) {
+            LOGGER.log(Level.WARNING, "SQLite snapshot rollback failed", ex);
+        }
+    }
+
+    private static void restoreAutoCommit(Connection conn, boolean value) {
+        try {
+            conn.setAutoCommit(value);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.WARNING, "SQLite snapshot autocommit restore failed", ex);
+        }
+    }
+
+    // SHA-256 truncated to 16 bytes over the raw serializeAsBytes payload. The
+    // truncation is the content address; a 128-bit space makes an accidental
+    // collision between two distinct item stacks not a practical concern.
+    static byte[] hash16(byte[] raw) {
+        try {
+            byte[] full = MessageDigest.getInstance("SHA-256").digest(raw);
+            byte[] out = new byte[16];
+            System.arraycopy(full, 0, out, 0, 16);
+            return out;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    static byte[] uuidToBytes(UUID uuid) {
+        byte[] out = new byte[16];
+        ByteBuffer.wrap(out).putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+        return out;
+    }
+
+    static UUID bytesToUuid(byte[] bytes) {
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        return new UUID(bb.getLong(), bb.getLong());
+    }
+
+    /** One captured slot resolved to its interned payload, for the save path. */
+    private record InternedSlot(int slot, int count, String material, byte[] hash, byte[] data) {
+    }
+
+    /** The {@code player_snapshots} header row, read before its slots. */
+    private record Header(byte[] id, String playerName, long occurred, String cause, long contentHash) {
+    }
+}

--- a/spyglass/src/main/resources/config.conf
+++ b/spyglass/src/main/resources/config.conf
@@ -156,6 +156,9 @@ events {
   rollback-op = { enabled = true, past-tense = "ran" }
   # An operator extracting an item from rollback salvage via /sg inventory.
   salvage-withdraw = { enabled = true, past-tense = "took" }
+  # An operator extracting a copy of an item from a /sg snapshot view (a
+  # past-instant player inventory or container, #341).
+  snapshot-take = { enabled = true, past-tense = "took" }
 }
 
 defaults {
@@ -239,4 +242,29 @@ analytics {
   # drops. Logged every `interval` and shown by /spyglass stats.
   enabled = false
   interval = "60s"  # floored at 5s
+}
+
+snapshot {
+  players {
+    # Capture what each player is carrying, so /sg snapshot p:<name> t:<time>
+    # can show their inventory as of a past instant. Independent of the event
+    # log - crafting, consuming, trading, and plugin-given items leave no
+    # event trail a rollback could replay from, so this is the only honest
+    # source for "what were they holding".
+    #
+    # Cost: one small write per player every `interval`, skipped entirely
+    # when the inventory hasn't changed since the last write (dirty-checked
+    # by content hash), plus one on join/quit/death/world-change. Item
+    # payloads are interned by content, so a player's steady kit costs one
+    # stored blob set, not one per snapshot. false stops capturing entirely.
+    enabled = true
+
+    # How often the background sweep captures every online player's
+    # inventory, on top of the join/quit/death/world-change captures.
+    interval = "5m"
+
+    # How long snapshot rows are kept before deletion. Independent of
+    # storage.retention. Units s/m/h/d/w; "0"/"never" = forever.
+    retention = "30d"
+  }
 }

--- a/spyglass/src/main/resources/plugin.yml
+++ b/spyglass/src/main/resources/plugin.yml
@@ -37,6 +37,16 @@ permissions:
   spyglass.migrate:
     description: Migrate Spyglass records between storage backends.
     default: op
+  # /sg snapshot - view a player inventory or container as of a past
+  # instant. Viewing and taking are separate nodes (#341), same split as
+  # spyglass.salvage: a view-only grant is legitimate on its own.
+  spyglass.snapshot:
+    default: op
+  # Take a copy of an item out of a snapshot view. Gates BOTH surfaces
+  # (the GUI re-checks it per click, the text-fallback take command
+  # checks it too) - independent of spyglass.snapshot.
+  spyglass.snapshot.take:
+    default: op
 
 # Externalized at runtime via Paper's library loader (Maven Central, cached
 # under <server>/libraries/); versions injected from Gradle at build time. The

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SnapshotServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/command/service/SnapshotServiceTest.java
@@ -1,0 +1,220 @@
+package net.medievalrp.spyglass.plugin.command.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.param.ParamParseException;
+import net.medievalrp.spyglass.plugin.snapshot.Reconstruction;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSession;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSlot;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the two pure pieces of {@link SnapshotService}: the restricted
+ * {@code /sg snapshot} query-string parser (no default injection, a much
+ * smaller key set than {@code QueryStringParser}) and the double-chest
+ * merge helper. Everything else (target resolution, store reads, the GUI
+ * hand-off) touches live Bukkit/store state and is exercised by the bot
+ * probe instead.
+ */
+class SnapshotServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
+
+    // ---- parse(): required t: -------------------------------------------
+
+    @Test
+    void tIsRequired() {
+        assertThatThrownBy(() -> SnapshotService.parse("p:Steve", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("t:");
+    }
+
+    @Test
+    void tAloneIsContainerModeWithNoPlayerName() throws Exception {
+        SnapshotService.ParsedQuery parsed = SnapshotService.parse("t:1h", NOW);
+        assertThat(parsed.playerMode()).isFalse();
+        assertThat(parsed.hasTrg()).isFalse();
+        assertThat(parsed.asOf()).isEqualTo(NOW.minusSeconds(3600));
+    }
+
+    @Test
+    void invalidDurationIsRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:notaduration", NOW))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void duplicateTIsRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h t:2h", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Duplicate");
+    }
+
+    // ---- parse(): key rejection ------------------------------------------
+
+    @Test
+    void unknownKeyIsRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h r:50", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("not a snapshot key: r");
+    }
+
+    @Test
+    void bareTokenWithNoColonIsRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h Steve", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("not a snapshot key: Steve");
+    }
+
+    @Test
+    void flagsAreRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h -g", NOW))
+                .isInstanceOf(ParamParseException.class);
+    }
+
+    @Test
+    void noDefaultRadiusOrRangeIsEverInjected() throws Exception {
+        // Only what was typed comes back - no r:/t-range machinery like
+        // QueryStringParser's default-time or default-radius predicates.
+        SnapshotService.ParsedQuery parsed = SnapshotService.parse("t:1h", NOW);
+        assertThat(parsed.x()).isNull();
+        assertThat(parsed.worldName()).isNull();
+    }
+
+    // ---- parse(): trg parsing --------------------------------------------
+
+    @Test
+    void trgParsesExactCoordinates() throws Exception {
+        SnapshotService.ParsedQuery parsed = SnapshotService.parse("t:1h trg:100,64,-200", NOW);
+        assertThat(parsed.hasTrg()).isTrue();
+        assertThat(parsed.x()).isEqualTo(100);
+        assertThat(parsed.y()).isEqualTo(64);
+        assertThat(parsed.z()).isEqualTo(-200);
+    }
+
+    @Test
+    void trgRejectsNonCoordinateValues() {
+        // Unlike search's trg:, snapshot's has no substring-match fallback -
+        // it is coordinates or nothing.
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h trg:chest", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("trg:");
+    }
+
+    @Test
+    void wRequiresTrg() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h w:world_nether", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("w:");
+    }
+
+    @Test
+    void wWithTrgParsesFine() throws Exception {
+        SnapshotService.ParsedQuery parsed = SnapshotService.parse("t:1h trg:1,2,3 w:world_nether", NOW);
+        assertThat(parsed.worldName()).isEqualTo("world_nether");
+    }
+
+    // ---- parse(): p exclusivity -------------------------------------------
+
+    @Test
+    void pAcceptsExactlyOneBareName() throws Exception {
+        SnapshotService.ParsedQuery parsed = SnapshotService.parse("t:1h p:Steve", NOW);
+        assertThat(parsed.playerMode()).isTrue();
+        assertThat(parsed.playerName()).isEqualTo("Steve");
+    }
+
+    @Test
+    void pRejectsCommaSeparatedNames() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h p:Steve,Alex", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("p:");
+    }
+
+    @Test
+    void pRejectsExcludeSyntax() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h p:!Steve", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("p:");
+    }
+
+    @Test
+    void pAndTrgCannotBeCombined() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h p:Steve trg:1,2,3", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("p:")
+                .hasMessageContaining("trg:");
+    }
+
+    @Test
+    void duplicatePIsRejected() {
+        assertThatThrownBy(() -> SnapshotService.parse("t:1h p:Steve p:Alex", NOW))
+                .isInstanceOf(ParamParseException.class)
+                .hasMessageContaining("Duplicate");
+    }
+
+    // ---- mergeHalves(): double-chest offset logic -------------------------
+
+    private static StoredItem item(int slot, String material) {
+        return new StoredItem(slot, material, "blob-" + slot);
+    }
+
+    @Test
+    void mergeOffsetsRightHalfSlotsByLeftSize() {
+        Reconstruction left = new Reconstruction(
+                List.of(new SnapshotSlot(0, 0, item(0, "DIAMOND"))),
+                SnapshotSession.Certainty.CERTAIN, List.of(), List.of());
+        Reconstruction right = new Reconstruction(
+                List.of(new SnapshotSlot(0, 0, item(0, "GOLD_INGOT")), new SnapshotSlot(5, 0, item(5, "IRON_INGOT"))),
+                SnapshotSession.Certainty.CERTAIN, List.of(), List.of());
+
+        Reconstruction merged = SnapshotService.mergeHalves(left, 27, right);
+
+        assertThat(merged.slots()).hasSize(3);
+        assertThat(merged.slots().stream().map(SnapshotSlot::slot)).containsExactlyInAnyOrder(0, 27, 32);
+        assertThat(merged.certain()).isTrue();
+    }
+
+    @Test
+    void mergeCertaintyIsWorstOfBothHalves() {
+        Reconstruction certainLeft = new Reconstruction(List.of(), SnapshotSession.Certainty.CERTAIN, List.of(), List.of());
+        Reconstruction uncertainRight = new Reconstruction(List.of(), SnapshotSession.Certainty.UNCERTAIN,
+                List.of("container no longer present"), List.of());
+
+        Reconstruction merged = SnapshotService.mergeHalves(certainLeft, 27, uncertainRight);
+
+        assertThat(merged.certain()).isFalse();
+        assertThat(merged.notes()).containsExactly("right half: container no longer present");
+    }
+
+    @Test
+    void mergeOffsetsMismatchSlotIndices() {
+        Reconstruction.Mismatch rightMismatch =
+                new Reconstruction.Mismatch(3, Reconstruction.Mismatch.Kind.END_STATE, "empty", "DIRT");
+        Reconstruction left = new Reconstruction(List.of(), SnapshotSession.Certainty.CERTAIN, List.of(), List.of());
+        Reconstruction right = new Reconstruction(List.of(), SnapshotSession.Certainty.UNCERTAIN,
+                List.of("mismatch"), List.of(rightMismatch));
+
+        Reconstruction merged = SnapshotService.mergeHalves(left, 27, right);
+
+        assertThat(merged.mismatches()).hasSize(1);
+        assertThat(merged.mismatches().get(0).slot()).isEqualTo(30);
+        assertThat(merged.mismatches().get(0).expected()).isEqualTo("empty");
+        assertThat(merged.mismatches().get(0).actual()).isEqualTo("DIRT");
+    }
+
+    @Test
+    void mergePreservesBothHalvesNotesInOrder() {
+        Reconstruction left = new Reconstruction(List.of(), SnapshotSession.Certainty.UNCERTAIN,
+                List.of("left note"), List.of());
+        Reconstruction right = new Reconstruction(List.of(), SnapshotSession.Certainty.UNCERTAIN,
+                List.of("right note"), List.of());
+
+        Reconstruction merged = SnapshotService.mergeHalves(left, 27, right);
+
+        assertThat(merged.notes()).containsExactly("left half: left note", "right half: right note");
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/config/LazyOperatorConfigTest.java
@@ -268,4 +268,58 @@ class LazyOperatorConfigTest {
         assertThat(config.enabled("break")).isTrue();
         assertThat(config.pastTense("break")).isEqualTo("break");
     }
+
+    @Test
+    void snapshotDefaultsWhenTheSectionIsAbsent(@TempDir Path dataFolder) throws Exception {
+        // #341: an upgraded config with no snapshot block still captures -
+        // enabled defaults true, same precedent as worldedit.enabled.
+        write(dataFolder, "database {\n  backend = \"sqlite\"\n}\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.snapshot().players().enabled()).isTrue();
+        assertThat(config.snapshot().players().interval().seconds()).isEqualTo(5L * 60L);
+        assertThat(config.snapshot().players().retention().seconds())
+                .isEqualTo(30L * 24L * 60L * 60L);
+    }
+
+    @Test
+    void snapshotReadsExplicitOverrides(@TempDir Path dataFolder) throws Exception {
+        write(dataFolder, "snapshot {\n"
+                + "  players {\n"
+                + "    enabled = false\n"
+                + "    interval = \"10m\"\n"
+                + "    retention = \"7d\"\n"
+                + "  }\n"
+                + "}\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.snapshot().players().enabled()).isFalse();
+        assertThat(config.snapshot().players().interval().seconds()).isEqualTo(10L * 60L);
+        assertThat(config.snapshot().players().retention().seconds())
+                .isEqualTo(7L * 24L * 60L * 60L);
+    }
+
+    @Test
+    void snapshotRetentionUnparseableHardFailsLikeStorageRetention(@TempDir Path dataFolder)
+            throws Exception {
+        // Deliberate hard-fail, same as storage.retention: snapshot.players.retention
+        // drives deletion of player-inventory history, so a typo must not silently
+        // fall back to a guessed default.
+        write(dataFolder, "snapshot { players { retention = \"banana\" } }\n");
+
+        assertThatThrownBy(() -> SpyglassConfig.load(pluginIn(dataFolder)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void snapshotRetentionAcceptsKeepForeverTokens(@TempDir Path dataFolder) throws Exception {
+        write(dataFolder, "snapshot { players { retention = \"never\" } }\n");
+
+        SpyglassConfig config = SpyglassConfig.load(pluginIn(dataFolder));
+
+        assertThat(config.snapshot().players().retention().seconds())
+                .isEqualTo(net.medievalrp.spyglass.plugin.storage.RetentionPolicy.NEVER_SECONDS);
+    }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/ClickHousePlayerSnapshotStoreIT.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/ClickHousePlayerSnapshotStoreIT.java
@@ -1,0 +1,202 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.EventIds;
+import net.medievalrp.spyglass.plugin.storage.ClickHouseRecordStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+
+/**
+ * {@link ClickHousePlayerSnapshotStore} against a real ClickHouse. The record
+ * store bootstraps the schema (including the two snapshot tables this store
+ * reads), then we exercise save/read, latest-at-or-before selection, the
+ * synchronous read-your-writes contract, intern dedupe (asserted over the
+ * intern table with the driver), and prune. Each test uses its own player /
+ * unique payloads, so no cross-test wipe is needed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ClickHousePlayerSnapshotStoreIT {
+
+    private static final HexFormat HEX = HexFormat.of().withUpperCase();
+
+    private ClickHouseContainer container;
+    private ClickHouseRecordStore store;
+    private ClickHousePlayerSnapshotStore snapStore;
+
+    @BeforeAll
+    void setup() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        container = new ClickHouseContainer("clickhouse/clickhouse-server:24.8-alpine");
+        container.start();
+        store = new ClickHouseRecordStore(
+                container.getHost(),
+                container.getMappedPort(8123),
+                "spyglass_it",
+                "event_records_it",
+                container.getUsername(),
+                container.getPassword(),
+                false);
+        snapStore = new ClickHousePlayerSnapshotStore(store.client(), "spyglass_it");
+    }
+
+    @AfterAll
+    void teardown() {
+        if (store != null) {
+            store.close();
+        }
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    // --- helpers ---------------------------------------------------
+
+    private static byte[] payload(String seed) {
+        return (seed + ":" + UUID.randomUUID()).getBytes();
+    }
+
+    private static StoredItem item(int slot, String material, byte[] raw) {
+        return new StoredItem(slot, material, Base64.getEncoder().encodeToString(raw));
+    }
+
+    private static PlayerSnapshot snapshot(UUID player, Instant at, long contentHash,
+                                           List<SnapshotSlot> slots) {
+        return new PlayerSnapshot(EventIds.newId(), player, "Tester", at,
+                PlayerSnapshot.CAUSE_SWEEP, contentHash, slots);
+    }
+
+    private static String expectedHex(byte[] raw) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(raw);
+            return HEX.formatHex(Arrays.copyOf(digest, 16));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private long internCount(String hex) {
+        return store.client().queryAll(
+                "SELECT count() AS c FROM `spyglass_it`.`snapshot_items` FINAL "
+                        + "WHERE hex(hash) = '" + hex + "'").get(0).getLong("c");
+    }
+
+    private long snapshotCount(UUID player) {
+        return store.client().queryAll(
+                "SELECT count() AS c FROM `spyglass_it`.`player_snapshots` FINAL "
+                        + "WHERE player_uuid = toUUID('" + player + "')").get(0).getLong("c");
+    }
+
+    // --- tests -----------------------------------------------------
+
+    @Test
+    void saveAndReadRoundtrip() {
+        UUID player = UUID.randomUUID();
+        byte[] sword = payload("sword");
+        byte[] cobble = payload("cobble");
+        Instant at = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(player, at, 0xABCDEF12L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:diamond_sword", sword)),
+                new SnapshotSlot(9, 32, item(9, "minecraft:cobblestone", cobble)))));
+
+        Optional<PlayerSnapshot> read = snapStore.latestAtOrBefore(player, at.plusSeconds(1));
+        assertThat(read).isPresent();
+        PlayerSnapshot snap = read.get();
+        assertThat(snap.player()).isEqualTo(player);
+        assertThat(snap.cause()).isEqualTo(PlayerSnapshot.CAUSE_SWEEP);
+        assertThat(snap.contentHash()).isEqualTo(0xABCDEF12L);
+        assertThat(snap.slots()).hasSize(2);
+
+        SnapshotSlot s0 = snap.slots().stream().filter(s -> s.slot() == 0).findFirst().orElseThrow();
+        assertThat(s0.count()).isEqualTo(1);
+        assertThat(s0.item().material()).isEqualTo("minecraft:diamond_sword");
+        assertThat(s0.item().data()).isEqualTo(Base64.getEncoder().encodeToString(sword));
+
+        SnapshotSlot s9 = snap.slots().stream().filter(s -> s.slot() == 9).findFirst().orElseThrow();
+        assertThat(s9.count()).isEqualTo(32);
+        assertThat(s9.item().material()).isEqualTo("minecraft:cobblestone");
+        assertThat(s9.item().data()).isEqualTo(Base64.getEncoder().encodeToString(cobble));
+    }
+
+    @Test
+    void latestAtOrBeforeSelectsNewest() {
+        UUID player = UUID.randomUUID();
+        Instant t1 = Instant.now().minusSeconds(60).truncatedTo(ChronoUnit.MILLIS);
+        Instant t2 = Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(player, t1, 111L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:stone", payload("s1"))))));
+        snapStore.save(snapshot(player, t2, 222L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:dirt", payload("s2"))))));
+
+        assertThat(snapStore.latestAtOrBefore(player, t2.plusSeconds(5)).orElseThrow().contentHash())
+                .isEqualTo(222L);
+        assertThat(snapStore.latestAtOrBefore(player, t2.minusSeconds(5)).orElseThrow().contentHash())
+                .isEqualTo(111L);
+        assertThat(snapStore.latestAtOrBefore(player, t1.minusSeconds(5))).isEmpty();
+    }
+
+    @Test
+    void readYourWritesImmediatelyAfterSave() {
+        UUID player = UUID.randomUUID();
+        Instant at = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(player, at, 7L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:torch", payload("torch"))))));
+        // No sleep: the synchronous insert must be visible immediately.
+        assertThat(snapStore.latestAtOrBefore(player, at)).isPresent();
+        assertThat(snapStore.lastContentHash(player)).hasValue(7L);
+    }
+
+    @Test
+    void internDedupesAcrossSnapshotsAndDoubleInternDoesNotThrow() {
+        byte[] shared = payload("shared-kit");
+        String hex = expectedHex(shared);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+
+        assertThatCode(() -> {
+            snapStore.save(snapshot(a, Instant.now().truncatedTo(ChronoUnit.MILLIS), 1L, List.of(
+                    new SnapshotSlot(0, 1, item(0, "minecraft:shield", shared)))));
+            // Second snapshot re-interns the identical payload: must not throw.
+            snapStore.save(snapshot(b, Instant.now().truncatedTo(ChronoUnit.MILLIS), 2L, List.of(
+                    new SnapshotSlot(0, 1, item(0, "minecraft:shield", shared)))));
+        }).doesNotThrowAnyException();
+
+        assertThat(internCount(hex)).as("payload interned exactly once").isEqualTo(1L);
+    }
+
+    @Test
+    void pruneRemovesOldSnapshotRows() {
+        UUID oldPlayer = UUID.randomUUID();
+        UUID newPlayer = UUID.randomUUID();
+        Instant old = Instant.now().minus(40, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+        Instant fresh = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(oldPlayer, old, 1L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:stone", payload("old"))))));
+        snapStore.save(snapshot(newPlayer, fresh, 2L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:dirt", payload("new"))))));
+
+        int removed = snapStore.prune(Instant.now().minus(30, ChronoUnit.DAYS));
+        assertThat(removed).isEqualTo(1);
+        assertThat(snapshotCount(oldPlayer)).as("old snapshot rows gone").isZero();
+        assertThat(snapStore.latestAtOrBefore(oldPlayer, fresh)).isEmpty();
+        assertThat(snapStore.latestAtOrBefore(newPlayer, fresh)).isPresent();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/MariaDbPlayerSnapshotStoreIT.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/MariaDbPlayerSnapshotStoreIT.java
@@ -1,0 +1,229 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.MariaDbRecordStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Covers the MariaDB {@link PlayerSnapshotStore} (#341) against a real InnoDB
+ * engine via Testcontainers. Mirrors {@code SqlitePlayerSnapshotStoreTest}
+ * plus the recorder-retry case (a second {@code save} of an already-committed
+ * capture) that only ever failed live with a Duplicate entry before the
+ * upsert idiom landed. Requires Docker; assume-skips cleanly without it.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MariaDbPlayerSnapshotStoreIT {
+
+    private MariaDBContainer<?> container;
+    private String host;
+    private int port;
+    private String db;
+    private String user;
+    private String pw;
+    private MariaDbRecordStore store;
+    private MariaDbPlayerSnapshotStore snapshots;
+
+    @BeforeAll
+    void setup() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        container = new MariaDBContainer<>(DockerImageName.parse("mariadb:11"));
+        container.start();
+        host = container.getHost();
+        port = container.getFirstMappedPort();
+        db = container.getDatabaseName();
+        user = container.getUsername();
+        pw = container.getPassword();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @BeforeEach
+    void fresh() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(jdbcUrl(), user, pw);
+             Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS player_snapshot_slots");
+            st.execute("DROP TABLE IF EXISTS player_snapshots");
+            st.execute("DROP TABLE IF EXISTS snapshot_items");
+            st.execute("DROP TABLE IF EXISTS records");
+            st.execute("DROP TABLE IF EXISTS dict");
+            st.execute("DROP TABLE IF EXISTS uuids");
+        }
+        store = new MariaDbRecordStore(host, port, db, user, pw, false, 3600L);
+        snapshots = new MariaDbPlayerSnapshotStore(store);
+    }
+
+    @AfterEach
+    void close() {
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    @Test
+    void saveReadRoundtripKeepsSlotFidelityAndMaterial() {
+        UUID player = UUID.randomUUID();
+        PlayerSnapshot snap = new PlayerSnapshot(UUID.randomUUID(), player, "Alice",
+                Instant.ofEpochMilli(2_000_000L), PlayerSnapshot.CAUSE_SWEEP, 0xABCDL,
+                List.of(slot(0, 64, "COBBLESTONE", "cobble-payload"),
+                        slot(40, 1, "SHIELD", "shield-payload")));
+        snapshots.save(snap);
+
+        PlayerSnapshot got = snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(3_000_000L)).orElseThrow();
+        assertThat(got.id()).isEqualTo(snap.id());
+        assertThat(got.player()).isEqualTo(player);
+        assertThat(got.playerName()).isEqualTo("Alice");
+        assertThat(got.cause()).isEqualTo(PlayerSnapshot.CAUSE_SWEEP);
+        assertThat(got.contentHash()).isEqualTo(0xABCDL);
+        assertThat(got.capturedAt()).isEqualTo(Instant.ofEpochMilli(2_000_000L));
+        assertThat(got.slots()).hasSize(2);
+
+        SnapshotSlot s0 = got.slots().get(0);
+        assertThat(s0.slot()).isEqualTo(0);
+        assertThat(s0.count()).isEqualTo(64);
+        assertThat(s0.item().material()).isEqualTo("COBBLESTONE");
+        assertThat(s0.item().data()).isEqualTo(base64("cobble-payload"));
+
+        SnapshotSlot s1 = got.slots().get(1);
+        assertThat(s1.slot()).isEqualTo(40);
+        assertThat(s1.count()).isEqualTo(1);
+        assertThat(s1.item().material()).isEqualTo("SHIELD");
+        assertThat(s1.item().data()).isEqualTo(base64("shield-payload"));
+    }
+
+    @Test
+    void latestAtOrBeforePicksTheCorrectRow() {
+        UUID player = UUID.randomUUID();
+        snapshots.save(snapshot(player, "P", 1_000L, 111L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "DIRT", "d1")));
+        snapshots.save(snapshot(player, "P", 2_000L, 222L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIRT", "d2")));
+        snapshots.save(snapshot(player, "P", 3_000L, 333L, PlayerSnapshot.CAUSE_QUIT,
+                slot(0, 1, "DIRT", "d3")));
+
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(2_500L)).orElseThrow()
+                .contentHash()).isEqualTo(222L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(3_000L)).orElseThrow()
+                .contentHash()).isEqualTo(333L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(500L))).isEmpty();
+    }
+
+    @Test
+    void internDedupesSharedPayloadsAcrossSnapshots() throws SQLException {
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        snapshots.save(snapshot(a, "A", 1_000L, 1L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIAMOND", "shared"), slot(1, 1, "GOLD_INGOT", "gold")));
+        snapshots.save(snapshot(b, "B", 1_000L, 2L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIAMOND", "shared"), slot(1, 1, "IRON_INGOT", "iron")));
+
+        assertThat(countItems()).isEqualTo(3L);
+    }
+
+    @Test
+    void reSaveOfCommittedCaptureIsIdempotent() throws SQLException {
+        UUID player = UUID.randomUUID();
+        PlayerSnapshot snap = snapshot(player, "P", 5_000L, 9L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "NETHERITE_INGOT", "ning"), slot(1, 1, "GOLD_INGOT", "gold"));
+        snapshots.save(snap);
+
+        // The recorder retry re-interns already-committed payloads and re-inserts
+        // the same snapshot id; a plain INSERT would throw Duplicate entry here.
+        assertThatCode(() -> snapshots.save(snap)).doesNotThrowAnyException();
+
+        assertThat(countItems()).isEqualTo(2L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(6_000L)).orElseThrow()
+                .slots()).hasSize(2);
+    }
+
+    @Test
+    void pruneRemovesOldRowsAndOrphanedBlobsButKeepsReferencedOnes() throws SQLException {
+        UUID player = UUID.randomUUID();
+        snapshots.save(snapshot(player, "P", 1_000L, 1L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "STONE", "X"), slot(1, 1, "GLASS", "Y")));
+        snapshots.save(snapshot(player, "P", 10_000L, 2L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "GLASS", "Y"), slot(1, 1, "SAND", "Z")));
+        assertThat(countItems()).isEqualTo(3L);
+
+        int removed = snapshots.prune(Instant.ofEpochMilli(5_000L));
+        assertThat(removed).isEqualTo(1);
+
+        assertThat(countItems()).isEqualTo(2L);
+
+        PlayerSnapshot survivor = snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(20_000L)).orElseThrow();
+        assertThat(survivor.contentHash()).isEqualTo(2L);
+        assertThat(survivor.slots()).extracting(sl -> sl.item().data())
+                .containsExactly(base64("Y"), base64("Z"));
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(1_000L))).isEmpty();
+    }
+
+    @Test
+    void lastContentHashReturnsNewest() {
+        UUID player = UUID.randomUUID();
+        assertThat(snapshots.lastContentHash(player)).isEmpty();
+
+        snapshots.save(snapshot(player, "P", 1_000L, 111L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "DIRT", "a")));
+        snapshots.save(snapshot(player, "P", 2_000L, 222L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIRT", "b")));
+
+        assertThat(snapshots.lastContentHash(player)).hasValue(222L);
+    }
+
+    // ----- helpers -----
+
+    private String jdbcUrl() {
+        return "jdbc:mariadb://" + host + ":" + port + "/" + db;
+    }
+
+    private long countItems() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(jdbcUrl(), user, pw);
+             Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM snapshot_items")) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static PlayerSnapshot snapshot(UUID player, String name, long occurredMs,
+                                           long contentHash, String cause, SnapshotSlot... slots) {
+        return new PlayerSnapshot(UUID.randomUUID(), player, name,
+                Instant.ofEpochMilli(occurredMs), cause, contentHash, List.of(slots));
+    }
+
+    private static SnapshotSlot slot(int slot, int count, String material, String payload) {
+        return new SnapshotSlot(slot, count, new StoredItem(slot, material, base64(payload)));
+    }
+
+    private static String base64(String payload) {
+        return Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/MongoPlayerSnapshotStoreIT.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/MongoPlayerSnapshotStoreIT.java
@@ -1,0 +1,204 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.EventIds;
+import net.medievalrp.spyglass.plugin.storage.IndexManager;
+import net.medievalrp.spyglass.plugin.storage.MongoRecordStore;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * {@link MongoPlayerSnapshotStore} against a real Mongo: save/read roundtrip
+ * with blob hydration, latest-at-or-before selection, intern dedupe asserted
+ * with the driver over the intern collection, double-intern no-throw, and
+ * prune's orphan GC (unreferenced payloads dropped, shared ones kept). Each
+ * test uses its own player / unique payloads, so no cross-test wipe is needed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MongoPlayerSnapshotStoreIT {
+
+    private MongoDBContainer container;
+    private MongoClient rawClient;
+    private MongoRecordStore store;
+    private MongoPlayerSnapshotStore snapStore;
+
+    @BeforeAll
+    void setup() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable())
+                .as("docker not available")
+                .isTrue();
+        container = new MongoDBContainer("mongo:7.0");
+        container.start();
+        String uri = container.getReplicaSetUrl();
+        rawClient = MongoClients.create(uri);
+        store = new MongoRecordStore(uri, "IT", "EventRecords", new IndexManager());
+        snapStore = new MongoPlayerSnapshotStore(store.database(), store.codecRegistry());
+    }
+
+    @AfterAll
+    void teardown() {
+        if (store != null) {
+            store.close();
+        }
+        if (rawClient != null) {
+            rawClient.close();
+        }
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    // --- helpers ---------------------------------------------------
+
+    private MongoCollection<Document> itemsCollection() {
+        return store.database().getCollection("snapshot_items");
+    }
+
+    private MongoCollection<Document> snapshotsCollection() {
+        return store.database().getCollection("player_snapshots");
+    }
+
+    private static byte[] payload(String seed) {
+        return (seed + ":" + UUID.randomUUID()).getBytes();
+    }
+
+    private static StoredItem item(int slot, String material, byte[] raw) {
+        return new StoredItem(slot, material, Base64.getEncoder().encodeToString(raw));
+    }
+
+    private static PlayerSnapshot snapshot(UUID player, Instant at, long contentHash,
+                                           List<SnapshotSlot> slots) {
+        return new PlayerSnapshot(EventIds.newId(), player, "Tester", at,
+                PlayerSnapshot.CAUSE_SWEEP, contentHash, slots);
+    }
+
+    private static Binary hash(byte[] raw) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(raw);
+            return new Binary(Arrays.copyOf(digest, 16));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private long internCount(byte[] raw) {
+        return itemsCollection().countDocuments(Filters.eq("_id", hash(raw)));
+    }
+
+    // --- tests -----------------------------------------------------
+
+    @Test
+    void saveAndReadRoundtrip() {
+        UUID player = UUID.randomUUID();
+        byte[] sword = payload("sword");
+        byte[] cobble = payload("cobble");
+        Instant at = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(player, at, 0xABCDEF12L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:diamond_sword", sword)),
+                new SnapshotSlot(9, 32, item(9, "minecraft:cobblestone", cobble)))));
+
+        Optional<PlayerSnapshot> read = snapStore.latestAtOrBefore(player, at.plusSeconds(1));
+        assertThat(read).isPresent();
+        PlayerSnapshot snap = read.get();
+        assertThat(snap.player()).isEqualTo(player);
+        assertThat(snap.cause()).isEqualTo(PlayerSnapshot.CAUSE_SWEEP);
+        assertThat(snap.contentHash()).isEqualTo(0xABCDEF12L);
+        assertThat(snap.slots()).hasSize(2);
+
+        SnapshotSlot s0 = snap.slots().stream().filter(s -> s.slot() == 0).findFirst().orElseThrow();
+        assertThat(s0.count()).isEqualTo(1);
+        assertThat(s0.item().material()).isEqualTo("minecraft:diamond_sword");
+        assertThat(s0.item().data()).isEqualTo(Base64.getEncoder().encodeToString(sword));
+
+        SnapshotSlot s9 = snap.slots().stream().filter(s -> s.slot() == 9).findFirst().orElseThrow();
+        assertThat(s9.count()).isEqualTo(32);
+        assertThat(s9.item().material()).isEqualTo("minecraft:cobblestone");
+        assertThat(s9.item().data()).isEqualTo(Base64.getEncoder().encodeToString(cobble));
+
+        assertThat(snapStore.lastContentHash(player)).hasValue(0xABCDEF12L);
+    }
+
+    @Test
+    void latestAtOrBeforeSelectsNewest() {
+        UUID player = UUID.randomUUID();
+        Instant t1 = Instant.now().minusSeconds(60).truncatedTo(ChronoUnit.MILLIS);
+        Instant t2 = Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.MILLIS);
+        snapStore.save(snapshot(player, t1, 111L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:stone", payload("s1"))))));
+        snapStore.save(snapshot(player, t2, 222L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:dirt", payload("s2"))))));
+
+        assertThat(snapStore.latestAtOrBefore(player, t2.plusSeconds(5)).orElseThrow().contentHash())
+                .isEqualTo(222L);
+        assertThat(snapStore.latestAtOrBefore(player, t2.minusSeconds(5)).orElseThrow().contentHash())
+                .isEqualTo(111L);
+        assertThat(snapStore.latestAtOrBefore(player, t1.minusSeconds(5))).isEmpty();
+    }
+
+    @Test
+    void internDedupesAcrossSnapshotsAndDoubleInternDoesNotThrow() {
+        byte[] shared = payload("shared-kit");
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+
+        assertThatCode(() -> {
+            snapStore.save(snapshot(a, Instant.now().truncatedTo(ChronoUnit.MILLIS), 1L, List.of(
+                    new SnapshotSlot(0, 1, item(0, "minecraft:shield", shared)))));
+            // Second snapshot re-interns the identical payload: must not throw.
+            snapStore.save(snapshot(b, Instant.now().truncatedTo(ChronoUnit.MILLIS), 2L, List.of(
+                    new SnapshotSlot(0, 1, item(0, "minecraft:shield", shared)))));
+        }).doesNotThrowAnyException();
+
+        assertThat(internCount(shared)).as("payload interned exactly once").isEqualTo(1L);
+    }
+
+    @Test
+    void pruneOrphanGcsUnreferencedPayloadsButKeepsShared() {
+        UUID oldPlayer = UUID.randomUUID();
+        UUID newPlayer = UUID.randomUUID();
+        byte[] orphan = payload("orphan");   // only the old snapshot references it
+        byte[] shared = payload("shared");   // both snapshots reference it
+        byte[] kept = payload("kept");       // only the new snapshot references it
+        Instant old = Instant.now().minus(40, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+        Instant fresh = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+        snapStore.save(snapshot(oldPlayer, old, 1L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:stone", orphan)),
+                new SnapshotSlot(1, 1, item(1, "minecraft:shield", shared)))));
+        snapStore.save(snapshot(newPlayer, fresh, 2L, List.of(
+                new SnapshotSlot(0, 1, item(0, "minecraft:dirt", kept)),
+                new SnapshotSlot(1, 1, item(1, "minecraft:shield", shared)))));
+
+        int removed = snapStore.prune(Instant.now().minus(30, ChronoUnit.DAYS));
+
+        assertThat(removed).isEqualTo(1);
+        assertThat(snapshotsCollection().countDocuments(Filters.eq("player", oldPlayer)))
+                .as("old snapshot doc gone").isZero();
+        assertThat(snapStore.latestAtOrBefore(newPlayer, fresh)).isPresent();
+        assertThat(internCount(orphan)).as("unreferenced payload GC'd").isZero();
+        assertThat(internCount(shared)).as("still-referenced payload kept").isEqualTo(1L);
+        assertThat(internCount(kept)).as("live snapshot's payload kept").isEqualTo(1L);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotServiceTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/PlayerSnapshotServiceTest.java
@@ -1,0 +1,269 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import net.medievalrp.spyglass.api.util.Duration;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link PlayerSnapshotService} capture behavior: count normalization, the
+ * dirty-hash skip, cause labeling, and the quit-time cache eviction.
+ *
+ * <p>{@code ItemStack.serializeAsBytes()} is a real CraftBukkit call that
+ * can't run under a plain Mockito stack, so every test injects a fake
+ * serializer via the package-private constructor - the production
+ * constructor still wires the real {@code ItemStack::serializeAsBytes}. The
+ * executor is a same-thread {@link DirectExecutorService} so a capture's
+ * off-main work has completed by the time {@code capture()} returns, with no
+ * latches or timeouts needed.
+ */
+class PlayerSnapshotServiceTest {
+
+    // Keys purely off material: production normalizes amount to 1 before
+    // serializing, so two stacks of the same material always produce the
+    // same "payload" here, exactly like the real serializeAsBytes would for
+    // two otherwise-identical stacks differing only in count.
+    private static final Function<ItemStack, byte[]> FAKE_SERIALIZER =
+            stack -> stack.getType().name().getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void countNormalizationProducesSamePayloadWithDifferentCounts() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+
+        Player alice = player(UUID.randomUUID(), "Alice", inventoryOf(stack(Material.DIAMOND, 5)));
+        Player bob = player(UUID.randomUUID(), "Bob", inventoryOf(stack(Material.DIAMOND, 64)));
+
+        service.capture(alice, PlayerSnapshot.CAUSE_SWEEP);
+        service.capture(bob, PlayerSnapshot.CAUSE_SWEEP);
+
+        assertThat(store.saved).hasSize(2);
+        SnapshotSlot aliceSlot = store.saved.get(0).slots().get(0);
+        SnapshotSlot bobSlot = store.saved.get(1).slots().get(0);
+        assertThat(aliceSlot.item().data())
+                .as("normalized payload must not depend on stack size")
+                .isEqualTo(bobSlot.item().data());
+        assertThat(aliceSlot.count()).isEqualTo(5);
+        assertThat(bobSlot.count()).isEqualTo(64);
+    }
+
+    @Test
+    void identicalInventoryTwiceSkipsTheSecondSave() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+        Player steve = player(UUID.randomUUID(), "Steve", inventoryOf(stack(Material.STONE, 10)));
+
+        service.capture(steve, PlayerSnapshot.CAUSE_JOIN);
+        service.capture(steve, PlayerSnapshot.CAUSE_SWEEP);
+
+        assertThat(store.saved)
+                .as("dirty-equal capture must skip the write entirely")
+                .hasSize(1);
+    }
+
+    @Test
+    void hashChangesWhenASlotChanges() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+        UUID uuid = UUID.randomUUID();
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        Player steve = mockPlayer(uuid, "Steve", inventory);
+
+        // Stack construction (its own nested when/thenReturn pairs) must fully
+        // finish as separate statements before the outer when(...).thenReturn(...)
+        // below - interleaving them mid-chain confuses Mockito's stubbing state
+        // (UnfinishedStubbingException).
+        ItemStack[] withStone = inventoryOf(stack(Material.STONE, 1));
+        when(inventory.getContents()).thenReturn(withStone);
+        service.capture(steve, PlayerSnapshot.CAUSE_SWEEP);
+
+        ItemStack[] withDirt = inventoryOf(stack(Material.DIRT, 1));
+        when(inventory.getContents()).thenReturn(withDirt);
+        service.capture(steve, PlayerSnapshot.CAUSE_SWEEP);
+
+        assertThat(store.saved).hasSize(2);
+        assertThat(store.saved.get(0).contentHash())
+                .as("a changed slot must change the content hash")
+                .isNotEqualTo(store.saved.get(1).contentHash());
+    }
+
+    @Test
+    void emptySlotsAreAbsentFromTheSnapshot() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+        ItemStack[] contents = new ItemStack[41];
+        contents[3] = stack(Material.DIAMOND, 2);
+        contents[5] = stack(Material.AIR, 1); // explicit air stack - must be excluded too
+        Player steve = player(UUID.randomUUID(), "Steve", contents);
+
+        service.capture(steve, PlayerSnapshot.CAUSE_SWEEP);
+
+        assertThat(store.saved).hasSize(1);
+        List<SnapshotSlot> slots = store.saved.get(0).slots();
+        assertThat(slots).hasSize(1);
+        assertThat(slots.get(0).slot()).isEqualTo(3);
+    }
+
+    @Test
+    void causeIsRecordedVerbatimForEveryCapturePoint() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+        List<String> causes = List.of(
+                PlayerSnapshot.CAUSE_JOIN, PlayerSnapshot.CAUSE_QUIT, PlayerSnapshot.CAUSE_DEATH,
+                PlayerSnapshot.CAUSE_WORLD_CHANGE, PlayerSnapshot.CAUSE_SWEEP);
+
+        // Distinct players per cause so no dirty-skip or quit-eviction
+        // interaction muddies this test - it only pins the label.
+        for (String cause : causes) {
+            Player p = player(UUID.randomUUID(), "p-" + cause, inventoryOf(stack(Material.STONE, 1)));
+            service.capture(p, cause);
+        }
+
+        assertThat(store.saved).extracting(PlayerSnapshot::cause).containsExactlyElementsOf(causes);
+    }
+
+    @Test
+    void quitEvictsTheHashCacheForcingAWarmOnTheNextCapture() {
+        FakeStore store = new FakeStore();
+        PlayerSnapshotService service = newService(store);
+        UUID uuid = UUID.randomUUID();
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        Player steve = mockPlayer(uuid, "Steve", inventory);
+
+        ItemStack[] withStone = inventoryOf(stack(Material.STONE, 1));
+        when(inventory.getContents()).thenReturn(withStone);
+        service.capture(steve, PlayerSnapshot.CAUSE_JOIN); // cold: warm #1 (empty) + save #1
+        service.capture(steve, PlayerSnapshot.CAUSE_QUIT); // cache hit: skip save, then evict
+
+        ItemStack[] withDirt = inventoryOf(stack(Material.DIRT, 1));
+        when(inventory.getContents()).thenReturn(withDirt);
+        service.capture(steve, PlayerSnapshot.CAUSE_JOIN); // cache was evicted: warm #2, differs, save #2
+
+        assertThat(store.saved).hasSize(2);
+        assertThat(store.lastContentHashCalls)
+                .as("the cache must have been evicted on quit, forcing a second warm from the store")
+                .isEqualTo(2);
+    }
+
+    private static PlayerSnapshotService newService(FakeStore store) {
+        return new PlayerSnapshotService(store, Duration.parse("5m"), Duration.parse("30d"),
+                new DirectExecutorService(), FAKE_SERIALIZER, Logger.getLogger("player-snapshot-service-test"));
+    }
+
+    private static Player player(UUID uuid, String name, ItemStack[] contents) {
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getContents()).thenReturn(contents);
+        return mockPlayer(uuid, name, inventory);
+    }
+
+    private static Player mockPlayer(UUID uuid, String name, PlayerInventory inventory) {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(player.getName()).thenReturn(name);
+        when(player.getInventory()).thenReturn(inventory);
+        return player;
+    }
+
+    private static ItemStack[] inventoryOf(ItemStack... occupiedFromSlotZero) {
+        ItemStack[] contents = new ItemStack[41];
+        System.arraycopy(occupiedFromSlotZero, 0, contents, 0, occupiedFromSlotZero.length);
+        return contents;
+    }
+
+    private static ItemStack stack(Material material, int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getType()).thenReturn(material);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.clone()).thenReturn(stack);
+        return stack;
+    }
+
+    /** In-memory {@link PlayerSnapshotStore} double: records every save, and
+     *  counts {@link #lastContentHash} calls so the cache-eviction test can
+     *  prove a second warm actually happened. */
+    private static final class FakeStore implements PlayerSnapshotStore {
+        final List<PlayerSnapshot> saved = new ArrayList<>();
+        final Map<UUID, Long> priorHash = new HashMap<>();
+        int lastContentHashCalls;
+
+        @Override
+        public void save(PlayerSnapshot snapshot) {
+            saved.add(snapshot);
+            priorHash.put(snapshot.player(), snapshot.contentHash());
+        }
+
+        @Override
+        public Optional<PlayerSnapshot> latestAtOrBefore(UUID player, Instant instant) {
+            return Optional.empty();
+        }
+
+        @Override
+        public OptionalLong lastContentHash(UUID player) {
+            lastContentHashCalls++;
+            Long value = priorHash.get(player);
+            return value == null ? OptionalLong.empty() : OptionalLong.of(value);
+        }
+
+        @Override
+        public int prune(Instant cutoff) {
+            return 0;
+        }
+    }
+
+    /** Runs every submitted task synchronously on the calling thread, so a
+     *  test's {@code capture()} call has already finished the off-main work
+     *  (serialize/hash/save) by the time it returns. */
+    private static final class DirectExecutorService extends AbstractExecutorService {
+        private volatile boolean shutdown;
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotReconstructorTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotReconstructorTest.java
@@ -1,0 +1,314 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.ContainerDepositRecord;
+import net.medievalrp.spyglass.api.event.ContainerWithdrawRecord;
+import net.medievalrp.spyglass.api.event.EventRecord;
+import net.medievalrp.spyglass.api.event.Origin;
+import net.medievalrp.spyglass.api.event.Source;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.api.util.EventIds;
+import net.medievalrp.spyglass.plugin.snapshot.Reconstruction.Mismatch;
+import net.medievalrp.spyglass.plugin.snapshot.SnapshotSession.Certainty;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure reverse-apply plus forward-replay tests for {@link SnapshotReconstructor}.
+ * Records are built with synthetic {@link StoredItem}s whose {@code data} blobs
+ * are arbitrary marker strings - the reconstructor compares slots by that blob,
+ * so no real serialization (and no Bukkit) is needed. Ids are minted with
+ * explicit sequences via {@link EventIds#uuidOf} so same-instant ordering is
+ * deterministic.
+ */
+class SnapshotReconstructorTest {
+
+    private static final UUID WORLD = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID PLAYER = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final BlockLocation LOCATION = new BlockLocation(WORLD, "world", 10, 64, 20);
+    private static final Instant T = Instant.parse("2026-07-24T00:00:00Z");
+    private static final int SIZE = 27;
+
+    // --- happy path: a deposit-then-withdraw chain rewinds to the T-state ---
+
+    @Test
+    void depositThenWithdrawChainRewindsToExactTState() {
+        StoredItem at64 = item("DIAMOND", "diamond#64");
+        StoredItem at50 = item("DIAMOND", "diamond#50");
+        StoredItem at58 = item("DIAMOND", "diamond#58");
+
+        // T-state slot 0 holds DIAMOND#64. A withdraw drops it to #50, then a
+        // deposit tops it up to #58, which is what live shows.
+        ContainerWithdrawRecord w = withdraw(1, T.plusSeconds(10), 0, at64, at50);
+        ContainerDepositRecord d = deposit(2, T.plusSeconds(20), 0, at50, at58);
+
+        StoredItem[] live = empty();
+        live[0] = at58;
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(w, d), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.CERTAIN);
+        assertThat(r.mismatches()).isEmpty();
+        assertThat(r.slots()).singleElement().satisfies(s -> {
+            assertThat(s.slot()).isEqualTo(0);
+            assertThat(s.item().data()).isEqualTo("diamond#64");
+            assertThat(s.count()).isEqualTo(SnapshotReconstructor.COUNT_IN_BLOB);
+        });
+    }
+
+    // --- interleaved multi-slot chains, out-of-order input ---
+
+    @Test
+    void interleavedMultiSlotChainsSortAndReconcileFromShuffledInput() {
+        StoredItem x10 = item("IRON_INGOT", "iron#10");
+        StoredItem x4 = item("IRON_INGOT", "iron#4");
+        StoredItem y5 = item("GOLD_INGOT", "gold#5");
+        StoredItem y9 = item("GOLD_INGOT", "gold#9");
+
+        // slot 0: empty -> 10 -> 4. slot 1: 5 -> 9. Interleaved in time.
+        ContainerDepositRecord a = deposit(1, T.plusSeconds(10), 0, null, x10);
+        ContainerDepositRecord b = deposit(2, T.plusSeconds(20), 1, y5, y9);
+        ContainerWithdrawRecord c = withdraw(3, T.plusSeconds(30), 0, x10, x4);
+
+        StoredItem[] live = empty();
+        live[0] = x4;
+        live[1] = y9;
+
+        // Deliberately shuffled input.
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(c, a, b), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.CERTAIN);
+        assertThat(r.mismatches()).isEmpty();
+        // slot 0 rewinds to empty (dropped from output); slot 1 to gold#5.
+        assertThat(r.slots()).singleElement().satisfies(s -> {
+            assertThat(s.slot()).isEqualTo(1);
+            assertThat(s.item().data()).isEqualTo("gold#5");
+        });
+    }
+
+    // --- an unexplained live item that no record touches stays, still CERTAIN ---
+
+    @Test
+    void unexplainedLiveItemSurvivesAndStaysCertainWhenReplayReconciles() {
+        StoredItem stone10 = item("STONE", "stone#10");
+        StoredItem stone3 = item("STONE", "stone#3");
+        StoredItem heirloom = item("NETHERITE_SWORD", "sword#unique");
+
+        ContainerWithdrawRecord w = withdraw(1, T.plusSeconds(10), 0, stone10, stone3);
+
+        StoredItem[] live = empty();
+        live[0] = stone3;
+        live[5] = heirloom; // never referenced by any record
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(w), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.CERTAIN);
+        assertThat(r.mismatches()).isEmpty();
+        assertThat(r.slots()).extracting(SnapshotSlot::slot).containsExactly(0, 5);
+        assertThat(r.slots()).filteredOn(s -> s.slot() == 5)
+                .singleElement()
+                .satisfies(s -> assertThat(s.item().data()).isEqualTo("sword#unique"));
+        assertThat(r.slots()).filteredOn(s -> s.slot() == 0)
+                .singleElement()
+                .satisfies(s -> assertThat(s.item().data()).isEqualTo("stone#10"));
+    }
+
+    // --- a tampered mid-chain record fails the forward-replay step check ---
+
+    @Test
+    void tamperedMidChainRecordIsUncertainWithSlotNamedNote() {
+        StoredItem a5 = item("APPLE", "apple#5");
+        StoredItem a10 = item("APPLE", "apple#10");
+        StoredItem bogus = item("BREAD", "bread#7"); // R2.before lies
+
+        // R1: empty -> 5. R2 claims before=BREAD#7 (tampered) -> 10. Live is 10,
+        // so the end state still reconciles; only the mid-chain step is wrong.
+        ContainerDepositRecord r1 = deposit(1, T.plusSeconds(10), 0, null, a5);
+        ContainerDepositRecord r2 = deposit(2, T.plusSeconds(20), 0, bogus, a10);
+
+        StoredItem[] live = empty();
+        live[0] = a10;
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(r1, r2), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.UNCERTAIN);
+        assertThat(r.mismatches())
+                .anySatisfy(m -> {
+                    assertThat(m.slot()).isEqualTo(0);
+                    assertThat(m.kind()).isEqualTo(Mismatch.Kind.REPLAY_STEP);
+                });
+        assertThat(r.notes()).anyMatch(n -> n.contains("slot 0"));
+    }
+
+    // --- an untracked change to the live container shows as an end-state diff ---
+
+    @Test
+    void untrackedLiveChangeIsUncertainEndStateMismatch() {
+        StoredItem c10 = item("COBBLESTONE", "cobble#10");
+        StoredItem c20 = item("COBBLESTONE", "cobble#20");
+        StoredItem tampered = item("COBBLESTONE", "cobble#40"); // live grew past the record
+
+        ContainerDepositRecord d = deposit(1, T.plusSeconds(10), 0, c10, c20);
+
+        StoredItem[] live = empty();
+        live[0] = tampered; // records say 20, live has 40
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(d), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.UNCERTAIN);
+        assertThat(r.mismatches())
+                .anySatisfy(m -> {
+                    assertThat(m.slot()).isEqualTo(0);
+                    assertThat(m.kind()).isEqualTo(Mismatch.Kind.END_STATE);
+                });
+    }
+
+    // --- a legacy slot < 0 row forces hard UNCERTAIN ---
+
+    @Test
+    void legacyNegativeSlotRecordIsHardUncertain() {
+        StoredItem full = item("EMERALD", "emerald#64");
+        // A clean chain for slot 0 alongside one pre-#268 slot=-1 row.
+        ContainerDepositRecord clean = deposit(1, T.plusSeconds(10), 0, null, full);
+        ContainerDepositRecord legacy = deposit(2, T.plusSeconds(20), -1, null, full);
+
+        StoredItem[] live = empty();
+        live[0] = full;
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(clean, legacy), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.UNCERTAIN);
+        assertThat(r.notes()).anyMatch(n -> n.contains("predates per-slot logging"));
+        // The legacy row is not applied, so the clean slot still reconstructs.
+        assertThat(r.slots()).isEmpty(); // slot 0 rewinds to empty (before the deposit)
+    }
+
+    // --- an absent container reconstructs from records against empty, UNCERTAIN ---
+
+    @Test
+    void absentContainerReconstructsFromRecordsAgainstEmpty() {
+        StoredItem kept = item("BOOK", "book#1");
+        StoredItem before = item("BOOK", "book#3");
+
+        // A withdraw whose before-state is what stood at T; the block is gone,
+        // so live is empty and forward-replay is skipped.
+        ContainerWithdrawRecord w = withdraw(1, T.plusSeconds(10), 4, before, kept);
+
+        StoredItem[] live = empty(); // container gone
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(w), live, SIZE, T, false, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.UNCERTAIN);
+        assertThat(r.notes()).anyMatch(n -> n.contains("container no longer present"));
+        assertThat(r.slots()).singleElement().satisfies(s -> {
+            assertThat(s.slot()).isEqualTo(4);
+            assertThat(s.item().data()).isEqualTo("book#3");
+        });
+    }
+
+    // --- a self-mutating block is UNCERTAIN even with a clean chain ---
+
+    @Test
+    void selfMutatingBlockIsHardUncertain() {
+        StoredItem coal = item("COAL", "coal#8");
+        StoredItem coal4 = item("COAL", "coal#4");
+        ContainerWithdrawRecord w = withdraw(1, T.plusSeconds(10), 0, coal, coal4);
+
+        StoredItem[] live = empty();
+        live[0] = coal4;
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(w), live, SIZE, T, true, true);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.UNCERTAIN);
+        assertThat(r.notes()).anyMatch(n -> n.contains("self-mutating"));
+    }
+
+    // --- a SWAP_WITH_CURSOR shape: withdraw + deposit, same instant, same slot ---
+
+    @Test
+    void swapWithCursorShapeReplaysCleanlyInBothDirections() {
+        StoredItem was = item("SHIELD", "shield#1");   // slot held this at T
+        StoredItem now = item("TORCH", "torch#12");    // cursor put this in
+
+        Instant instant = T.plusSeconds(10);
+        // The swap is one click: withdraw the old stack (before=SHIELD,
+        // after=empty), then deposit the cursor (before=empty, after=TORCH),
+        // both at the same instant. Sequence ids (1 then 2) fix the order.
+        ContainerWithdrawRecord out = withdraw(1, instant, 0, was, null);
+        ContainerDepositRecord in = deposit(2, instant, 0, null, now);
+
+        StoredItem[] live = empty();
+        live[0] = now;
+
+        // Pass them reversed to prove ordering comes from (occurred, id), not
+        // list order.
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(in, out), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.CERTAIN);
+        assertThat(r.mismatches()).isEmpty();
+        assertThat(r.slots()).singleElement().satisfies(s -> {
+            assertThat(s.slot()).isEqualTo(0);
+            assertThat(s.item().data()).isEqualTo("shield#1");
+        });
+    }
+
+    // --- records older than T are ignored (defensive window filter) ---
+
+    @Test
+    void recordsBeforeTAreIgnored() {
+        StoredItem before = item("STICK", "stick#2");
+        StoredItem after = item("STICK", "stick#5");
+        // This op happened before T; it must not be reverse-applied.
+        ContainerDepositRecord stale = deposit(1, T.minusSeconds(60), 0, before, after);
+
+        StoredItem[] live = empty();
+        live[0] = after;
+
+        Reconstruction r = SnapshotReconstructor.reconstruct(
+                List.<EventRecord>of(stale), live, SIZE, T, true, false);
+
+        assertThat(r.certainty()).isEqualTo(Certainty.CERTAIN);
+        // The stale op was skipped, so the T-state is just the live contents.
+        assertThat(r.slots()).singleElement().satisfies(s ->
+                assertThat(s.item().data()).isEqualTo("stick#5"));
+    }
+
+    // --- helpers ---
+
+    private static StoredItem[] empty() {
+        return new StoredItem[SIZE];
+    }
+
+    private static StoredItem item(String material, String data) {
+        return new StoredItem(0, material, data);
+    }
+
+    private static ContainerDepositRecord deposit(long seq, Instant occurred, int slot,
+                                                  StoredItem before, StoredItem after) {
+        return new ContainerDepositRecord(
+                EventIds.uuidOf(seq), "deposit", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(PLAYER, "Tester"),
+                LOCATION, "srv", "TARGET", "CHEST", slot, 1, before, after);
+    }
+
+    private static ContainerWithdrawRecord withdraw(long seq, Instant occurred, int slot,
+                                                    StoredItem before, StoredItem after) {
+        return new ContainerWithdrawRecord(
+                EventIds.uuidOf(seq), "withdraw", occurred, occurred.plusSeconds(3600),
+                Origin.player(), Source.player(PLAYER, "Tester"),
+                LOCATION, "srv", "TARGET", "CHEST", slot, 1, before, after);
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSessionsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotSessionsTest.java
@@ -1,0 +1,142 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code PageCache} idiom applied to snapshots: one live session per
+ * sender, resolved only by the exact token that was cached for them.
+ */
+class SnapshotSessionsTest {
+
+    private static SnapshotSession session(UUID token) {
+        return new SnapshotSession(token, SnapshotSession.Kind.PLAYER, "Steve", Instant.EPOCH,
+                Instant.EPOCH, PlayerSnapshot.CAUSE_JOIN, SnapshotSession.Certainty.CERTAIN,
+                List.of(), 6, List.of());
+    }
+
+    private static Player playerWithId(UUID id) {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(id);
+        return player;
+    }
+
+    @Test
+    void resolveSucceedsWithTheExactCachedToken() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+        UUID token = UUID.randomUUID();
+        sessions.store(sender, session(token));
+
+        assertThat(sessions.resolve(sender, token)).isPresent();
+    }
+
+    @Test
+    void resolveFailsOnATokenMismatch() {
+        // A stale link from a render a newer /sg snapshot superseded, or a
+        // hand-typed wrong token - both must be refused, not resolve to
+        // whatever happens to be cached.
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+        sessions.store(sender, session(UUID.randomUUID()));
+
+        assertThat(sessions.resolve(sender, UUID.randomUUID())).isEmpty();
+    }
+
+    @Test
+    void resolveFailsWithNothingCached() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+
+        assertThat(sessions.resolve(sender, UUID.randomUUID())).isEmpty();
+    }
+
+    @Test
+    void getIgnoresTheTokenAndReturnsWhateverIsCached() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+        UUID token = UUID.randomUUID();
+        sessions.store(sender, session(token));
+
+        assertThat(sessions.get(sender)).isPresent();
+        assertThat(sessions.get(sender).get().token()).isEqualTo(token);
+    }
+
+    @Test
+    void aNewStoreReplacesThePreviousSessionAndItsOldTokenNoLongerResolves() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+        UUID firstToken = UUID.randomUUID();
+        UUID secondToken = UUID.randomUUID();
+        sessions.store(sender, session(firstToken));
+        sessions.store(sender, session(secondToken));
+
+        assertThat(sessions.resolve(sender, firstToken)).isEmpty();
+        assertThat(sessions.resolve(sender, secondToken)).isPresent();
+    }
+
+    @Test
+    void clearRemovesTheCachedSession() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player sender = playerWithId(UUID.randomUUID());
+        UUID token = UUID.randomUUID();
+        sessions.store(sender, session(token));
+
+        sessions.clear(sender);
+
+        assertThat(sessions.get(sender)).isEmpty();
+        assertThat(sessions.resolve(sender, token)).isEmpty();
+    }
+
+    @Test
+    void differentSendersNeverShareASession() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        Player alice = playerWithId(UUID.randomUUID());
+        Player bob = playerWithId(UUID.randomUUID());
+        UUID aliceToken = UUID.randomUUID();
+        sessions.store(alice, session(aliceToken));
+
+        assertThat(sessions.get(bob)).isEmpty();
+        assertThat(sessions.resolve(bob, aliceToken)).isEmpty();
+    }
+
+    @Test
+    void onQuitClearsThatPlayersSession() {
+        SnapshotSessions sessions = new SnapshotSessions();
+        UUID playerId = UUID.randomUUID();
+        Player player = playerWithId(playerId);
+        sessions.store(player, session(UUID.randomUUID()));
+
+        PlayerQuitEvent quit = mock(PlayerQuitEvent.class);
+        when(quit.getPlayer()).thenReturn(player);
+        sessions.onQuit(quit);
+
+        assertThat(sessions.get(player)).isEmpty();
+    }
+
+    @Test
+    void namedNonPlayerSendersResolveByNameNotIdentity() {
+        // A non-player, non-console sender (e.g. RCON) falls back to a
+        // name-derived UUID: two distinct CommandSender instances sharing a
+        // name must hit the same cache entry.
+        SnapshotSessions sessions = new SnapshotSessions();
+        CommandSender firstHandle = mock(CommandSender.class);
+        when(firstHandle.getName()).thenReturn("Rcon");
+        CommandSender secondHandle = mock(CommandSender.class);
+        when(secondHandle.getName()).thenReturn("Rcon");
+        UUID token = UUID.randomUUID();
+
+        sessions.store(firstHandle, session(token));
+
+        assertThat(sessions.resolve(secondHandle, token)).isPresent();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakesTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotTakesTest.java
@@ -1,0 +1,272 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.util.ItemSerialization;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * The shared extract engine behind both {@code /sg snapshot} surfaces
+ * (#341): the permission re-check, the refuse-whole-not-partial fit check,
+ * and the audit hand-off.
+ */
+class SnapshotTakesTest {
+
+    private static StoredItem item(int slot, String blob) {
+        return new StoredItem(slot, "DIAMOND", blob);
+    }
+
+    private static SnapshotSession playerSession(int slot, int count, String blob) {
+        return new SnapshotSession(java.util.UUID.randomUUID(), SnapshotSession.Kind.PLAYER, "Steve",
+                Instant.EPOCH, Instant.EPOCH, PlayerSnapshot.CAUSE_JOIN, SnapshotSession.Certainty.CERTAIN,
+                List.of(), 6, List.of(new SnapshotSlot(slot, count, item(slot, blob))));
+    }
+
+    private static SnapshotSession containerSession(int slot, String blob) {
+        return new SnapshotSession(java.util.UUID.randomUUID(), SnapshotSession.Kind.CONTAINER, "world 1,2,3 CHEST",
+                Instant.EPOCH, Instant.EPOCH, null, SnapshotSession.Certainty.CERTAIN,
+                List.of(), 3, List.of(new SnapshotSlot(slot, 0, item(slot, blob))));
+    }
+
+    /** A mock ItemStack whose amount actually changes when {@code setAmount}
+     *  is called - a plain stub would leave getAmount() frozen, which would
+     *  hide the exact bug this class exists to avoid (calling setAmount on
+     *  a container-mode slot). */
+    private static ItemStack mutableStack(Material material, int initialAmount, int maxStackSize) {
+        ItemStack stack = mock(ItemStack.class);
+        int[] amount = {initialAmount};
+        when(stack.getType()).thenReturn(material);
+        when(stack.getMaxStackSize()).thenReturn(maxStackSize);
+        when(stack.getAmount()).thenAnswer(inv -> amount[0]);
+        doAnswer(inv -> {
+            amount[0] = inv.getArgument(0);
+            return null;
+        }).when(stack).setAmount(anyInt());
+        when(stack.clone()).thenReturn(stack);
+        when(stack.isSimilar(any())).thenReturn(false);
+        return stack;
+    }
+
+    private static Player playerWith(PlayerInventory inventory, boolean canTake) {
+        Player player = mock(Player.class);
+        when(player.hasPermission(SnapshotTakes.PERMISSION)).thenReturn(canTake);
+        when(player.getInventory()).thenReturn(inventory);
+        return player;
+    }
+
+    private static PlayerInventory inventoryWithStorage(ItemStack[] storageContents) {
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getStorageContents()).thenReturn(storageContents);
+        return inventory;
+    }
+
+    // ---- permission check --------------------------------------------------
+
+    @Test
+    void withoutPermissionRefusesAndTouchesNothing() {
+        SnapshotTakeLogger logger = mock(SnapshotTakeLogger.class);
+        SnapshotTakes takes = new SnapshotTakes(logger);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, false);
+        SnapshotSession session = playerSession(0, 64, "blob");
+
+        SnapshotTakes.Result result = takes.take(player, session, 0);
+
+        assertThat(result).isEqualTo(SnapshotTakes.Result.NO_PERMISSION);
+        verify(inventory, never()).addItem(any(ItemStack.class));
+        verify(logger, never()).log(any(), any(), any(), anyInt());
+    }
+
+    // ---- slot resolution -----------------------------------------------
+
+    @Test
+    void missingSlotIsRefused() {
+        SnapshotTakes takes = new SnapshotTakes(null);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, true);
+        SnapshotSession session = playerSession(5, 64, "blob");
+
+        SnapshotTakes.Result result = takes.take(player, session, 12);
+
+        assertThat(result).isEqualTo(SnapshotTakes.Result.SLOT_EMPTY);
+        verify(inventory, never()).addItem(any(ItemStack.class));
+    }
+
+    @Test
+    void decodeReturningNullIsRefused() {
+        SnapshotTakes takes = new SnapshotTakes(null);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, true);
+        SnapshotSession session = playerSession(0, 64, "blob");
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode(anyString())).thenReturn(null);
+
+            SnapshotTakes.Result result = takes.take(player, session, 0);
+
+            assertThat(result).isEqualTo(SnapshotTakes.Result.SLOT_EMPTY);
+            verify(inventory, never()).addItem(any(ItemStack.class));
+        }
+    }
+
+    // ---- refusal on full: no partial, no ground drop -------------------
+
+    @Test
+    void wholeStackRefusedWhenInventoryCannotFitItAndNothingIsAddedOrLogged() {
+        SnapshotTakeLogger logger = mock(SnapshotTakeLogger.class);
+        SnapshotTakes takes = new SnapshotTakes(logger);
+
+        // 36 full, dissimilar slots: no merge room, no empty slot.
+        ItemStack[] full = new ItemStack[36];
+        for (int i = 0; i < full.length; i++) {
+            full[i] = mutableStack(Material.DIRT, 64, 64);
+        }
+        PlayerInventory inventory = inventoryWithStorage(full);
+        Player player = playerWith(inventory, true);
+        SnapshotSession session = playerSession(0, 64, "blob");
+        ItemStack decoded = mutableStack(Material.DIAMOND, 1, 64);
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode(anyString())).thenReturn(decoded);
+
+            SnapshotTakes.Result result = takes.take(player, session, 0);
+
+            assertThat(result).isEqualTo(SnapshotTakes.Result.INVENTORY_FULL);
+            verify(inventory, never()).addItem(any(ItemStack.class));
+            verify(logger, never()).log(any(), any(), any(), anyInt());
+        }
+    }
+
+    // ---- success + audit -------------------------------------------------
+
+    @Test
+    void successfulTakeAddsACloneAndLogsTheAudit() {
+        SnapshotTakeLogger logger = mock(SnapshotTakeLogger.class);
+        SnapshotTakes takes = new SnapshotTakes(logger);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]); // all empty
+        Player player = playerWith(inventory, true);
+        SnapshotSession session = playerSession(0, 64, "blob");
+        ItemStack decoded = mutableStack(Material.DIAMOND, 1, 64);
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode("blob")).thenReturn(decoded);
+
+            SnapshotTakes.Result result = takes.take(player, session, 0);
+
+            assertThat(result).isEqualTo(SnapshotTakes.Result.TAKEN);
+            verify(inventory, times(1)).addItem(any(ItemStack.class));
+            verify(logger, times(1)).log(eq(player), eq(session), any(ItemStack.class), eq(0));
+        }
+    }
+
+    @Test
+    void aNullLoggerNeverThrowsOnASuccessfulTake() {
+        SnapshotTakes takes = new SnapshotTakes(null);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, true);
+        SnapshotSession session = playerSession(0, 64, "blob");
+        ItemStack decoded = mutableStack(Material.DIAMOND, 1, 64);
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode("blob")).thenReturn(decoded);
+
+            SnapshotTakes.Result result = takes.take(player, session, 0);
+
+            assertThat(result).isEqualTo(SnapshotTakes.Result.TAKEN);
+        }
+    }
+
+    // ---- count semantics: player vs container mode -----------------------
+
+    @Test
+    void playerModeOverwritesTheDecodedAmountWithTheSlotCount() {
+        SnapshotTakes takes = new SnapshotTakes(null);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, true);
+        // The interned blob normalizes to amount 1; the real count (64)
+        // lives in the slot, per SnapshotSlot's javadoc.
+        SnapshotSession session = playerSession(0, 64, "blob");
+        ItemStack decoded = mutableStack(Material.DIAMOND, 1, 64);
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode("blob")).thenReturn(decoded);
+
+            takes.take(player, session, 0);
+
+            assertThat(decoded.getAmount()).isEqualTo(64);
+        }
+    }
+
+    @Test
+    void containerModeNeverCallsSetAmountOnTheDecodedStack() {
+        SnapshotTakes takes = new SnapshotTakes(null);
+        PlayerInventory inventory = inventoryWithStorage(new ItemStack[36]);
+        Player player = playerWith(inventory, true);
+        // COUNT_IN_BLOB (0) is a sentinel, not a real amount - the real
+        // count already lives inside the decoded blob (5 here).
+        SnapshotSession session = containerSession(0, "blob");
+        ItemStack decoded = mutableStack(Material.DIAMOND, 5, 64);
+
+        try (MockedStatic<ItemSerialization> serialization = mockStatic(ItemSerialization.class)) {
+            serialization.when(() -> ItemSerialization.decode("blob")).thenReturn(decoded);
+
+            takes.take(player, session, 0);
+
+            assertThat(decoded.getAmount()).isEqualTo(5);
+        }
+    }
+
+    // ---- fits(): merge-then-empty-slot simulation -------------------------
+
+    @Test
+    void fitsMergesIntoAPartialExistingStackBeforeNeedingAnEmptySlot() {
+        ItemStack partialDiamonds = mutableStack(Material.DIAMOND, 60, 64);
+        when(partialDiamonds.isSimilar(any())).thenReturn(true); // same type as candidate
+        ItemStack[] storage = new ItemStack[36];
+        storage[0] = partialDiamonds; // 4 slots of room, no empty slots at all
+        ItemStack candidate = mutableStack(Material.DIAMOND, 4, 64);
+
+        assertThat(SnapshotTakes.fits(storage, candidate)).isTrue();
+    }
+
+    @Test
+    void fitsRefusesWhenThePartialStackCannotCoverTheWholeAmountAndNoSlotIsEmpty() {
+        ItemStack partialDiamonds = mutableStack(Material.DIAMOND, 60, 64);
+        when(partialDiamonds.isSimilar(any())).thenReturn(true);
+        ItemStack[] storage = new ItemStack[36];
+        for (int i = 0; i < storage.length; i++) {
+            storage[i] = mutableStack(Material.DIRT, 64, 64); // full, unrelated, no empties
+        }
+        storage[0] = partialDiamonds; // only 4 slots of room
+        ItemStack candidate = mutableStack(Material.DIAMOND, 5, 64); // needs 5
+
+        assertThat(SnapshotTakes.fits(storage, candidate)).isFalse();
+    }
+
+    @Test
+    void fitsFallsThroughToAnEmptySlotWhenNoExistingStackHasRoom() {
+        ItemStack[] storage = new ItemStack[36]; // every slot empty
+        ItemStack candidate = mutableStack(Material.DIAMOND, 64, 64);
+
+        assertThat(SnapshotTakes.fits(storage, candidate)).isTrue();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotViewsTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SnapshotViewsTest.java
@@ -1,0 +1,37 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The version gate that decides whether a server gets the InvUI {@code
+ * /sg snapshot} GUI. InvUI 1.49 supports Minecraft 1.x only; the post-1.21
+ * "26.x" scheme falls back to the text-only listing. Getting this wrong
+ * either crashes 26.x (loading InvUI) or needlessly drops the GUI on 1.21.x,
+ * so it is worth pinning - mirrors {@code SalvageViewsTest} exactly, since
+ * both gates share the same InvUI 1.49 version ceiling.
+ */
+class SnapshotViewsTest {
+
+    @Test
+    void supportsCurrentAndOlderOneDotXReleases() {
+        assertThat(SnapshotViews.invUiSupported("1.21.11-R0.1-SNAPSHOT")).isTrue();
+        assertThat(SnapshotViews.invUiSupported("1.21.8-R0.1-SNAPSHOT")).isTrue();
+        assertThat(SnapshotViews.invUiSupported("1.20.4-R0.1-SNAPSHOT")).isTrue();
+        assertThat(SnapshotViews.invUiSupported("1.16.5-R0.1-SNAPSHOT")).isTrue();
+    }
+
+    @Test
+    void rejectsThePost1_21Scheme() {
+        assertThat(SnapshotViews.invUiSupported("26.1.2-R0.1-SNAPSHOT")).isFalse();
+        assertThat(SnapshotViews.invUiSupported("26.2-R0.1-SNAPSHOT")).isFalse();
+    }
+
+    @Test
+    void rejectsGarbageAndEmptyDefensively() {
+        assertThat(SnapshotViews.invUiSupported(null)).isFalse();
+        assertThat(SnapshotViews.invUiSupported("")).isFalse();
+        assertThat(SnapshotViews.invUiSupported("not-a-version")).isFalse();
+    }
+}

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SqlitePlayerSnapshotStoreTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/snapshot/SqlitePlayerSnapshotStoreTest.java
@@ -1,0 +1,182 @@
+package net.medievalrp.spyglass.plugin.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import net.medievalrp.spyglass.api.event.StoredItem;
+import net.medievalrp.spyglass.plugin.storage.SqliteRecordStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the SQLite {@link PlayerSnapshotStore} (#341) against a file-backed
+ * temp database sharing the record store's connection - no Docker. Mirrors the
+ * {@code SqliteAuxStoresTest} shape; asserts intern dedupe and orphan GC over
+ * a direct connection to the same DB.
+ */
+class SqlitePlayerSnapshotStoreTest {
+
+    @TempDir
+    Path dir;
+    private SqliteRecordStore store;
+    private SqlitePlayerSnapshotStore snapshots;
+
+    @BeforeEach
+    void open() {
+        store = new SqliteRecordStore(dir.resolve("spyglass.db"));
+        snapshots = new SqlitePlayerSnapshotStore(store);
+    }
+
+    @AfterEach
+    void close() {
+        store.close();
+    }
+
+    @Test
+    void saveReadRoundtripKeepsSlotFidelityAndMaterial() {
+        UUID player = UUID.randomUUID();
+        PlayerSnapshot snap = new PlayerSnapshot(UUID.randomUUID(), player, "Alice",
+                Instant.ofEpochMilli(2_000_000L), PlayerSnapshot.CAUSE_SWEEP, 0xABCDL,
+                List.of(slot(0, 64, "COBBLESTONE", "cobble-payload"),
+                        slot(40, 1, "SHIELD", "shield-payload")));
+        snapshots.save(snap);
+
+        PlayerSnapshot got = snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(3_000_000L)).orElseThrow();
+        assertThat(got.id()).isEqualTo(snap.id());
+        assertThat(got.player()).isEqualTo(player);
+        assertThat(got.playerName()).isEqualTo("Alice");
+        assertThat(got.cause()).isEqualTo(PlayerSnapshot.CAUSE_SWEEP);
+        assertThat(got.contentHash()).isEqualTo(0xABCDL);
+        assertThat(got.capturedAt()).isEqualTo(Instant.ofEpochMilli(2_000_000L));
+        assertThat(got.slots()).hasSize(2);
+
+        SnapshotSlot s0 = got.slots().get(0);
+        assertThat(s0.slot()).isEqualTo(0);
+        assertThat(s0.count()).isEqualTo(64);
+        assertThat(s0.item().material()).isEqualTo("COBBLESTONE");
+        assertThat(s0.item().data()).isEqualTo(base64("cobble-payload"));
+
+        SnapshotSlot s1 = got.slots().get(1);
+        assertThat(s1.slot()).isEqualTo(40);
+        assertThat(s1.count()).isEqualTo(1);
+        assertThat(s1.item().material()).isEqualTo("SHIELD");
+        assertThat(s1.item().data()).isEqualTo(base64("shield-payload"));
+    }
+
+    @Test
+    void latestAtOrBeforePicksTheCorrectRow() {
+        UUID player = UUID.randomUUID();
+        snapshots.save(snapshot(player, "P", 1_000L, 111L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "DIRT", "d1")));
+        snapshots.save(snapshot(player, "P", 2_000L, 222L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIRT", "d2")));
+        snapshots.save(snapshot(player, "P", 3_000L, 333L, PlayerSnapshot.CAUSE_QUIT,
+                slot(0, 1, "DIRT", "d3")));
+
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(2_500L)).orElseThrow()
+                .contentHash()).isEqualTo(222L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(3_000L)).orElseThrow()
+                .contentHash()).isEqualTo(333L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(500L))).isEmpty();
+    }
+
+    @Test
+    void internDedupesSharedPayloadsAcrossSnapshots() {
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        // Both carry the same "shared" payload; a also holds gold, b also iron.
+        snapshots.save(snapshot(a, "A", 1_000L, 1L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIAMOND", "shared"), slot(1, 1, "GOLD_INGOT", "gold")));
+        snapshots.save(snapshot(b, "B", 1_000L, 2L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIAMOND", "shared"), slot(1, 1, "IRON_INGOT", "iron")));
+
+        // Distinct payloads {shared, gold, iron} -> one intern row each.
+        assertThat(countItems()).isEqualTo(3L);
+    }
+
+    @Test
+    void reInternOfCommittedPayloadDoesNotThrow() {
+        UUID player = UUID.randomUUID();
+        PlayerSnapshot snap = snapshot(player, "P", 5_000L, 9L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "NETHERITE_INGOT", "ning"));
+        snapshots.save(snap);
+
+        // The recorder retry re-saves the exact same capture; must be idempotent.
+        assertThatCode(() -> snapshots.save(snap)).doesNotThrowAnyException();
+        assertThat(countItems()).isEqualTo(1L);
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(6_000L)).orElseThrow()
+                .slots()).hasSize(1);
+    }
+
+    @Test
+    void pruneRemovesOldRowsAndOrphanedBlobsButKeepsReferencedOnes() {
+        UUID player = UUID.randomUUID();
+        // Old snapshot: unique payload X + shared payload Y.
+        snapshots.save(snapshot(player, "P", 1_000L, 1L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "STONE", "X"), slot(1, 1, "GLASS", "Y")));
+        // New snapshot: shared payload Y + payload Z.
+        snapshots.save(snapshot(player, "P", 10_000L, 2L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "GLASS", "Y"), slot(1, 1, "SAND", "Z")));
+        assertThat(countItems()).isEqualTo(3L);
+
+        int removed = snapshots.prune(Instant.ofEpochMilli(5_000L));
+        assertThat(removed).isEqualTo(1);
+
+        // X was only referenced by the pruned snapshot -> GC'd; Y and Z survive.
+        assertThat(countItems()).isEqualTo(2L);
+
+        PlayerSnapshot survivor = snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(20_000L)).orElseThrow();
+        assertThat(survivor.contentHash()).isEqualTo(2L);
+        assertThat(survivor.slots()).extracting(sl -> sl.item().data())
+                .containsExactly(base64("Y"), base64("Z"));
+        // The pruned snapshot is no longer readable at its own instant.
+        assertThat(snapshots.latestAtOrBefore(player, Instant.ofEpochMilli(1_000L))).isEmpty();
+    }
+
+    @Test
+    void lastContentHashReturnsNewest() {
+        UUID player = UUID.randomUUID();
+        assertThat(snapshots.lastContentHash(player)).isEmpty();
+
+        snapshots.save(snapshot(player, "P", 1_000L, 111L, PlayerSnapshot.CAUSE_JOIN,
+                slot(0, 1, "DIRT", "a")));
+        snapshots.save(snapshot(player, "P", 2_000L, 222L, PlayerSnapshot.CAUSE_SWEEP,
+                slot(0, 1, "DIRT", "b")));
+
+        assertThat(snapshots.lastContentHash(player)).hasValue(222L);
+    }
+
+    // ----- helpers -----
+
+    private long countItems() {
+        return store.withReadConnection(conn -> {
+            try (var st = conn.createStatement();
+                 var rs = st.executeQuery("SELECT COUNT(*) FROM snapshot_items")) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        });
+    }
+
+    private static PlayerSnapshot snapshot(UUID player, String name, long occurredMs,
+                                           long contentHash, String cause, SnapshotSlot... slots) {
+        return new PlayerSnapshot(UUID.randomUUID(), player, name,
+                Instant.ofEpochMilli(occurredMs), cause, contentHash, List.of(slots));
+    }
+
+    private static SnapshotSlot slot(int slot, int count, String material, String payload) {
+        return new SnapshotSlot(slot, count, new StoredItem(slot, material, base64(payload)));
+    }
+
+    private static String base64(String payload) {
+        return Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Implements #341: `/sg snapshot` - view a player inventory or a container as it stood at a past instant, and take audited copies out. Design and rationale are on the issue; this PR is the read-only view + take half, #309's restore stays open.

## What's here

- `/sg snapshot t:6h` - look-at (or `trg:x,y,z w:<world>`) container reconstructed via the #267 algorithm: reverse-apply the per-slot container records newest-first from live, then forward-replay to verify. CERTAIN only when the chain fully explains the live state; UNCERTAIN names each unexplained slot. Double chests reconstruct per half and merge; furnace/brewing/campfire always open UNCERTAIN. Zero new storage.
- `/sg snapshot p:Steve t:2d` - newest player snapshot at or before T from a new per-backend `PlayerSnapshotStore` (all four backends). Capture on join/quit/death/world-change plus a dirty-checked sweep (`snapshot.players.interval`, default 5m); payloads interned content-addressed with counts normalized out, so a steady kit costs one blob set. Own retention (`snapshot.players.retention`, default 30d), additive config section, no config-version bump.
- Takes clone the stack into the viewer (whole-stack-or-refuse, never partial, never ground-dropped), live state untouched, one shared `SnapshotTakes` engine behind both the InvUI GUI (1.x) and the clickable text fallback (26.x/console). Every take lands a searchable `snapshot-take` record (ItemPickupRecord + new opt-in extensions channel naming subject and as-of instant - full parity across backends).

## Verification

- `./gradlew check --rerun-tasks` green: 1054 tests, 0 failures, 0 skipped, WITH Docker (MariaDB/Mongo/ClickHouse snapshot-store ITs ran, including the re-intern retry case and ClickHouse read-your-writes).
- Live probe (`regression/bot/_snapshot-341-probe.mjs`, throwaway 1.21.11 Paper, SQLite): 11/11 on BOTH the shaded and the lean jar. Covers: container reconstruction shows the T-state and not the later mutation; take hands a copy; live chest byte-identical after; player snapshot shows the past kit with count restored on take; both takes audited; `t:` required and foreign keys rejected.
- UNCERTAIN path proven live: an unlogged `item replace` over a logged deposit opens the GUI with the UNCERTAIN badge and the note `slot 0: live GOLD_INGOT does not match the reconstructed EMERALD (change not in the log)`.
- Boot smoke: lean and shaded jars on 1.21.11, clean enable. Two live-only bugs were caught and fixed this way: the InvUI singleton tolerating the salvage view's earlier claim, and snapshot ids minted via `EventIds` so the ClickHouse store's sequence fold is lossless.

Not live-verified: the 26.x text-only fallback path (gate logic is unit-tested and identical in shape to the proven `SalvageViews` split).
