### PR TITLE
fix(container): log entity-held container inventories (#347)

### DIFF
--- a/regression/bot/_entity-container-probe.mjs
+++ b/regression/bot/_entity-container-probe.mjs
@@ -6,7 +6,9 @@ import net from 'net';
 import { execFileSync } from 'child_process';
 
 const HOST = '127.0.0.1', PORT = 25590, RCON_PORT = 25580, PASS = 'test123';
-const DB = '/private/tmp/claude-502/-Volumes-External-NVME-Documents-GitHub-MedievalRP-Spyglass/70087784-6aef-47af-bc62-bb42bb5beb5d/scratchpad/sgfawe/plugins/Spyglass/spyglass.db';
+// Point SG_DB at the throwaway server's SQLite file.
+const DB = process.env.SG_DB;
+if (!DB) { console.error("set SG_DB=<path to the server's plugins/Spyglass/spyglass.db>"); process.exit(2); }
 const BOT = 'ec' + Date.now().toString(36).slice(-4);
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const log = (...a) => console.log('[' + new Date().toISOString().slice(11, 19) + ']', ...a);

--- a/regression/bot/_entity-container-probe.mjs
+++ b/regression/bot/_entity-container-probe.mjs
@@ -1,0 +1,188 @@
+// #347 live probe: donkey chest, horse saddle slot, chest boat.
+// Sneak + interact opens the entity inventory; deposits/withdrawals must land
+// as deposit/withdraw records (container type = entity type) plus open/close.
+import mineflayer from 'mineflayer';
+import net from 'net';
+import { execFileSync } from 'child_process';
+
+const HOST = '127.0.0.1', PORT = 25590, RCON_PORT = 25580, PASS = 'test123';
+const DB = '/private/tmp/claude-502/-Volumes-External-NVME-Documents-GitHub-MedievalRP-Spyglass/70087784-6aef-47af-bc62-bb42bb5beb5d/scratchpad/sgfawe/plugins/Spyglass/spyglass.db';
+const BOT = 'ec' + Date.now().toString(36).slice(-4);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const log = (...a) => console.log('[' + new Date().toISOString().slice(11, 19) + ']', ...a);
+let pass = 0, fail = 0; const results = [];
+const check = (name, ok, detail) => { if (ok) { pass++; log(`  PASS  ${name}`); } else { fail++; log(`  FAIL  ${name} :: ${detail}`); } results.push({ name, ok, detail }); };
+
+function pkt(i, t, b) { const u = Buffer.from(b); const l = 10 + u.length; const o = Buffer.alloc(4 + l); o.writeInt32LE(l, 0); o.writeInt32LE(i, 4); o.writeInt32LE(t, 8); u.copy(o, 12); return o; }
+function rcon(cmd) { return new Promise((res, rej) => { const s = net.createConnection({ host: HOST, port: RCON_PORT, timeout: 60000 }); let st = 0, bs = []; s.on('error', rej); s.on('timeout', () => { s.destroy(); rej('t/o'); }); s.on('connect', () => s.write(pkt(1, 3, PASS))); s.on('data', c => { bs.push(c); const a = Buffer.concat(bs); if (a.length < 4) return; const l = a.readInt32LE(0); if (a.length < l + 4) return; if (st === 0) { st = 1; bs = []; s.write(pkt(1, 2, cmd)); } else { s.end(); res(a.slice(12, 12 + l - 10).toString().replace(/§./g, '')); } }); }); }
+function sql(q) { try { return execFileSync('sqlite3', ['-cmd', '.timeout 4000', '-readonly', DB, q], { encoding: 'utf8' }).trim(); } catch (e) { return 'SQLERR:' + (e.stderr || e.message); } }
+function rowsAt(x, z) {
+  return sql(`SELECT ed.val || '/' || COALESCE(td.val,'?') || '/s' || COALESCE(CAST(r.y AS TEXT),'?') FROM records r JOIN dict ed ON r.event=ed.id LEFT JOIN dict td ON r.target=td.id WHERE r.x BETWEEN ${x - 1} AND ${x + 1} AND r.z BETWEEN ${z - 1} AND ${z + 1} AND ed.val IN ('deposit','withdraw','open','close') ORDER BY r.seq;`).replace(/\n/g, ' | ');
+}
+function cntAt(x, z, ev, target) {
+  const t = target ? ` AND td.val='${target}'` : '';
+  return parseInt(sql(`SELECT COUNT(*) FROM records r JOIN dict ed ON r.event=ed.id LEFT JOIN dict td ON r.target=td.id WHERE r.x BETWEEN ${x - 1} AND ${x + 1} AND r.z BETWEEN ${z - 1} AND ${z + 1} AND ed.val='${ev}'${t};`)) || 0;
+}
+
+let bot = null;
+function waitWindow(t = 8000) {
+  return new Promise(res => {
+    const h = w => { clearTimeout(timer); res(w); };
+    const timer = setTimeout(() => { bot.removeListener('windowOpen', h); res(null); }, t);
+    bot.once('windowOpen', h);
+  });
+}
+async function closeWin(w) { try { bot.closeWindow(w); } catch { } await sleep(600); }
+function findEntity(name, x, z) {
+  return Object.values(bot.entities).find(e => e.name === name
+    && Math.abs(e.position.x - x) < 3 && Math.abs(e.position.z - z) < 3);
+}
+// On 1.21.8 sneak-interact does not open the entity inventory for a bot
+// (sneak state rides the player_input bitflags the server does not see in
+// time), so do it the way a riding player does: mount, then send the
+// open_vehicle_inventory player command (entity_action actionId 5 on this
+// protocol - the sneak start/stop ids left entity_action in 1.21.2+).
+async function openEntityInv(name, x, z) {
+  await dismount();
+  await rcon(`tp ${BOT} ${x - 1} 72 ${z}`); await sleep(1500);
+  const e = findEntity(name, x, z);
+  if (!e) throw new Error('entity not found: ' + name);
+  for (let i = 0; i < 3 && bot.vehicle !== e; i++) {
+    bot.activateEntity(e).catch(() => { });
+    await sleep(1500);
+  }
+  if (bot.vehicle !== e) throw new Error('mount failed for ' + name);
+  const winP = waitWindow();
+  bot._client.write('entity_action', { entityId: bot.entity.id, actionId: 5, jumpBoost: 0 });
+  return await winP;
+}
+async function dismount() {
+  for (let i = 0; i < 4 && bot.vehicle; i++) {
+    try { bot.dismount(); } catch { }
+    await sleep(800);
+  }
+}
+// prismarine-windows cannot model clicks on the horse window type, so send
+// raw window_click packets: the click action is server-authoritative and the
+// hashed cursor/changed-slot fields are only desync hints (server resyncs).
+let lastStateId = 1;
+function trackState(botRef) {
+  botRef._client.on('window_items', p => { if (p.stateId !== undefined) lastStateId = p.stateId; });
+  botRef._client.on('set_slot', p => { if (p.stateId !== undefined) lastStateId = p.stateId; });
+}
+async function rawClick(slot) {
+  bot._client.write('window_click', {
+    windowId: bot.currentWindow ? bot.currentWindow.id : 1,
+    stateId: lastStateId,
+    slot, mouseButton: 0, mode: 0,
+    changedSlots: [],
+    cursorItem: undefined,
+  });
+  await sleep(600);
+}
+async function placeInto(w, itemName, containerSlot) {
+  const n = w.slots.length - 36;
+  const from = w.slots.findIndex((it, i) => i >= n && it && it.name === itemName);
+  if (from < 0) throw new Error('item not in inventory view: ' + itemName);
+  await rawClick(from);
+  await rawClick(containerSlot);
+}
+async function takeOut(w, containerSlot) {
+  const n = w.slots.length - 36;
+  const empt = w.slots.findIndex((it, i) => i >= n && it == null);
+  await rawClick(containerSlot);
+  if (empt >= 0) { await rawClick(empt); }
+}
+
+(async () => {
+  log(`=== entity-container probe (bot=${BOT}) ===`);
+  const BX = 21000, BY = 72, BZ = 21000;
+  await rcon(`forceload add ${BX - 16} ${BZ - 16} ${BX + 32} ${BZ + 16}`); await sleep(500);
+  await rcon(`fill ${BX - 4} ${BY - 1} ${BZ - 4} ${BX + 24} ${BY - 1} ${BZ + 8} minecraft:stone`); await sleep(500);
+  await rcon('kill @e[type=minecraft:donkey]'); await rcon('kill @e[type=minecraft:horse]'); await rcon('kill @e[type=minecraft:oak_chest_boat]'); await sleep(500);
+
+  bot = mineflayer.createBot({ host: HOST, port: PORT, username: BOT, version: '1.21.8' });
+  trackState(bot);
+  await new Promise((r, j) => { bot.once('spawn', r); bot.once('error', j); });
+  await rcon(`op ${BOT}`); await rcon(`gamemode creative ${BOT}`);
+  await rcon(`tp ${BOT} ${BX} ${BY} ${BZ}`); await sleep(2500);
+  try { await bot.waitForChunksToLoad(); } catch { }
+  await sleep(1000);
+
+  // ---- donkey chest ----
+  log('--- donkey ---');
+  const DK = { x: BX + 4, z: BZ + 2 };
+  log('summon: ' + (await rcon(`summon minecraft:donkey ${DK.x} ${BY} ${DK.z} {ChestedHorse:1b,Tame:1b,NoAI:1b,Invulnerable:1b}`)).trim());
+  await rcon(`clear ${BOT}`); await rcon(`give ${BOT} minecraft:iron_ingot 9`); await sleep(1500);
+  let w = await openEntityInv('donkey', DK.x, DK.z);
+  check('D1 donkey inventory opens', w != null, 'no windowOpen');
+  if (w) {
+    log('  window slots=' + w.slots.length);
+    await placeInto(w, 'iron_ingot', 3);   // a chest slot
+    await sleep(1000);
+    await takeOut(w, 3);
+    await sleep(1000);
+    await closeWin(w);
+    await dismount();
+    await sleep(2500);
+    log('  rows: ' + rowsAt(DK.x, DK.z));
+    check('D2 donkey deposit recorded', cntAt(DK.x, DK.z, 'deposit', 'IRON_INGOT') >= 1, rowsAt(DK.x, DK.z));
+    check('D3 donkey withdraw recorded', cntAt(DK.x, DK.z, 'withdraw', 'IRON_INGOT') >= 1, rowsAt(DK.x, DK.z));
+    check('D4 donkey open recorded', cntAt(DK.x, DK.z, 'open', 'DONKEY') >= 1, rowsAt(DK.x, DK.z));
+    check('D5 donkey close recorded', cntAt(DK.x, DK.z, 'close', 'DONKEY') >= 1, rowsAt(DK.x, DK.z));
+  }
+
+  // ---- horse saddle slot ----
+  // The saddle rides in pre-equipped (the horse window's client-side slot
+  // view is misaligned in mineflayer, so searching the player-inv region for
+  // the saddle is unreliable); two raw clicks on server slot 0 then produce a
+  // deterministic withdraw (pick up) + deposit (put back) pair.
+  log('--- horse ---');
+  const HR = { x: BX + 12, z: BZ + 2 };
+  log('summon: ' + (await rcon(`summon minecraft:horse ${HR.x} ${BY} ${HR.z} {Tame:1b,NoAI:1b,Invulnerable:1b,equipment:{saddle:{id:"minecraft:saddle",count:1}}}`)).trim());
+  await sleep(1500);
+  w = await openEntityInv('horse', HR.x, HR.z);
+  check('H1 horse inventory opens', w != null, 'no windowOpen');
+  if (w) {
+    await rawClick(0);   // pick the saddle up = withdraw
+    await sleep(800);
+    await rawClick(0);   // put it back = deposit
+    await sleep(800);
+    await closeWin(w);
+    await dismount();
+    await sleep(2500);
+    log('  rows: ' + rowsAt(HR.x, HR.z));
+    check('H2 saddle withdraw recorded (slot 0)', cntAt(HR.x, HR.z, 'withdraw', 'SADDLE') >= 1, rowsAt(HR.x, HR.z));
+    check('H3 saddle deposit recorded (slot 0)', cntAt(HR.x, HR.z, 'deposit', 'SADDLE') >= 1, rowsAt(HR.x, HR.z));
+  }
+
+  // ---- chest boat (best effort) ----
+  log('--- chest boat ---');
+  const CB = { x: BX + 20, z: BZ + 2 };
+  log('summon: ' + (await rcon(`summon minecraft:oak_chest_boat ${CB.x} ${BY} ${CB.z}`)).trim());
+  await rcon(`give ${BOT} minecraft:gold_ingot 3`); await sleep(1500);
+  try {
+    w = await openEntityInv('oak_chest_boat', CB.x, CB.z);
+    if (w == null) {
+      log('  SKIP chest boat: window did not open (mount/interact semantics)');
+      results.push({ name: 'B1 chest boat (inconclusive)', ok: true, detail: 'skipped' });
+    } else {
+      await placeInto(w, 'gold_ingot', 1);
+      await sleep(1000);
+      await closeWin(w);
+      await dismount();
+      await sleep(2500);
+      log('  rows: ' + rowsAt(CB.x, CB.z));
+      check('B1 chest boat deposit recorded', cntAt(CB.x, CB.z, 'deposit', 'GOLD_INGOT') >= 1, rowsAt(CB.x, CB.z));
+    }
+  } catch (e) {
+    log('  SKIP chest boat: ' + e.message);
+    results.push({ name: 'B1 chest boat (inconclusive)', ok: true, detail: 'skipped: ' + e.message });
+  }
+
+  bot.quit();
+  await rcon(`forceload remove ${BX - 16} ${BZ - 16} ${BX + 32} ${BZ + 16}`);
+  log(`\n=== RESULT: ${pass} passed, ${fail} failed ===`);
+  for (const r of results) log(`   ${r.ok ? 'PASS' : 'FAIL'}  ${r.name}${r.ok ? '' : '  :: ' + r.detail}`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { log('FATAL', e?.stack || e?.message || e); process.exit(2); });

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerDragListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerDragListener.java
@@ -9,10 +9,8 @@ import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.listener.RecordingListener;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
-import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.api.capture.ItemSerialization;
 import org.bukkit.Material;
-import org.bukkit.block.Container;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -46,15 +44,18 @@ public final class ContainerDragListener implements RecordingListener {
         }
         Inventory top = event.getView().getTopInventory();
         InventoryHolder holder = top.getHolder();
-        if (!(holder instanceof Container container)) {
-            return;
-        }
         if (holder instanceof ShulkerBox) {
             return;
         }
+        // Any trackable holder - block containers, minecarts, and entity-held
+        // inventories (horse family, chest boats; #347) alike.
+        ContainerHolders.Target target = ContainerHolders.resolve(holder);
+        if (target == null) {
+            return;
+        }
         int topSize = top.getSize();
-        BlockLocation location = BlockLocations.fromLocation(container.getBlock().getLocation());
-        String containerType = container.getBlock().getType().name();
+        BlockLocation location = target.location();
+        String containerType = target.type();
         Instant occurred = support.now();
         for (Map.Entry<Integer, ItemStack> entry : event.getNewItems().entrySet()) {
             int rawSlot = entry.getKey();

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerHolders.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerHolders.java
@@ -1,0 +1,67 @@
+package net.medievalrp.spyglass.plugin.listener.container;
+
+import net.medievalrp.spyglass.api.util.BlockLocation;
+import net.medievalrp.spyglass.plugin.util.BlockLocations;
+import org.bukkit.Location;
+import org.bukkit.block.Container;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.ChestBoat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.entity.minecart.StorageMinecart;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Resolve any inventory holder the container listeners record into a uniform
+ * (location, type-name) pair, shared by the click, drag, and open/close
+ * listeners so the set of trackable containers cannot drift between them
+ * (#347 was exactly that drift: clicks knew about minecarts, but nothing knew
+ * about entity-held inventories).
+ *
+ * <p>Covered: block containers, storage/hopper minecarts, the horse family
+ * ({@link AbstractHorse}: horse, donkey, mule, llama, camel - saddle, armor,
+ * and chest slots are all ordinary slots of the same entity-held inventory),
+ * and chest boats. Entity-held inventories record against the entity's
+ * current location - they move, so the recorded location is a snapshot at
+ * event time, the storage-minecart precedent. Returns null for holders we
+ * don't track (player inventories, anvils, brewing stands, ...).
+ */
+@ApiStatus.Internal
+final class ContainerHolders {
+
+    /** A trackable container: where it is and what to call it. */
+    record Target(BlockLocation location, String type) {
+    }
+
+    private ContainerHolders() {
+    }
+
+    static @Nullable Target resolve(@Nullable InventoryHolder holder) {
+        if (holder instanceof Container blockContainer) {
+            Location loc = blockContainer.getBlock().getLocation();
+            return new Target(BlockLocations.fromLocation(loc),
+                    blockContainer.getBlock().getType().name());
+        }
+        if (holder instanceof StorageMinecart cart) {
+            return entityTarget(cart);
+        }
+        if (holder instanceof HopperMinecart cart) {
+            return entityTarget(cart);
+        }
+        if (holder instanceof AbstractHorse horse) {
+            return entityTarget(horse);
+        }
+        if (holder instanceof ChestBoat boat) {
+            return entityTarget(boat);
+        }
+        return null;
+    }
+
+    static Target entityTarget(Entity entity) {
+        return new Target(
+                BlockLocations.fromLocation(entity.getLocation()),
+                entity.getType().name());
+    }
+}

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerInteractListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerInteractListener.java
@@ -3,12 +3,9 @@ package net.medievalrp.spyglass.plugin.listener.container;
 import java.util.Set;
 import net.medievalrp.spyglass.api.event.ContainerInteractRecord;
 import net.medievalrp.spyglass.api.event.RecordContext;
-import net.medievalrp.spyglass.api.util.BlockLocation;
 import net.medievalrp.spyglass.plugin.listener.RecordingListener;
 import net.medievalrp.spyglass.plugin.listener.RecordingSupport;
 import net.medievalrp.spyglass.plugin.pipeline.Recorder;
-import net.medievalrp.spyglass.plugin.util.BlockLocations;
-import org.bukkit.block.Container;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -48,14 +45,13 @@ public final class ContainerInteractListener implements RecordingListener {
         }
         Inventory inv = event.getInventory();
         InventoryHolder holder = inv.getHolder();
-        if (!(holder instanceof Container container)) {
+        ContainerHolders.Target target = ContainerHolders.resolve(holder);
+        if (target == null) {
             return;
         }
         String event_ = holder instanceof ShulkerBox ? "shulker-open" : "open";
-        BlockLocation location = BlockLocations.fromLocation(container.getBlock().getLocation());
-        String target = container.getBlock().getType().name();
-        RecordContext ctx = support.playerContext(player, location);
-        recorder.record(ContainerInteractRecord.of(ctx, event_, target));
+        RecordContext ctx = support.playerContext(player, target.location());
+        recorder.record(ContainerInteractRecord.of(ctx, event_, target.type()));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -65,13 +61,12 @@ public final class ContainerInteractListener implements RecordingListener {
         }
         Inventory inv = event.getInventory();
         InventoryHolder holder = inv.getHolder();
-        if (!(holder instanceof Container container)) {
+        ContainerHolders.Target target = ContainerHolders.resolve(holder);
+        if (target == null) {
             return;
         }
         String event_ = holder instanceof ShulkerBox ? "shulker-close" : "close";
-        BlockLocation location = BlockLocations.fromLocation(container.getBlock().getLocation());
-        String target = container.getBlock().getType().name();
-        RecordContext ctx = support.playerContext(player, location);
-        recorder.record(ContainerInteractRecord.of(ctx, event_, target));
+        RecordContext ctx = support.playerContext(player, target.location());
+        recorder.record(ContainerInteractRecord.of(ctx, event_, target.type()));
     }
 }

--- a/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
+++ b/spyglass/src/main/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListener.java
@@ -16,16 +16,11 @@ import net.medievalrp.spyglass.plugin.util.BlockLocations;
 import net.medievalrp.spyglass.plugin.util.InventoryActions;
 import net.medievalrp.spyglass.plugin.util.InventoryActions.Direction;
 import net.medievalrp.spyglass.api.capture.ItemSerialization;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Chest;
-import org.bukkit.block.Container;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.block.ShulkerBox;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.minecart.HopperMinecart;
-import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryAction;
@@ -109,7 +104,7 @@ public final class ContainerTransactionListener implements RecordingListener {
         if (resolved == null) {
             return;
         }
-        ContainerTarget containerTarget = resolved.target();
+        ContainerHolders.Target containerTarget = resolved.target();
         // Block-local slot: what the single-block rollback path expects.
         int slot = resolved.slot();
         // Reads use the RAW slot (the combined inventory the player clicked);
@@ -210,10 +205,11 @@ public final class ContainerTransactionListener implements RecordingListener {
         if (!clicked.equals(bottom)) {
             return;
         }
-        // Trackable destination only: a Container/minecart, or a DoubleChest
-        // (which resolveTarget alone drops but resolveSlotTarget handles
-        // per-slot). Anvils, brewing stands etc. bail before the snapshot.
-        if (!(topHolder instanceof DoubleChest) && resolveTarget(topHolder) == null) {
+        // Trackable destination only: anything ContainerHolders resolves, or
+        // a DoubleChest (which the resolver alone drops but resolveSlotTarget
+        // handles per-slot). Anvils, brewing stands etc. bail before the
+        // snapshot.
+        if (!(topHolder instanceof DoubleChest) && ContainerHolders.resolve(topHolder) == null) {
             return;
         }
         // Shift-click from player inventory to container -> deposit. The
@@ -261,7 +257,7 @@ public final class ContainerTransactionListener implements RecordingListener {
         });
     }
 
-    private void handleHotbarSwap(InventoryClickEvent event, ContainerTarget containerTarget, Player player,
+    private void handleHotbarSwap(InventoryClickEvent event, ContainerHolders.Target containerTarget, Player player,
                                   int slot, ItemStack slotItem, Instant occurred) {
         int hotbarButton = event.getHotbarButton();
         if (hotbarButton < 0) {
@@ -291,7 +287,7 @@ public final class ContainerTransactionListener implements RecordingListener {
         }
     }
 
-    private void handleSwap(ContainerTarget containerTarget, Player player, int slot,
+    private void handleSwap(ContainerHolders.Target containerTarget, Player player, int slot,
                             ItemStack slotItem, ItemStack cursor, Instant occurred) {
         BlockLocation location = containerTarget.location();
         String containerType = containerTarget.type();
@@ -362,14 +358,14 @@ public final class ContainerTransactionListener implements RecordingListener {
      *
      * <p>Double chests are the reason this exists: their holder is a
      * {@link DoubleChest} (which does <em>not</em> implement
-     * {@link Container}, so {@link #resolveTarget} alone drops them), and
+     * {@code Container}, so {@link ContainerHolders#resolve} alone drops them), and
      * they present one 54-slot inventory spanning two blocks. The clicked
      * slot is mapped back to the half it belongs to and re-based into that
      * half's 0-26 range so the recorded {@code (location, slot)} round-trips
      * through the single-block rollback path. A slot {@code < 0} (slotless
      * deposit) pins the left half.
      *
-     * <p>Every other holder delegates to {@link #resolveTarget} with the
+     * <p>Every other holder delegates to {@link ContainerHolders#resolve} with the
      * slot unchanged, so single chests, barrels and minecarts behave exactly
      * as before.
      */
@@ -382,52 +378,19 @@ public final class ContainerTransactionListener implements RecordingListener {
             int leftSize = left.getBlockInventory().getSize();
             Chest half = slot >= leftSize ? right : left;
             int localSlot = slot >= leftSize ? slot - leftSize : slot;
-            ContainerTarget target = new ContainerTarget(
+            ContainerHolders.Target target = new ContainerHolders.Target(
                     BlockLocations.fromLocation(half.getBlock().getLocation()),
                     half.getBlock().getType().name());
             return new SlotTarget(target, localSlot);
         }
-        ContainerTarget base = resolveTarget(holder);
+        ContainerHolders.Target base = ContainerHolders.resolve(holder);
         return base == null ? null : new SlotTarget(base, slot);
-    }
-
-    /**
-     * Resolve any inventory holder we care about into a uniform
-     * (BlockLocation, type-name) pair so the deposit / withdraw flow
-     * doesn't have to special-case minecart inventories vs block
-     * containers all over the place. Returns null for holders we
-     * don't track (player inventory, anvils, brewing stands, etc.).
-     */
-    private static @Nullable ContainerTarget resolveTarget(@Nullable InventoryHolder holder) {
-        if (holder instanceof Container blockContainer) {
-            Location loc = blockContainer.getBlock().getLocation();
-            return new ContainerTarget(BlockLocations.fromLocation(loc),
-                    blockContainer.getBlock().getType().name());
-        }
-        // Storage / hopper minecarts use the entity's current location
-        // — they're moving inventories, so the recorded location is a
-        // snapshot at deposit/withdraw time.
-        if (holder instanceof StorageMinecart cart) {
-            return entityTarget(cart);
-        }
-        if (holder instanceof HopperMinecart cart) {
-            return entityTarget(cart);
-        }
-        return null;
-    }
-
-    private static ContainerTarget entityTarget(Entity entity) {
-        return new ContainerTarget(
-                BlockLocations.fromLocation(entity.getLocation()),
-                entity.getType().name());
-    }
-
-    private record ContainerTarget(BlockLocation location, String type) {
     }
 
     /** A resolved container target paired with the block-local slot the
      *  click maps to (identical to the raw slot for everything but double
-     *  chests). */
-    private record SlotTarget(ContainerTarget target, int slot) {
+     *  chests). Holder resolution itself lives in {@link ContainerHolders},
+     *  shared with the drag and open/close listeners. */
+    private record SlotTarget(ContainerHolders.Target target, int slot) {
     }
 }

--- a/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
+++ b/spyglass/src/test/java/net/medievalrp/spyglass/plugin/listener/container/ContainerTransactionListenerTest.java
@@ -307,7 +307,88 @@ class ContainerTransactionListenerTest {
         assertThat(record.slot()).isEqualTo(3);
     }
 
+    // ── entity-held container inventories (#347) ─────────────────
+
+    @Test
+    void donkeyChestDepositIsRecordedAgainstTheEntity() {
+        // A donkey's inventory holder is the AbstractHorse entity, not a
+        // block Container - the old resolver returned null and silently
+        // dropped every horse-family GUI click (#347).
+        InventoryClickEvent event = entityHolderClickEvent(
+                mock(org.bukkit.entity.Donkey.class), org.bukkit.entity.EntityType.DONKEY,
+                InventoryAction.PLACE_ALL, 2, null, ironStack(12));
+
+        listener.onInventoryClick(event);
+
+        assertThat(recorder.records)
+                .as("donkey chest deposits must be recorded, not dropped")
+                .hasSize(1);
+        ContainerDepositRecord record = (ContainerDepositRecord) recorder.records.get(0);
+        assertThat(record.containerType()).isEqualTo("DONKEY");
+        assertThat(record.slot()).isEqualTo(2);
+        assertThat(record.amount()).isEqualTo(12);
+        assertThat(record.location().x()).isEqualTo(5);
+    }
+
+    @Test
+    void horseSaddleSlotWithdrawIsRecorded() {
+        // Saddle (slot 0) and armor slots are ordinary slots of the same
+        // entity-held inventory.
+        InventoryClickEvent event = entityHolderClickEvent(
+                mock(org.bukkit.entity.Horse.class), org.bukkit.entity.EntityType.HORSE,
+                InventoryAction.PICKUP_ALL, 0, mockStack(Material.SADDLE, 1), null);
+
+        listener.onInventoryClick(event);
+
+        assertThat(recorder.records).hasSize(1);
+        ContainerWithdrawRecord record = (ContainerWithdrawRecord) recorder.records.get(0);
+        assertThat(record.containerType()).isEqualTo("HORSE");
+        assertThat(record.slot()).isEqualTo(0);
+        assertThat(record.target()).isEqualTo("SADDLE");
+    }
+
+    @Test
+    void chestBoatDepositIsRecordedAgainstTheEntity() {
+        InventoryClickEvent event = entityHolderClickEvent(
+                mock(org.bukkit.entity.ChestBoat.class), org.bukkit.entity.EntityType.OAK_CHEST_BOAT,
+                InventoryAction.PLACE_ALL, 4, null, ironStack(3));
+
+        listener.onInventoryClick(event);
+
+        assertThat(recorder.records).hasSize(1);
+        ContainerDepositRecord record = (ContainerDepositRecord) recorder.records.get(0);
+        assertThat(record.containerType()).isEqualTo("OAK_CHEST_BOAT");
+        assertThat(record.slot()).isEqualTo(4);
+    }
+
     // ── fixtures ─────────────────────────────────────────────────
+
+    /** A click in an entity-held container inventory (horse family, chest
+     *  boat): the holder is the entity itself, standing at (5, 64, 6). */
+    private <E extends org.bukkit.entity.Entity & org.bukkit.inventory.InventoryHolder>
+            InventoryClickEvent entityHolderClickEvent(E entity, org.bukkit.entity.EntityType type,
+                    InventoryAction action, int slot, ItemStack slotItem, ItemStack cursor) {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_ID);
+        when(player.getName()).thenReturn("Alice");
+
+        when(world.getUID()).thenReturn(UUID.fromString("77777777-7777-7777-7777-777777777777"));
+        when(world.getName()).thenReturn("world");
+        when(entity.getLocation()).thenReturn(new Location(world, 5, 64, 6));
+        when(entity.getType()).thenReturn(type);
+
+        Inventory inventory = mock(Inventory.class);
+        when(inventory.getHolder(false)).thenReturn(entity);
+        when(inventory.getItem(slot)).thenReturn(slotItem);
+
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getWhoClicked()).thenReturn(player);
+        when(event.getClickedInventory()).thenReturn(inventory);
+        when(event.getAction()).thenReturn(action);
+        when(event.getSlot()).thenReturn(slot);
+        when(event.getCursor()).thenReturn(cursor);
+        return event;
+    }
 
     private InventoryClickEvent clickEvent(InventoryAction action, int slot,
                                            ItemStack slotItem, ItemStack cursor) {


### PR DESCRIPTION
Fixes #347.

Root cause: each container listener resolved the inventory holder on its own, and none accepted entity-held inventories. The click listener knew block containers and storage/hopper minecarts; the drag and open/close listeners knew only block containers. So every click in a horse/donkey/mule/llama/camel GUI, and in a chest boat, was silently dropped, with no open/close either.

Change:
- New shared ContainerHolders resolver used by all three listeners, so the set of trackable containers cannot drift between them again. Adds AbstractHorse (saddle, armor, and chest slots are ordinary slots of the one entity-held inventory) and ChestBoat.
- Entity-held inventories record against the entity's current location with the entity type as the container name, exactly like storage minecarts already did.
- Side effect worth noting: open/close records now also cover minecart inventories, which the old block-only gate dropped.

Verification:
- Unit tests pin the donkey, horse, and chest-boat holder mappings (plus all existing container tests green; :spyglass and :spyglass-core suites pass, Docker store ITs not run).
- Live 9/9 on Paper 1.21.8 + SQLite (regression/bot/_entity-container-probe.mjs): donkey chest deposit + withdraw + open + close, horse saddle slot withdraw + deposit (slot 0), chest boat deposit + open + close. Harness notes in the probe header: a bot cannot sneak-interact on this protocol, so it mounts and sends the open_vehicle_inventory player command (entity_action 5 on 1.21.8).

One adjacent gap deliberately NOT covered here: equipping a saddle or horse armor by right-clicking the animal directly (never opening the GUI) goes through the entity-interact path, not an inventory click, and is still unlogged - same class of gap as armor-stand manipulation was before its dedicated listener. Say the word and it gets its own issue.